### PR TITLE
fix: Fixed the intermittent failure issue in `testOnMessageStreamNewMessageSendPushNotificationSuccess`

### DIFF
--- a/sdk-server-common/src/test/java/io/a2a/server/requesthandlers/JSONRPCHandlerTest.java
+++ b/sdk-server-common/src/test/java/io/a2a/server/requesthandlers/JSONRPCHandlerTest.java
@@ -700,7 +700,6 @@ public class JSONRPCHandlerTest {
                 public void onSubscribe(Flow.Subscription subscription) {
                     subscriptionRef.set(subscription);
                     subscription.request(1);
-                    latch.countDown();
                 }
 
                 @Override
@@ -726,16 +725,6 @@ public class JSONRPCHandlerTest {
 
         assertTrue(latch.await(5, TimeUnit.SECONDS));
         subscriptionRef.get().cancel();
-        if (results.size() != 3) {
-            // TODO - this is very strange. The results array is synchronized, and the latch is counted down
-            //  AFTER adding items to the list. Still, I am seeing intermittently, but frequently that
-            //  the results list only has two items.
-            //  Remove System.out.printlns in this test when done.
-            long end = System.currentTimeMillis() + 5000;
-            while (results.size() != 3 && System.currentTimeMillis() < end) {
-                Thread.sleep(1000);
-            }
-        }
         assertEquals(3, results.size());
         assertEquals(3, httpClient.tasks.size());
 


### PR DESCRIPTION
The reason for its intermittent failure, I believe, is as follows:

We initially set up the `CountDownLatch` with a count of 6, and we will call `latch.countDown()` at the following three locations:

- A. in `onSubscribe`
- B. in the `finally` block of the `post` method in `HttpClient`
- C. in `onNext`

Ideally, when the test method runs, the sequence of `countDown()` calls should be like this:
**A B C B C B C**

The `countDown()` function was called a total of 7 times!

This explains why we sometimes see only **2 elements** in `results` when we do `assertEquals(3, results.size())`. It's because the last `onNext` may not have completed execution yet.

**What this PR does:**  

We could fix this by initializing the `CountDownLatch` to 7. However, considering the purpose of this test method, I chose instead to keep the count at 6 and **remove the `latch.countDown()` call in `onSubscribe`**.

Fixes #140 