### PR TITLE
feat: add default noop providers for AgentCard and -Executor

### DIFF
--- a/reference-impl/src/main/java/io/a2a/server/apps/quarkus/DefaultProducers.java
+++ b/reference-impl/src/main/java/io/a2a/server/apps/quarkus/DefaultProducers.java
@@ -1,0 +1,48 @@
+package io.a2a.server.apps.quarkus;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Default;
+import jakarta.ws.rs.Produces;
+
+import io.a2a.server.PublicAgentCard;
+import io.a2a.server.agentexecution.AgentExecutor;
+import io.a2a.server.agentexecution.RequestContext;
+import io.a2a.server.events.EventQueue;
+import io.a2a.spec.AgentCapabilities;
+import io.a2a.spec.AgentCard;
+import io.a2a.spec.JSONRPCError;
+import io.quarkus.arc.DefaultBean;
+
+/**
+ * Contains beans annotated with the Quarkus @DefaultBean annotation, in order to avoid
+ * injection failures when building the Quarkus application as discussed in
+ * <a href="https://github.com/a2aproject/a2a-java/issues/213">Issue 213</a>.
+ *
+ * If an application provides actual implementations of these beans,
+ * those will be used instead.
+ */
+@ApplicationScoped
+public class DefaultProducers {
+    @Produces
+    @PublicAgentCard
+    @DefaultBean
+    public AgentCard createDefaultAgentCard() {
+        throw new IllegalStateException(wrap("Please provide your own AgentCard implementation"));
+    }
+
+    @Produces
+    @Default
+    @DefaultBean
+    public AgentExecutor createDefaultAgentExecutor() {
+        throw new IllegalStateException(wrap("Please provide your own AgentExecutor implementation"));
+    }
+
+    private String wrap(String s) {
+        return s +
+                " as a CDI bean. Your bean will automatically take precedence over this @DefaultBean " +
+                "annotated implementation.";
+    }
+}


### PR DESCRIPTION
This avoids CDI injection problems when building an application with the Quarkus plugin, and still makes people have to implement them to run their application

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](../CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
    - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
        - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
        - `feat:` represents a new feature, and correlates to a SemVer minor.
        - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests pass
- [x] Appropriate READMEs were updated (if necessary)

Fixes #213