### PR TITLE
docs: fix link to use official repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ mvn clean install
 
 ## Examples
 
-You can find an example of how to use the A2A Java SDK [here](https://github.com/fjuma/a2a-samples/tree/java-sdk-example/samples/multi_language/python_and_java_multiagent/weather_agent).
+You can find an example of how to use the A2A Java SDK in the [a2a-samples repository](https://github.com/a2aproject/a2a-samples/tree/main/samples/multi_language/python_and_java_multiagent/weather_agent).
 
 More examples will be added soon.
 


### PR DESCRIPTION
This PR updates the example link to point to the official repository.

Before: https://github.com/fjuma/...
After: https://github.com/a2aproject/...