### PR TITLE
Rename references to a2a-java-sdk to a2a-java

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -63,7 +63,7 @@ reported to the community leaders responsible for enforcement:
 
 Farah Juma - fjuma@redhat.com \
 Kabir Khan - kkhan@redhat.com \
-Stefano Maestri - smaestri@redhat.com \
+Stefano Maestri - smaestri@redhat.com
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-Contributing to a2a-java-sdk
+Contributing to a2a-java
 ==================================
 
 Welcome to the A2A Java SDK project! We welcome contributions from the community. This guide will walk you through the steps for getting started on our project.
@@ -12,12 +12,12 @@ Welcome to the A2A Java SDK project! We welcome contributions from the community
 
 
 ## Forking the Project
-To contribute, you will first need to fork the [a2a-java-sdk](https://github.com/fjuma/a2a-java-sdk) repository.
+To contribute, you will first need to fork the [a2a-java](https://github.com/a2aproject/a2a-java) repository.
 
 This can be done by looking in the top-right corner of the repository page and clicking "Fork".
 ![fork](images/fork.jpg)
 
-The next step is to clone your newly forked repository onto your local workspace. This can be done by going to your newly forked repository, which should be at `https://github.com/USERNAME/a2a-java-sdk`.
+The next step is to clone your newly forked repository onto your local workspace. This can be done by going to your newly forked repository, which should be at `https://github.com/USERNAME/a2a-java`.
 
 Then, there will be a green button that says "Code". Click on that and copy the URL.
 
@@ -30,17 +30,17 @@ Be sure to replace [URL] with the URL that you copied.
 Now you have the repository on your computer!
 
 ## Issues
-The `a2a-java-sdk` project uses GitHub to manage issues. All issues can be found [here](https://github.com/fjuma/a2a-java-sdk/issues).
+The `a2a-java` project uses GitHub to manage issues. All issues can be found [here](https://github.com/a2aproject/a2a-java/issues).
 
 To create a new issue, comment on an existing issue, or assign an issue to yourself, you'll need to first [create a GitHub account](https://github.com/).
 
 
 ### Good First Issues
-Want to contribute to the a2a-java-sdk project but aren't quite sure where to start? Check out our issues with the `good-first-issue` label. These are a triaged set of issues that are great for getting started on our project. These can be found [here](https://github.com/fjuma/a2a-java-sdk/labels/good%20first%20issue).
+Want to contribute to the a2a-java project but aren't quite sure where to start? Check out our issues with the `good-first-issue` label. These are a triaged set of issues that are great for getting started on our project. These can be found [here](https://github.com/a2aproject/a2a-java/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).
 
 Once you have selected an issue you'd like to work on, make sure it's not already assigned to someone else, and assign it to yourself.
 
-It is recommended that you use a separate branch for every issue you work on. To keep things straightforward and memorable, you can name each branch using the GitHub issue number. This way, you can have multiple PRs open for different issues. For example, if you were working on [issue-20](https://github.com/fjuma/a2a-java-sdk/issues/20), you could use `issue-20` as your branch name.
+It is recommended that you use a separate branch for every issue you work on. To keep things straightforward and memorable, you can name each branch using the GitHub issue number. This way, you can have multiple PRs open for different issues. For example, if you were working on [issue-20](https://github.com/a2aproject/a2a-java/issues/20), you could use `issue-20` as your branch name.
 
 ## Setting up your Developer Environment
 You will need:
@@ -51,15 +51,15 @@ You will need:
 
 To set up your development environment you need to:
 
-1. First `cd` to the directory where you cloned the project (eg: `cd a2a-java-sdk`)
+1. First `cd` to the directory where you cloned the project (eg: `cd a2a-java`)
 
 2. Add a remote ref to upstream, for pulling future updates. For example:
 
     ```
-    git remote add upstream https://github.com/fjuma/a2a-java-sdk
+    git remote add upstream https://github.com/a2aproject/a2a-java
     ```
 
-3. To build `a2a-java-sdk` and run the tests, use the following command:
+3. To build `a2a-java` and run the tests, use the following command:
 
     ```
     mvn clean install
@@ -82,10 +82,10 @@ When submitting a PR, please keep the following guidelines in mind:
 
 3. Your PR should include tests for the functionality that you are adding.
 
-4. Your PR should include appropriate [documentation](https://github.com/fjuma/a2a-java-sdk/blob/main/README.md) for the functionality that you are adding.
+4. Your PR should include appropriate [documentation](https://github.com/a2aproject/a2a-java/blob/main/README.md) for the functionality that you are adding.
 
 ## Code Reviews
 
-All submissions, including submissions by project members, need to be reviewed by at least one `a2a-java-sdk` committer before being merged.
+All submissions, including submissions by project members, need to be reviewed by at least one `a2a-java` committer before being merged.
 
 The [GitHub Pull Request Review Process](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews) is followed for every pull request.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # A2A Java SDK
 
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+
+<!-- markdownlint-disable no-inline-html -->
+
 <html>
-   <h3 align="center">A Java library that helps run agentic applications as A2AServers following Google's <a href="https://google-a2a.github.io/A2A">Agent2Agent (A2A) Protocol</a>.</h3>
+   <h2 align="center">
+   <img src="https://raw.githubusercontent.com/google-a2a/A2A/refs/heads/main/docs/assets/a2a-logo-black.svg" width="256" alt="A2A Logo"/>
+   </h2>
+   <h3 align="center">A Java library that helps run agentic applications as A2AServers following the <a href="https://google-a2a.github.io/A2A">Agent2Agent (A2A) Protocol</a>.</h3>
 </html>
 
 ## Installation
@@ -30,7 +37,7 @@ The A2A Java SDK provides a Java server implementation of the [Agent2Agent (A2A)
 ### 1. Add the A2A Java SDK Core Maven dependency to your project
 
 > **Note**: The A2A Java SDK isn't available yet in Maven Central but will be soon. For now, be
-> sure to check out the latest tag (you can see the tags [here](https://github.com/fjuma/a2a-java-sdk/tags)), build from the tag, and reference that version below. For example, if the latest tag is `0.2.3`, you can use the following dependency.
+> sure to check out the latest tag (you can see the tags [here](https://github.com/a2aproject/a2a-java/tags)), build from the tag, and reference that version below. For example, if the latest tag is `0.2.3`, you can use the following dependency.
 
 ```xml
 <dependency>
@@ -176,7 +183,7 @@ public class WeatherAgentExecutorProducer {
 ### 4. Add an A2A Java SDK Server Maven dependency to your project
 
 > **Note**: The A2A Java SDK isn't available yet in Maven Central but will be soon. For now, be
-> sure to check out the latest tag (you can see the tags [here](https://github.com/fjuma/a2a-java-sdk/tags)), build from the tag, and reference that version below. For example, if the latest tag is `0.2.3`, you can use the following dependency.
+> sure to check out the latest tag (you can see the tags [here](https://github.com/a2aproject/a2a-java/tags)), build from the tag, and reference that version below. For example, if the latest tag is `0.2.3`, you can use the following dependency.
 
 Adding a dependency on an A2A Java SDK Server will allow you to run your agentic Java application as an A2A server.
 

--- a/examples/src/main/java/io/a2a/examples/helloworld/client/README.md
+++ b/examples/src/main/java/io/a2a/examples/helloworld/client/README.md
@@ -47,10 +47,10 @@ The Java client can be run using JBang, which allows you to run Java source file
 
 ### Build the A2A Java SDK
 
-First, ensure you have built the `a2a-java-sdk` project:
+First, ensure you have built the `a2a-java` project:
 
 ```bash
-cd /path/to/a2a-java-sdk
+cd /path/to/a2a-java
 mvn clean install
 ```
 
@@ -81,7 +81,7 @@ Alternatively, you can run the Java client with JBang by specifying the classpat
    mvn clean package
    ```
 
-2. Run the Java client with JBang from the root of the a2a-java-sdk project:
+2. Run the Java client with JBang from the root of the a2a-java project:
    ```bash
    jbang --cp target/classes examples/src/main/java/io/a2a/examples/helloworld/client/HelloWorldClient.java
    ```

--- a/examples/src/main/java/io/a2a/examples/helloworld/server/README.md
+++ b/examples/src/main/java/io/a2a/examples/helloworld/server/README.md
@@ -54,7 +54,7 @@ The client will connect to the Java server running on `http://localhost:9999`.
 The Python A2A client (`test_client.py`) performs the following actions:
 
 1. Fetches the server's public agent card
-2. Fetches the server's extended agent card if supported by the server (see https://github.com/fjuma/a2a-java-sdk/issues/81)
+2. Fetches the server's extended agent card if supported by the server (see https://github.com/a2aproject/a2a-java/issues/81)
 3. Creates an A2A client using the extended agent card that connects to the Python server at `http://localhost:9999`.
 4. Sends a regular message asking "how much is 10 USD in INR?".
 5. Prints the server's response.

--- a/sdk-jakarta/src/main/java/io/a2a/server/apps/jakarta/A2AServerResource.java
+++ b/sdk-jakarta/src/main/java/io/a2a/server/apps/jakarta/A2AServerResource.java
@@ -117,7 +117,7 @@ public class A2AServerResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getAuthenticatedExtendedAgentCard() {
         // TODO need to add authentication for this endpoint
-        // https://github.com/fjuma/a2a-java-sdk/issues/77
+        // https://github.com/a2aproject/a2a-java/issues/77
         if (! jsonRpcHandler.getAgentCard().supportsAuthenticatedExtendedCard()) {
             JSONErrorResponse errorResponse = new JSONErrorResponse("Extended agent card not supported or not enabled.");
             return Response.status(Response.Status.NOT_FOUND)

--- a/sdk-quarkus/src/main/java/io/a2a/server/apps/quarkus/A2AServerRoutes.java
+++ b/sdk-quarkus/src/main/java/io/a2a/server/apps/quarkus/A2AServerRoutes.java
@@ -161,7 +161,7 @@ public class A2AServerRoutes {
     @Route(path = "/agent/authenticatedExtendedCard", methods = Route.HttpMethod.GET, produces = APPLICATION_JSON)
     public void getAuthenticatedExtendedAgentCard(RoutingExchange re) {
         // TODO need to add authentication for this endpoint
-        // https://github.com/fjuma/a2a-java-sdk/issues/77
+        // https://github.com/a2aproject/a2a-java/issues/77
         try {
             if (! jsonRpcHandler.getAgentCard().supportsAuthenticatedExtendedCard()) {
                 JSONErrorResponse errorResponse = new JSONErrorResponse("Extended agent card not supported or not enabled.");

--- a/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
@@ -154,7 +154,7 @@ public abstract class AbstractA2AServerTest {
                 .extract()
                 .as(GetTaskResponse.class);
         assertEquals("1", response.getId());
-        // this should be an instance of TaskNotFoundError, see https://github.com/fjuma/a2a-java-sdk/issues/23
+        // this should be an instance of TaskNotFoundError, see https://github.com/a2aproject/a2a-java/issues/23
         assertInstanceOf(JSONRPCError.class, response.getError());
         assertEquals(new TaskNotFoundError().getCode(), response.getError().getCode());
         assertNull(response.getResult());
@@ -202,7 +202,7 @@ public abstract class AbstractA2AServerTest {
                     .as(CancelTaskResponse.class);
             assertEquals(request.getId(), response.getId());
             assertNull(response.getResult());
-            // this should be an instance of UnsupportedOperationError, see https://github.com/fjuma/a2a-java-sdk/issues/23
+            // this should be an instance of UnsupportedOperationError, see https://github.com/a2aproject/a2a-java/issues/23
             assertInstanceOf(JSONRPCError.class, response.getError());
             assertEquals(new UnsupportedOperationError().getCode(), response.getError().getCode());
         } catch (Exception e) {
@@ -225,7 +225,7 @@ public abstract class AbstractA2AServerTest {
                 .as(CancelTaskResponse.class);
         assertEquals(request.getId(), response.getId());
         assertNull(response.getResult());
-        // this should be an instance of UnsupportedOperationError, see https://github.com/fjuma/a2a-java-sdk/issues/23
+        // this should be an instance of UnsupportedOperationError, see https://github.com/a2aproject/a2a-java/issues/23
         assertInstanceOf(JSONRPCError.class, response.getError());
         assertEquals(new TaskNotFoundError().getCode(), response.getError().getCode());
     }
@@ -376,7 +376,7 @@ public abstract class AbstractA2AServerTest {
                 .as(SendMessageResponse.class);
         assertEquals(request.getId(), response.getId());
         assertNull(response.getResult());
-        // this should be an instance of UnsupportedOperationError, see https://github.com/fjuma/a2a-java-sdk/issues/23
+        // this should be an instance of UnsupportedOperationError, see https://github.com/a2aproject/a2a-java/issues/23
         assertInstanceOf(JSONRPCError.class, response.getError());
         assertEquals(new UnsupportedOperationError().getCode(), response.getError().getCode());
     }
@@ -732,7 +732,7 @@ public abstract class AbstractA2AServerTest {
                     if (jsonResponse != null) {
                         assertEquals(request.getId(), jsonResponse.getId());
                         assertNull(jsonResponse.getResult());
-                        // this should be an instance of TaskNotFoundError, see https://github.com/fjuma/a2a-java-sdk/issues/23
+                        // this should be an instance of TaskNotFoundError, see https://github.com/a2aproject/a2a-java/issues/23
                         assertInstanceOf(JSONRPCError.class, jsonResponse.getError());
                         assertEquals(new TaskNotFoundError().getCode(), jsonResponse.getError().getCode());
                         latch.countDown();


### PR DESCRIPTION
This just updates references to `a2a-java-sdk` to match the repo name, `a2a-java`.