### PR TITLE
optimize: Improved `JSONRPCErrorDeserializer`

### DIFF
--- a/core/src/main/java/io/a2a/spec/ContentTypeNotSupportedError.java
+++ b/core/src/main/java/io/a2a/spec/ContentTypeNotSupportedError.java
@@ -10,13 +10,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ContentTypeNotSupportedError extends JSONRPCError {
+
+    public final static Integer DEFAULT_CODE = -32005;
+
     @JsonCreator
     public ContentTypeNotSupportedError(
             @JsonProperty("code") Integer code,
             @JsonProperty("message") String message,
             @JsonProperty("data") Object data) {
         super(
-                defaultIfNull(code, -32005),
+                defaultIfNull(code, DEFAULT_CODE),
                 defaultIfNull(message, "Incompatible content types"),
                 data);
     }

--- a/core/src/main/java/io/a2a/spec/InternalError.java
+++ b/core/src/main/java/io/a2a/spec/InternalError.java
@@ -10,13 +10,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class InternalError extends JSONRPCError {
+
+    public final static Integer DEFAULT_CODE = -32603;
+
     @JsonCreator
     public InternalError(
             @JsonProperty("code") Integer code,
             @JsonProperty("message") String message,
             @JsonProperty("data") Object data) {
         super(
-                defaultIfNull(code, -32603),
+                defaultIfNull(code, DEFAULT_CODE),
                 defaultIfNull(message, "Internal Error"),
                 data);
     }

--- a/core/src/main/java/io/a2a/spec/InvalidAgentResponseError.java
+++ b/core/src/main/java/io/a2a/spec/InvalidAgentResponseError.java
@@ -13,13 +13,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class InvalidAgentResponseError extends JSONRPCError {
+
+    public final static Integer DEFAULT_CODE = -32006;
+
     @JsonCreator
     public InvalidAgentResponseError(
             @JsonProperty("code") Integer code,
             @JsonProperty("message") String message,
             @JsonProperty("data") Object data) {
         super(
-                defaultIfNull(code, -32006),
+                defaultIfNull(code, DEFAULT_CODE),
                 defaultIfNull(message, "Invalid agent response"),
                 data);
     }

--- a/core/src/main/java/io/a2a/spec/InvalidParamsError.java
+++ b/core/src/main/java/io/a2a/spec/InvalidParamsError.java
@@ -10,13 +10,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class InvalidParamsError extends JSONRPCError {
+
+    public final static Integer DEFAULT_CODE = -32602;
+
     @JsonCreator
     public InvalidParamsError(
             @JsonProperty("code") Integer code,
             @JsonProperty("message") String message,
             @JsonProperty("data") Object data) {
         super(
-                defaultIfNull(code, -32602),
+                defaultIfNull(code, DEFAULT_CODE),
                 defaultIfNull(message, "Invalid parameters"),
                 data);
     }

--- a/core/src/main/java/io/a2a/spec/InvalidRequestError.java
+++ b/core/src/main/java/io/a2a/spec/InvalidRequestError.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class InvalidRequestError extends JSONRPCError {
 
+    public final static Integer DEFAULT_CODE = -32600;
+
     public InvalidRequestError() {
         this(null, null, null);
     }
@@ -21,7 +23,7 @@ public class InvalidRequestError extends JSONRPCError {
             @JsonProperty("message") String message,
             @JsonProperty("data") Object data) {
         super(
-                defaultIfNull(code, -32600),
+                defaultIfNull(code, DEFAULT_CODE),
                 defaultIfNull(message, "Request payload validation error"),
                 data);
     }

--- a/core/src/main/java/io/a2a/spec/JSONParseError.java
+++ b/core/src/main/java/io/a2a/spec/JSONParseError.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class JSONParseError extends JSONRPCError implements A2AError {
 
+    public final static Integer DEFAULT_CODE = -32700;
+
     public JSONParseError() {
         this(null, null, null);
     }
@@ -25,7 +27,7 @@ public class JSONParseError extends JSONRPCError implements A2AError {
             @JsonProperty("message") String message,
             @JsonProperty("data") Object data) {
         super(
-                defaultIfNull(code, -32700),
+                defaultIfNull(code, DEFAULT_CODE),
                 defaultIfNull(message, "Invalid JSON payload"),
                 data);
     }

--- a/core/src/main/java/io/a2a/spec/JSONRPCErrorDeserializer.java
+++ b/core/src/main/java/io/a2a/spec/JSONRPCErrorDeserializer.java
@@ -1,6 +1,8 @@
 package io.a2a.spec;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -9,6 +11,22 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 public class JSONRPCErrorDeserializer extends StdDeserializer<JSONRPCError> {
+
+    private static final Map<Integer, TriFunction<Integer, String, Object, JSONRPCError>> ERROR_MAP = new HashMap<>();
+
+    static {
+        ERROR_MAP.put(JSONParseError.DEFAULT_CODE, JSONParseError::new);
+        ERROR_MAP.put(InvalidRequestError.DEFAULT_CODE, InvalidRequestError::new);
+        ERROR_MAP.put(MethodNotFoundError.DEFAULT_CODE, MethodNotFoundError::new);
+        ERROR_MAP.put(InvalidParamsError.DEFAULT_CODE, InvalidParamsError::new);
+        ERROR_MAP.put(InternalError.DEFAULT_CODE, InternalError::new);
+        ERROR_MAP.put(PushNotificationNotSupportedError.DEFAULT_CODE, PushNotificationNotSupportedError::new);
+        ERROR_MAP.put(UnsupportedOperationError.DEFAULT_CODE, UnsupportedOperationError::new);
+        ERROR_MAP.put(ContentTypeNotSupportedError.DEFAULT_CODE, ContentTypeNotSupportedError::new);
+        ERROR_MAP.put(InvalidAgentResponseError.DEFAULT_CODE, InvalidAgentResponseError::new);
+        ERROR_MAP.put(TaskNotCancelableError.DEFAULT_CODE, TaskNotCancelableError::new);
+        ERROR_MAP.put(TaskNotFoundError.DEFAULT_CODE, TaskNotFoundError::new);
+    }
 
     public JSONRPCErrorDeserializer() {
         this(null);
@@ -26,6 +44,16 @@ public class JSONRPCErrorDeserializer extends StdDeserializer<JSONRPCError> {
         String message = node.get("message").asText();
         JsonNode dataNode = node.get("data");
         Object data = dataNode != null ? jsonParser.getCodec().treeToValue(dataNode, Object.class) : null;
-        return new JSONRPCError(code, message, data);
+        TriFunction<Integer, String, Object, JSONRPCError> constructor = ERROR_MAP.get(code);
+        if (constructor != null) {
+            return constructor.apply(code, message, data);
+        } else {
+            return new JSONRPCError(code, message, data);
+        }
+    }
+
+    @FunctionalInterface
+    private interface TriFunction<A, B, C, R> {
+        R apply(A a, B b, C c);
     }
 }

--- a/core/src/main/java/io/a2a/spec/MethodNotFoundError.java
+++ b/core/src/main/java/io/a2a/spec/MethodNotFoundError.java
@@ -10,18 +10,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MethodNotFoundError extends JSONRPCError {
+
+    public final static Integer DEFAULT_CODE = -32601;
+
     @JsonCreator
     public MethodNotFoundError(
             @JsonProperty("code") Integer code,
             @JsonProperty("message") String message,
             @JsonProperty("data") Object data) {
         super(
-                defaultIfNull(code, -32601),
+                defaultIfNull(code, DEFAULT_CODE),
                 defaultIfNull(message, "Method not found"),
                 data);
     }
 
     public MethodNotFoundError() {
-        this(-32601, null, null);
+        this(DEFAULT_CODE, null, null);
     }
 }

--- a/core/src/main/java/io/a2a/spec/PushNotificationNotSupportedError.java
+++ b/core/src/main/java/io/a2a/spec/PushNotificationNotSupportedError.java
@@ -10,13 +10,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PushNotificationNotSupportedError extends JSONRPCError {
+
+    public final static Integer DEFAULT_CODE = -32003;
+
     @JsonCreator
     public PushNotificationNotSupportedError(
             @JsonProperty("code") Integer code,
             @JsonProperty("message") String message,
             @JsonProperty("data") Object data) {
         super(
-                defaultIfNull(code, -32003),
+                defaultIfNull(code, DEFAULT_CODE),
                 defaultIfNull(message, "Push Notification is not supported"),
                 data);
     }

--- a/core/src/main/java/io/a2a/spec/TaskNotCancelableError.java
+++ b/core/src/main/java/io/a2a/spec/TaskNotCancelableError.java
@@ -10,6 +10,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TaskNotCancelableError extends JSONRPCError {
+
+    public final static Integer DEFAULT_CODE = -32002;
+
     public TaskNotCancelableError() {
         this(null, null, null);
     }
@@ -20,7 +23,7 @@ public class TaskNotCancelableError extends JSONRPCError {
             @JsonProperty("message") String message,
             @JsonProperty("data") Object data) {
         super(
-                defaultIfNull(code, -32002),
+                defaultIfNull(code, DEFAULT_CODE),
                 defaultIfNull(message, "Task cannot be canceled"),
                 data);
     }

--- a/core/src/main/java/io/a2a/spec/TaskNotFoundError.java
+++ b/core/src/main/java/io/a2a/spec/TaskNotFoundError.java
@@ -10,6 +10,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TaskNotFoundError extends JSONRPCError {
+
+    public final static Integer DEFAULT_CODE = -32001;
+
     public TaskNotFoundError() {
         this(null, null, null);
     }
@@ -21,7 +24,7 @@ public class TaskNotFoundError extends JSONRPCError {
             @JsonProperty("message") String message,
             @JsonProperty("data") Object data) {
         super(
-                defaultIfNull(code, -32001),
+                defaultIfNull(code, DEFAULT_CODE),
                 defaultIfNull(message, "Task not found"),
                 data);
     }

--- a/core/src/main/java/io/a2a/spec/UnsupportedOperationError.java
+++ b/core/src/main/java/io/a2a/spec/UnsupportedOperationError.java
@@ -10,13 +10,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UnsupportedOperationError extends JSONRPCError {
+
+    public final static Integer DEFAULT_CODE = -32004;
+
     @JsonCreator
     public UnsupportedOperationError(
             @JsonProperty("code") Integer code,
             @JsonProperty("message") String message,
             @JsonProperty("data") Object data) {
         super(
-                defaultIfNull(code, -32004),
+                defaultIfNull(code, DEFAULT_CODE),
                 defaultIfNull(message, "This operation is not supported"),
                 data);
     }

--- a/core/src/test/java/io/a2a/spec/JSONRPCErrorSerializationTest.java
+++ b/core/src/test/java/io/a2a/spec/JSONRPCErrorSerializationTest.java
@@ -1,0 +1,52 @@
+package io.a2a.spec;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class JSONRPCErrorSerializationTest {
+    @Test
+    public void shouldDeserializeToCorrectJSONRPCErrorSubclass() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonTemplate = """
+                {"code": %s, "message": "error", "data": "anything"}
+                """;
+
+        record ErrorCase(int code, Class<? extends JSONRPCError> clazz) {}
+
+        List<ErrorCase> cases = List.of(
+                new ErrorCase(JSONParseError.DEFAULT_CODE, JSONParseError.class),
+                new ErrorCase(InvalidRequestError.DEFAULT_CODE, InvalidRequestError.class),
+                new ErrorCase(MethodNotFoundError.DEFAULT_CODE, MethodNotFoundError.class),
+                new ErrorCase(InvalidParamsError.DEFAULT_CODE, InvalidParamsError.class),
+                new ErrorCase(InternalError.DEFAULT_CODE, InternalError.class),
+                new ErrorCase(PushNotificationNotSupportedError.DEFAULT_CODE, PushNotificationNotSupportedError.class),
+                new ErrorCase(UnsupportedOperationError.DEFAULT_CODE, UnsupportedOperationError.class),
+                new ErrorCase(ContentTypeNotSupportedError.DEFAULT_CODE, ContentTypeNotSupportedError.class),
+                new ErrorCase(InvalidAgentResponseError.DEFAULT_CODE, InvalidAgentResponseError.class),
+                new ErrorCase(TaskNotCancelableError.DEFAULT_CODE, TaskNotCancelableError.class),
+                new ErrorCase(TaskNotFoundError.DEFAULT_CODE, TaskNotFoundError.class),
+                new ErrorCase(Integer.MAX_VALUE, JSONRPCError.class) // Any unknown code will be treated as JSONRPCError
+        );
+
+        for (ErrorCase errorCase : cases) {
+            String json = jsonTemplate.formatted(errorCase.code());
+            JSONRPCError error;
+            try {
+                error = objectMapper.readValue(json, JSONRPCError.class);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+            assertInstanceOf(errorCase.clazz(), error);
+            assertEquals("error", error.getMessage());
+            assertEquals("anything", error.getData().toString());
+        }
+    }
+
+
+}


### PR DESCRIPTION
This PR includes the following changes:

1. Improved the `JSONRPCErrorDeserializer` so that it can return the correct subclass based on the error code, instead of always returning `JSONRPCError`.  

2. Added corresponding unit tests.

Fixes #23 