### PR TITLE
refactor: GH-165 Decoupled the transport layer

### DIFF
--- a/core/src/main/java/io/a2a/client/A2ACardResolver.java
+++ b/core/src/main/java/io/a2a/client/A2ACardResolver.java
@@ -1,20 +1,15 @@
 package io.a2a.client;
 
-import static io.a2a.util.Utils.unmarshalFrom;
-
-import java.io.IOException;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import io.a2a.http.A2AHttpClient;
-import io.a2a.http.A2AHttpResponse;
 import io.a2a.spec.A2AClientError;
 import io.a2a.spec.A2AClientJSONError;
 import io.a2a.spec.AgentCard;
+import io.a2a.transport.A2ATransport;
 
 public class A2ACardResolver {
-    private final A2AHttpClient httpClient;
+    private final A2ATransport transport;
     private final String url;
     private final Map<String, String> authHeaders;
 
@@ -22,32 +17,32 @@ public class A2ACardResolver {
 
     static final TypeReference<AgentCard> AGENT_CARD_TYPE_REFERENCE = new TypeReference<>() {};
     /**
-     * @param httpClient the http client to use
+     * @param transport the transport to use
      * @param baseUrl the base URL for the agent whose agent card we want to retrieve
      */
-    public A2ACardResolver(A2AHttpClient httpClient, String baseUrl) {
-        this(httpClient, baseUrl, null, null);
+    public A2ACardResolver(A2ATransport transport, String baseUrl) {
+        this(transport, baseUrl, null, null);
     }
 
     /**
-     * @param httpClient the http client to use
+     * @param transport the transport to use
      * @param baseUrl the base URL for the agent whose agent card we want to retrieve
      * @param agentCardPath optional path to the agent card endpoint relative to the base
      *                         agent URL, defaults to ".well-known/agent.json"
      */
-    public A2ACardResolver(A2AHttpClient httpClient, String baseUrl, String agentCardPath) {
-        this(httpClient, baseUrl, agentCardPath, null);
+    public A2ACardResolver(A2ATransport transport, String baseUrl, String agentCardPath) {
+        this(transport, baseUrl, agentCardPath, null);
     }
 
     /**
-     * @param httpClient the http client to use
+     * @param transport the transport to use
      * @param baseUrl the base URL for the agent whose agent card we want to retrieve
      * @param agentCardPath optional path to the agent card endpoint relative to the base
      *                         agent URL, defaults to ".well-known/agent.json"
      * @param authHeaders the HTTP authentication headers to use. May be {@code null}
      */
-    public A2ACardResolver(A2AHttpClient httpClient, String baseUrl, String agentCardPath, Map<String, String> authHeaders) {
-        this.httpClient = httpClient;
+    public A2ACardResolver(A2ATransport transport, String baseUrl, String agentCardPath, Map<String, String> authHeaders) {
+        this.transport = transport;
         if (!baseUrl.endsWith("/")) {
             baseUrl += "/";
         }
@@ -67,33 +62,7 @@ public class A2ACardResolver {
      * @throws A2AClientJSONError f the response body cannot be decoded as JSON or validated against the AgentCard schema
      */
     public AgentCard getAgentCard() throws A2AClientError, A2AClientJSONError {
-        A2AHttpClient.GetBuilder builder = httpClient.createGet()
-                .url(url)
-                .addHeader("Content-Type", "application/json");
-
-        if (authHeaders != null) {
-            for (Map.Entry<String, String> entry : authHeaders.entrySet()) {
-                builder.addHeader(entry.getKey(), entry.getValue());
-            }
-        }
-
-        String body;
-        try {
-            A2AHttpResponse response = builder.get();
-            if (!response.success()) {
-                throw new A2AClientError("Failed to obtain agent card: " + response.status());
-            }
-            body = response.body();
-        } catch (IOException | InterruptedException e) {
-            throw new A2AClientError("Failed to obtain agent card", e);
-        }
-
-        try {
-            return unmarshalFrom(body, AGENT_CARD_TYPE_REFERENCE);
-        } catch (JsonProcessingException e) {
-            throw new A2AClientJSONError("Could not unmarshal agent card response", e);
-        }
-
+        return transport.getAgentCard(url, authHeaders);
     }
 
 

--- a/core/src/main/java/io/a2a/spec/A2A.java
+++ b/core/src/main/java/io/a2a/spec/A2A.java
@@ -4,8 +4,8 @@ import java.util.Collections;
 import java.util.Map;
 
 import io.a2a.client.A2ACardResolver;
-import io.a2a.http.A2AHttpClient;
-import io.a2a.http.JdkA2AHttpClient;
+import io.a2a.transport.A2ATransport;
+import io.a2a.transport.http.JdkA2AHttpTransport;
 
 
 /**
@@ -86,20 +86,20 @@ public class A2A {
      * @throws A2AClientJSONError f the response body cannot be decoded as JSON or validated against the AgentCard schema
      */
     public static AgentCard getAgentCard(String agentUrl) throws A2AClientError, A2AClientJSONError {
-        return getAgentCard(new JdkA2AHttpClient(), agentUrl);
+        return getAgentCard(new JdkA2AHttpTransport(), agentUrl);
     }
 
     /**
      * Get the agent card for an A2A agent.
      *
-     * @param httpClient the http client to use
+     * @param transport the transport to use
      * @param agentUrl the base URL for the agent whose agent card we want to retrieve
      * @return the agent card
      * @throws A2AClientError If an HTTP error occurs fetching the card
      * @throws A2AClientJSONError f the response body cannot be decoded as JSON or validated against the AgentCard schema
      */
-    public static AgentCard getAgentCard(A2AHttpClient httpClient, String agentUrl) throws A2AClientError, A2AClientJSONError  {
-        return getAgentCard(httpClient, agentUrl, null, null);
+    public static AgentCard getAgentCard(A2ATransport transport, String agentUrl) throws A2AClientError, A2AClientJSONError  {
+        return getAgentCard(transport, agentUrl, null, null);
     }
 
     /**
@@ -114,13 +114,13 @@ public class A2A {
      * @throws A2AClientJSONError f the response body cannot be decoded as JSON or validated against the AgentCard schema
      */
     public static AgentCard getAgentCard(String agentUrl, String relativeCardPath, Map<String, String> authHeaders) throws A2AClientError, A2AClientJSONError {
-        return getAgentCard(new JdkA2AHttpClient(), agentUrl, relativeCardPath, authHeaders);
+        return getAgentCard(new JdkA2AHttpTransport(), agentUrl, relativeCardPath, authHeaders);
     }
 
     /**
      * Get the agent card for an A2A agent.
      *
-     * @param httpClient the http client to use
+     * @param transport the transport to use
      * @param agentUrl the base URL for the agent whose agent card we want to retrieve
      * @param relativeCardPath optional path to the agent card endpoint relative to the base
      *                         agent URL, defaults to ".well-known/agent.json"
@@ -129,8 +129,8 @@ public class A2A {
      * @throws A2AClientError If an HTTP error occurs fetching the card
      * @throws A2AClientJSONError f the response body cannot be decoded as JSON or validated against the AgentCard schema
      */
-    public static AgentCard getAgentCard(A2AHttpClient httpClient, String agentUrl, String relativeCardPath, Map<String, String> authHeaders) throws A2AClientError, A2AClientJSONError  {
-        A2ACardResolver resolver = new A2ACardResolver(httpClient, agentUrl, relativeCardPath, authHeaders);
+    public static AgentCard getAgentCard(A2ATransport transport, String agentUrl, String relativeCardPath, Map<String, String> authHeaders) throws A2AClientError, A2AClientJSONError  {
+        A2ACardResolver resolver = new A2ACardResolver(transport, agentUrl, relativeCardPath, authHeaders);
         return resolver.getAgentCard();
     }
 

--- a/core/src/main/java/io/a2a/transport/A2ATransport.java
+++ b/core/src/main/java/io/a2a/transport/A2ATransport.java
@@ -1,0 +1,31 @@
+package io.a2a.transport;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.a2a.spec.A2AClientError;
+import io.a2a.spec.AgentCard;
+import io.a2a.spec.Event;
+import io.a2a.spec.JSONRPCRequest;
+import io.a2a.spec.JSONRPCResponse;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+public interface A2ATransport {
+
+    AgentCard getAgentCard(String method, Map<String, String> authInfo) throws A2AClientError;
+
+    void sendEvent(Event event, String method) throws IOException, InterruptedException;
+
+    <T extends JSONRPCResponse<?>> T sendMessage(
+            JSONRPCRequest<?> request, String operation, TypeReference<T> responseTypeRef) throws IOException, InterruptedException;
+
+    <T extends JSONRPCResponse<?>> CompletableFuture<Void> sendMessageStreaming(
+            JSONRPCRequest<?> request,
+            String operation,
+            TypeReference<T> responseTypeRef,
+            Consumer<T> responseConsumer,
+            Consumer<Throwable> errorConsumer,
+            Runnable completeRunnable) throws IOException, InterruptedException;
+}

--- a/core/src/main/java/io/a2a/transport/http/A2AHttpResponse.java
+++ b/core/src/main/java/io/a2a/transport/http/A2AHttpResponse.java
@@ -1,4 +1,4 @@
-package io.a2a.http;
+package io.a2a.transport.http;
 
 public interface A2AHttpResponse {
     int status();

--- a/core/src/main/java/io/a2a/transport/http/A2AHttpTransport.java
+++ b/core/src/main/java/io/a2a/transport/http/A2AHttpTransport.java
@@ -1,10 +1,12 @@
-package io.a2a.http;
+package io.a2a.transport.http;
+
+import io.a2a.transport.A2ATransport;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
-public interface A2AHttpClient {
+public interface A2AHttpTransport extends A2ATransport {
 
     GetBuilder createGet();
 

--- a/core/src/main/java/io/a2a/transport/http/JdkA2AHttpTransport.java
+++ b/core/src/main/java/io/a2a/transport/http/JdkA2AHttpTransport.java
@@ -1,12 +1,22 @@
-package io.a2a.http;
+package io.a2a.transport.http;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.a2a.spec.AgentCard;
+import io.a2a.spec.A2AClientError;
+import io.a2a.spec.A2AClientJSONError;
+import io.a2a.spec.A2AServerException;
+import io.a2a.spec.JSONRPCError;
+import io.a2a.spec.JSONRPCRequest;
+import io.a2a.spec.JSONRPCResponse;
+import io.a2a.spec.Event;
+import io.a2a.util.Utils;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandler;
-import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,16 +24,88 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 import java.util.function.Consumer;
 
-public class JdkA2AHttpClient implements A2AHttpClient {
+import static io.a2a.util.Utils.OBJECT_MAPPER;
+import static io.a2a.util.Utils.unmarshalFrom;
+
+public class JdkA2AHttpTransport implements A2AHttpTransport {
+    private static final TypeReference<AgentCard> AGENT_CARD_TYPE_REFERENCE = new TypeReference<>() { };
+
 
     private final HttpClient httpClient;
 
-    public JdkA2AHttpClient() {
+    public JdkA2AHttpTransport() {
         httpClient = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_2)
                 .followRedirects(HttpClient.Redirect.NORMAL)
                 .build();
     }
+
+    @Override
+    public AgentCard getAgentCard(String method, Map<String, String> authInfo) throws A2AClientError {
+        GetBuilder builder = createGet()
+                .url(method)
+                .addHeader("Content-Type", "application/json");
+
+        if (authInfo != null) {
+            for (Map.Entry<String, String> entry : authInfo.entrySet()) {
+                builder.addHeader(entry.getKey(), entry.getValue());
+            }
+        }
+
+        String body;
+        try {
+            A2AHttpResponse response = builder.get();
+            if (!response.success()) {
+                throw new A2AClientError("Failed to obtain agent card: " + response.status());
+            }
+            body = response.body();
+        } catch (IOException | InterruptedException e) {
+            throw new A2AClientError("Failed to obtain agent card", e);
+        }
+
+        try {
+            return unmarshalFrom(body, AGENT_CARD_TYPE_REFERENCE);
+        } catch (JsonProcessingException e) {
+            throw new A2AClientJSONError("Could not unmarshal agent card response", e);
+        }
+    }
+
+    @Override
+    public void sendEvent(Event event, String method) throws IOException, InterruptedException {
+        String body = Utils.OBJECT_MAPPER.writeValueAsString(event);
+        createPost().url(method).body(body).post();
+    }
+
+    @Override
+    public <T extends JSONRPCResponse<?>> T sendMessage(
+            JSONRPCRequest<?> request, String operation, TypeReference<T> responseTypeRef) throws IOException, InterruptedException {
+
+        PostBuilder postBuilder = createPostBuilder(request, operation);
+        A2AHttpResponse response = postBuilder.post();
+
+        if (!response.success()) {
+            throw new IOException("Request failed " + response.status());
+        }
+
+        return unmarshalResponse(response.body(), responseTypeRef);
+    }
+
+    @Override
+    public <T extends JSONRPCResponse<?>> CompletableFuture<Void> sendMessageStreaming(
+            JSONRPCRequest<?> request, String operation, TypeReference<T> responseTypeRef,
+            Consumer<T> responseConsumer, Consumer<Throwable> errorConsumer, Runnable completeRunnable) throws IOException, InterruptedException {
+        PostBuilder postBuilder = createPostBuilder(request, operation);
+
+        return postBuilder.postAsyncSSE(message -> {
+            try {
+                T response = unmarshalResponse(message, responseTypeRef);
+                responseConsumer.accept(response);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }, errorConsumer, completeRunnable);
+    }
+
 
     @Override
     public GetBuilder createGet() {
@@ -35,9 +117,27 @@ public class JdkA2AHttpClient implements A2AHttpClient {
         return new JdkPostBuilder();
     }
 
+
+    private PostBuilder createPostBuilder(JSONRPCRequest<?> request, String method) throws JsonProcessingException {
+        return createPost()
+                .url(method)
+                .addHeader("Content-Type", "application/json")
+                .body(OBJECT_MAPPER.writeValueAsString(request));
+    }
+
+    private <T extends JSONRPCResponse<?>> T unmarshalResponse(String response, TypeReference<T> typeReference)
+            throws A2AServerException, JsonProcessingException {
+        T value = unmarshalFrom(response, typeReference);
+        JSONRPCError error = value.getError();
+        if (error != null) {
+            throw new A2AServerException(error.getMessage() + (error.getData() != null ? ": " + error.getData() : ""));
+        }
+        return value;
+    }
+
     private abstract class JdkBuilder<T extends Builder<T>> implements Builder<T> {
         private String url;
-        private Map<String, String> headers = new HashMap<>();
+        private final Map<String, String> headers = new HashMap<>();
 
         @Override
         public T url(String url) {
@@ -105,7 +205,7 @@ public class JdkA2AHttpClient implements A2AHttpClient {
                 }
             };
 
-            BodyHandler<Void> bodyHandler = BodyHandlers.fromLineSubscriber(subscriber);
+            HttpResponse.BodyHandler<Void> bodyHandler = HttpResponse.BodyHandlers.fromLineSubscriber(subscriber);
 
             // Send the response async, and let the subscriber handle the lines.
             return httpClient.sendAsync(request, bodyHandler)
@@ -117,7 +217,7 @@ public class JdkA2AHttpClient implements A2AHttpClient {
         }
     }
 
-    private class JdkGetBuilder extends JdkBuilder<GetBuilder> implements A2AHttpClient.GetBuilder {
+    private class JdkGetBuilder extends JdkBuilder<GetBuilder> implements A2AHttpTransport.GetBuilder {
 
         private HttpRequest.Builder createRequestBuilder(boolean SSE) throws IOException {
             HttpRequest.Builder builder = super.createRequestBuilder().GET();
@@ -132,7 +232,7 @@ public class JdkA2AHttpClient implements A2AHttpClient {
             HttpRequest request = createRequestBuilder(false)
                     .build();
             HttpResponse<String> response =
-                    httpClient.send(request, BodyHandlers.ofString(StandardCharsets.UTF_8));
+                    httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
             return new JdkHttpResponse(response);
         }
 
@@ -147,7 +247,7 @@ public class JdkA2AHttpClient implements A2AHttpClient {
         }
     }
 
-    private class JdkPostBuilder extends JdkBuilder<PostBuilder> implements A2AHttpClient.PostBuilder {
+    private class JdkPostBuilder extends JdkBuilder<PostBuilder> implements A2AHttpTransport.PostBuilder {
         String body = "";
 
         @Override
@@ -171,7 +271,7 @@ public class JdkA2AHttpClient implements A2AHttpClient {
                     .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
                     .build();
             HttpResponse<String> response =
-                    httpClient.send(request, BodyHandlers.ofString(StandardCharsets.UTF_8));
+                    httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
             return new JdkHttpResponse(response);
         }
 

--- a/core/src/test/java/io/a2a/client/A2ACardResolverTest.java
+++ b/core/src/test/java/io/a2a/client/A2ACardResolverTest.java
@@ -8,58 +8,64 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
-import io.a2a.http.A2AHttpClient;
-import io.a2a.http.A2AHttpResponse;
-import io.a2a.spec.A2AClientError;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.a2a.spec.A2AClientJSONError;
 import io.a2a.spec.AgentCard;
+import io.a2a.spec.A2AClientError;
+import io.a2a.spec.Event;
+import io.a2a.spec.JSONRPCResponse;
+import io.a2a.spec.JSONRPCRequest;
+import io.a2a.transport.http.A2AHttpResponse;
+import io.a2a.transport.http.A2AHttpTransport;
 import org.junit.jupiter.api.Test;
 
 public class A2ACardResolverTest {
     @Test
     public void testConstructorStripsSlashes() throws Exception {
-        TestHttpClient client = new TestHttpClient();
-        client.body = JsonMessages.AGENT_CARD;
+        TestHttpTransport transport = new TestHttpTransport();
+        transport.body = JsonMessages.AGENT_CARD;
 
-        A2ACardResolver resolver = new A2ACardResolver(client, "http://example.com/");
+        A2ACardResolver resolver = new A2ACardResolver(transport, "http://example.com/");
         AgentCard card = resolver.getAgentCard();
 
-        assertEquals("http://example.com" + A2ACardResolver.DEFAULT_AGENT_CARD_PATH, client.url);
+        assertEquals("http://example.com" + A2ACardResolver.DEFAULT_AGENT_CARD_PATH, transport.url);
 
 
-        resolver = new A2ACardResolver(client, "http://example.com");
+        resolver = new A2ACardResolver(transport, "http://example.com");
         card = resolver.getAgentCard();
 
-        assertEquals("http://example.com" + A2ACardResolver.DEFAULT_AGENT_CARD_PATH, client.url);
+        assertEquals("http://example.com" + A2ACardResolver.DEFAULT_AGENT_CARD_PATH, transport.url);
 
-        resolver = new A2ACardResolver(client, "http://example.com/", A2ACardResolver.DEFAULT_AGENT_CARD_PATH);
+        resolver = new A2ACardResolver(transport, "http://example.com/", A2ACardResolver.DEFAULT_AGENT_CARD_PATH);
         card = resolver.getAgentCard();
 
-        assertEquals("http://example.com" + A2ACardResolver.DEFAULT_AGENT_CARD_PATH, client.url);
+        assertEquals("http://example.com" + A2ACardResolver.DEFAULT_AGENT_CARD_PATH, transport.url);
 
-        resolver = new A2ACardResolver(client, "http://example.com", A2ACardResolver.DEFAULT_AGENT_CARD_PATH);
+        resolver = new A2ACardResolver(transport, "http://example.com", A2ACardResolver.DEFAULT_AGENT_CARD_PATH);
         card = resolver.getAgentCard();
 
-        assertEquals("http://example.com" + A2ACardResolver.DEFAULT_AGENT_CARD_PATH, client.url);
+        assertEquals("http://example.com" + A2ACardResolver.DEFAULT_AGENT_CARD_PATH, transport.url);
 
-        resolver = new A2ACardResolver(client, "http://example.com/", A2ACardResolver.DEFAULT_AGENT_CARD_PATH.substring(0));
+        resolver = new A2ACardResolver(transport, "http://example.com/", A2ACardResolver.DEFAULT_AGENT_CARD_PATH.substring(0));
         card = resolver.getAgentCard();
 
-        assertEquals("http://example.com" + A2ACardResolver.DEFAULT_AGENT_CARD_PATH, client.url);
+        assertEquals("http://example.com" + A2ACardResolver.DEFAULT_AGENT_CARD_PATH, transport.url);
 
-        resolver = new A2ACardResolver(client, "http://example.com", A2ACardResolver.DEFAULT_AGENT_CARD_PATH.substring(0));
+        resolver = new A2ACardResolver(transport, "http://example.com", A2ACardResolver.DEFAULT_AGENT_CARD_PATH.substring(0));
         card = resolver.getAgentCard();
 
-        assertEquals("http://example.com" + A2ACardResolver.DEFAULT_AGENT_CARD_PATH, client.url);
+        assertEquals("http://example.com" + A2ACardResolver.DEFAULT_AGENT_CARD_PATH, transport.url);
     }
 
 
     @Test
     public void testGetAgentCardSuccess() throws Exception {
-        TestHttpClient client = new TestHttpClient();
+        TestHttpTransport client = new TestHttpTransport();
         client.body = JsonMessages.AGENT_CARD;
 
         A2ACardResolver resolver = new A2ACardResolver(client, "http://example.com/");
@@ -74,7 +80,7 @@ public class A2ACardResolverTest {
 
     @Test
     public void testGetAgentCardJsonDecodeError() throws Exception {
-        TestHttpClient client = new TestHttpClient();
+        TestHttpTransport client = new TestHttpTransport();
         client.body = "X" + JsonMessages.AGENT_CARD;
 
         A2ACardResolver resolver = new A2ACardResolver(client, "http://example.com/");
@@ -91,7 +97,7 @@ public class A2ACardResolverTest {
 
     @Test
     public void testGetAgentCardRequestError() throws Exception {
-        TestHttpClient client = new TestHttpClient();
+        TestHttpTransport client = new TestHttpTransport();
         client.status = 503;
 
         A2ACardResolver resolver = new A2ACardResolver(client, "http://example.com/");
@@ -105,7 +111,7 @@ public class A2ACardResolverTest {
         assertTrue(msg.contains("503"));
     }
 
-    private static class TestHttpClient implements A2AHttpClient {
+    private static class TestHttpTransport implements A2AHttpTransport {
         int status = 200;
         String body;
         String url;
@@ -120,7 +126,52 @@ public class A2ACardResolverTest {
             return null;
         }
 
-        class TestGetBuilder implements A2AHttpClient.GetBuilder {
+        @Override
+        public AgentCard getAgentCard(String method, Map<String, String> authInfo) throws A2AClientError {
+            GetBuilder builder = createGet()
+                    .url(method)
+                    .addHeader("Content-Type", "application/json");
+
+            if (authInfo != null) {
+                for (Map.Entry<String, String> entry : authInfo.entrySet()) {
+                    builder.addHeader(entry.getKey(), entry.getValue());
+                }
+            }
+
+            String body;
+            try {
+                A2AHttpResponse response = builder.get();
+                if (!response.success()) {
+                    throw new A2AClientError("Failed to obtain agent card: " + response.status());
+                }
+                body = response.body();
+            } catch (IOException | InterruptedException e) {
+                throw new A2AClientError("Failed to obtain agent card", e);
+            }
+
+            try {
+                return unmarshalFrom(body, AGENT_CARD_TYPE_REFERENCE);
+            } catch (JsonProcessingException e) {
+                throw new A2AClientJSONError("Could not unmarshal agent card response", e);
+            }
+        }
+
+        @Override
+        public void sendEvent(Event event, String method) throws IOException, InterruptedException {
+
+        }
+
+        @Override
+        public <T extends JSONRPCResponse<?>> T sendMessage(JSONRPCRequest<?> request, String operation, TypeReference<T> responseTypeRef) throws IOException, InterruptedException {
+            return null;
+        }
+
+        @Override
+        public <T extends JSONRPCResponse<?>> CompletableFuture<Void> sendMessageStreaming(JSONRPCRequest<?> request, String operation, TypeReference<T> responseTypeRef, Consumer<T> responseConsumer, Consumer<Throwable> errorConsumer, Runnable completeRunnable) throws IOException, InterruptedException {
+            return null;
+        }
+
+        class TestGetBuilder implements GetBuilder {
 
             @Override
             public A2AHttpResponse get() throws IOException, InterruptedException {

--- a/sdk-quarkus/src/test/resources/application.properties
+++ b/sdk-quarkus/src/test/resources/application.properties
@@ -1,1 +1,1 @@
-quarkus.arc.selected-alternatives=io.a2a.server.apps.common.TestHttpClient
+quarkus.arc.selected-alternatives=io.a2a.server.apps.common.TestHttpTransport

--- a/sdk-server-common/src/main/java/io/a2a/server/tasks/InMemoryPushNotifier.java
+++ b/sdk-server-common/src/main/java/io/a2a/server/tasks/InMemoryPushNotifier.java
@@ -5,28 +5,26 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.a2a.transport.A2ATransport;
+import io.a2a.transport.http.JdkA2AHttpTransport;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import io.a2a.http.A2AHttpClient;
-import io.a2a.http.JdkA2AHttpClient;
 import io.a2a.spec.PushNotificationConfig;
 import io.a2a.spec.Task;
-import io.a2a.util.Utils;
 
 @ApplicationScoped
 public class InMemoryPushNotifier implements PushNotifier {
-    private final A2AHttpClient httpClient;
+    private final A2ATransport transport;
     private final Map<String, PushNotificationConfig> pushNotificationInfos = Collections.synchronizedMap(new HashMap<>());
 
     @Inject
     public InMemoryPushNotifier() {
-        this.httpClient = new JdkA2AHttpClient();
+        this.transport = new JdkA2AHttpTransport();
     }
 
-    public InMemoryPushNotifier(A2AHttpClient httpClient) {
-        this.httpClient = httpClient;
+    public InMemoryPushNotifier(A2ATransport transport) {
+        this.transport = transport;
     }
 
     @Override
@@ -54,22 +52,8 @@ public class InMemoryPushNotifier implements PushNotifier {
 
         // TODO auth
 
-        String body;
         try {
-            body = Utils.OBJECT_MAPPER.writeValueAsString(task);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            throw new RuntimeException("Error writing value as string: " + e.getMessage(), e);
-        } catch (Throwable throwable) {
-            throwable.printStackTrace();
-            throw new RuntimeException("Error writing value as string: " + throwable.getMessage(), throwable);
-        }
-
-        try {
-            httpClient.createPost()
-                    .url(url)
-                    .body(body)
-                    .post();
+            transport.sendEvent(task, url);
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException("Error pushing data to " + url + ": " + e.getMessage(), e);
         }

--- a/sdk-server-common/src/test/java/io/a2a/server/requesthandlers/JSONRPCHandlerTest.java
+++ b/sdk-server-common/src/test/java/io/a2a/server/requesthandlers/JSONRPCHandlerTest.java
@@ -1,5 +1,7 @@
 package io.a2a.server.requesthandlers;
 
+import static io.a2a.util.Utils.OBJECT_MAPPER;
+import static io.a2a.util.Utils.unmarshalFrom;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -12,6 +14,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -21,21 +24,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import jakarta.enterprise.context.Dependent;
-
-import io.a2a.http.A2AHttpClient;
-import io.a2a.http.A2AHttpResponse;
-import io.a2a.server.agentexecution.AgentExecutor;
-import io.a2a.server.agentexecution.RequestContext;
-import io.a2a.server.events.EventConsumer;
-import io.a2a.server.events.EventQueue;
-import io.a2a.server.events.InMemoryQueueManager;
-import io.a2a.server.tasks.InMemoryPushNotifier;
-import io.a2a.server.tasks.InMemoryTaskStore;
-import io.a2a.server.tasks.PushNotifier;
-import io.a2a.server.tasks.ResultAggregator;
-import io.a2a.server.tasks.TaskStore;
-import io.a2a.server.tasks.TaskUpdater;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.a2a.spec.A2AClientError;
+import io.a2a.spec.A2AServerException;
 import io.a2a.spec.AgentCapabilities;
 import io.a2a.spec.AgentCard;
 import io.a2a.spec.Artifact;
@@ -49,6 +41,8 @@ import io.a2a.spec.GetTaskResponse;
 import io.a2a.spec.InternalError;
 import io.a2a.spec.InvalidRequestError;
 import io.a2a.spec.JSONRPCError;
+import io.a2a.spec.JSONRPCRequest;
+import io.a2a.spec.JSONRPCResponse;
 import io.a2a.spec.Message;
 import io.a2a.spec.MessageSendParams;
 import io.a2a.spec.PushNotificationConfig;
@@ -71,6 +65,21 @@ import io.a2a.spec.TaskStatus;
 import io.a2a.spec.TaskStatusUpdateEvent;
 import io.a2a.spec.TextPart;
 import io.a2a.spec.UnsupportedOperationError;
+import io.a2a.transport.http.A2AHttpTransport;
+import jakarta.enterprise.context.Dependent;
+
+import io.a2a.transport.http.A2AHttpResponse;
+import io.a2a.server.agentexecution.AgentExecutor;
+import io.a2a.server.agentexecution.RequestContext;
+import io.a2a.server.events.EventConsumer;
+import io.a2a.server.events.EventQueue;
+import io.a2a.server.events.InMemoryQueueManager;
+import io.a2a.server.tasks.InMemoryPushNotifier;
+import io.a2a.server.tasks.InMemoryTaskStore;
+import io.a2a.server.tasks.PushNotifier;
+import io.a2a.server.tasks.ResultAggregator;
+import io.a2a.server.tasks.TaskStore;
+import io.a2a.server.tasks.TaskUpdater;
 import io.a2a.util.Utils;
 import io.quarkus.arc.profile.IfBuildProfile;
 import mutiny.zero.ZeroPublisher;
@@ -103,7 +112,7 @@ public class JSONRPCHandlerTest {
     AgentExecutorMethod agentExecutorExecute;
     AgentExecutorMethod agentExecutorCancel;
     private InMemoryQueueManager queueManager;
-    private TestHttpClient httpClient;
+    private TestHttpTransport transport;
 
     private final Executor internalExecutor = Executors.newCachedThreadPool();
 
@@ -128,8 +137,8 @@ public class JSONRPCHandlerTest {
 
         taskStore = new InMemoryTaskStore();
         queueManager = new InMemoryQueueManager();
-        httpClient = new TestHttpClient();
-        PushNotifier pushNotifier = new InMemoryPushNotifier(httpClient);
+        transport = new TestHttpTransport();
+        PushNotifier pushNotifier = new InMemoryPushNotifier(transport);
 
         requestHandler = new DefaultRequestHandler(executor, taskStore, queueManager, pushNotifier, internalExecutor);
     }
@@ -692,7 +701,7 @@ public class JSONRPCHandlerTest {
         final List<StreamingEventKind> results = Collections.synchronizedList(new ArrayList<>());
         final AtomicReference<Flow.Subscription> subscriptionRef = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(6);
-        httpClient.latch = latch;
+        transport.latch = latch;
 
         Executors.newSingleThreadExecutor().execute(() -> {
             response.subscribe(new Flow.Subscriber<>() {
@@ -726,15 +735,15 @@ public class JSONRPCHandlerTest {
         assertTrue(latch.await(5, TimeUnit.SECONDS));
         subscriptionRef.get().cancel();
         assertEquals(3, results.size());
-        assertEquals(3, httpClient.tasks.size());
+        assertEquals(3, transport.tasks.size());
 
-        Task curr = httpClient.tasks.get(0);
+        Task curr = transport.tasks.get(0);
         assertEquals(MINIMAL_TASK.getId(), curr.getId());
         assertEquals(MINIMAL_TASK.getContextId(), curr.getContextId());
         assertEquals(MINIMAL_TASK.getStatus().state(), curr.getStatus().state());
         assertEquals(0, curr.getArtifacts() == null ? 0 : curr.getArtifacts().size());
 
-        curr = httpClient.tasks.get(1);
+        curr = transport.tasks.get(1);
         assertEquals(MINIMAL_TASK.getId(), curr.getId());
         assertEquals(MINIMAL_TASK.getContextId(), curr.getContextId());
         assertEquals(MINIMAL_TASK.getStatus().state(), curr.getStatus().state());
@@ -742,7 +751,7 @@ public class JSONRPCHandlerTest {
         assertEquals(1, curr.getArtifacts().get(0).parts().size());
         assertEquals("text", ((TextPart)curr.getArtifacts().get(0).parts().get(0)).getText());
 
-        curr = httpClient.tasks.get(2);
+        curr = transport.tasks.get(2);
         assertEquals(MINIMAL_TASK.getId(), curr.getId());
         assertEquals(MINIMAL_TASK.getContextId(), curr.getContextId());
         assertEquals(TaskState.COMPLETED, curr.getStatus().state());
@@ -1264,7 +1273,7 @@ public class JSONRPCHandlerTest {
 
     @Dependent
     @IfBuildProfile("test")
-    private static class TestHttpClient implements A2AHttpClient {
+    private static class TestHttpTransport implements A2AHttpTransport {
         final List<Task> tasks = Collections.synchronizedList(new ArrayList<>());
         volatile CountDownLatch latch;
 
@@ -1278,7 +1287,52 @@ public class JSONRPCHandlerTest {
             return new TestPostBuilder();
         }
 
-        class TestPostBuilder implements A2AHttpClient.PostBuilder {
+        @Override
+        public AgentCard getAgentCard(String method, Map<String, String> authInfo) throws A2AClientError {
+            return null;
+        }
+
+        @Override
+        public void sendEvent(Event event, String method) throws IOException, InterruptedException {
+            String body = Utils.OBJECT_MAPPER.writeValueAsString(event);
+            createPost().url(method).body(body).post();
+        }
+
+        @Override
+        public <T extends JSONRPCResponse<?>> T sendMessage(JSONRPCRequest<?> request, String operation, TypeReference<T> responseTypeRef) throws IOException, InterruptedException {
+            PostBuilder postBuilder = createPostBuilder(request, operation);
+            A2AHttpResponse response = postBuilder.post();
+
+            if (!response.success()) {
+                throw new IOException("Request failed " + response.status());
+            }
+
+            return unmarshalResponse(response.body(), responseTypeRef);
+        }
+
+        @Override
+        public <T extends JSONRPCResponse<?>> CompletableFuture<Void> sendMessageStreaming(JSONRPCRequest<?> request, String operation, TypeReference<T> responseTypeRef, Consumer<T> responseConsumer, Consumer<Throwable> errorConsumer, Runnable completeRunnable) throws IOException, InterruptedException {
+            return null;
+        }
+
+        private PostBuilder createPostBuilder(JSONRPCRequest<?> request, String method) throws JsonProcessingException {
+            return createPost()
+                    .url(method)
+                    .addHeader("Content-Type", "application/json")
+                    .body(OBJECT_MAPPER.writeValueAsString(request));
+        }
+
+        private <T extends JSONRPCResponse<?>> T unmarshalResponse(String response, TypeReference<T> typeReference)
+                throws A2AServerException, JsonProcessingException {
+            T value = unmarshalFrom(response, typeReference);
+            JSONRPCError error = value.getError();
+            if (error != null) {
+                throw new A2AServerException(error.getMessage() + (error.getData() != null ? ": " + error.getData() : ""));
+            }
+            return value;
+        }
+
+        class TestPostBuilder implements PostBuilder {
             private volatile String body;
             @Override
             public PostBuilder body(String body) {

--- a/tests/server-common/src/test/java/io/a2a/server/apps/common/TestHttpTransport.java
+++ b/tests/server-common/src/test/java/io/a2a/server/apps/common/TestHttpTransport.java
@@ -4,21 +4,28 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.a2a.spec.A2AClientError;
+import io.a2a.spec.AgentCard;
+import io.a2a.spec.Event;
+import io.a2a.spec.JSONRPCResponse;
+import io.a2a.spec.JSONRPCRequest;
+import io.a2a.spec.Task;
+import io.a2a.transport.http.A2AHttpTransport;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 
-import io.a2a.http.A2AHttpClient;
-import io.a2a.http.A2AHttpResponse;
-import io.a2a.spec.Task;
+import io.a2a.transport.http.A2AHttpResponse;
 import io.a2a.util.Utils;
 
 @Dependent
 @Alternative
-public class TestHttpClient implements A2AHttpClient {
+public class TestHttpTransport implements A2AHttpTransport {
     final List<Task> tasks = Collections.synchronizedList(new ArrayList<>());
     volatile CountDownLatch latch;
 
@@ -32,7 +39,27 @@ public class TestHttpClient implements A2AHttpClient {
         return new TestPostBuilder();
     }
 
-    class TestPostBuilder implements A2AHttpClient.PostBuilder {
+    @Override
+    public AgentCard getAgentCard(String method, Map<String, String> authInfo) throws A2AClientError {
+        return null;
+    }
+
+    @Override
+    public void sendEvent(Event event, String method) throws IOException, InterruptedException {
+
+    }
+
+    @Override
+    public <T extends JSONRPCResponse<?>> T sendMessage(JSONRPCRequest<?> request, String operation, TypeReference<T> responseTypeRef) throws IOException, InterruptedException {
+        return null;
+    }
+
+    @Override
+    public <T extends JSONRPCResponse<?>> CompletableFuture<Void> sendMessageStreaming(JSONRPCRequest<?> request, String operation, TypeReference<T> responseTypeRef, Consumer<T> responseConsumer, Consumer<Throwable> errorConsumer, Runnable completeRunnable) throws IOException, InterruptedException {
+        return null;
+    }
+
+    class TestPostBuilder implements PostBuilder {
         private volatile String body;
         @Override
         public PostBuilder body(String body) {


### PR DESCRIPTION
This PR decouples the transport protocol layer. Considering that, according to the A2A Protocol Specification (https://a2aproject.github.io/A2A/latest/specification/#3-transport-and-format), communication **must** occur over HTTP(S), I believe we can first decouple the transport layer into a package, rather than rushing to split it into a module (which would face some issues).

The following changes have been made in this PR:

1. Abstract out `A2ATransport` as the transport layer for the A2A protocol.
2. Refactor all existing code that directly used `HttpClient` to instead use `A2ATransport` (defaulting to `JdkA2AHttpTransport`).
3. Add a new constructor to `A2AClient` that accepts an `A2ATransport` parameter.
4. All test classes have been executed and passed successfully.