### PR TITLE
test: add ToProto and FromProto tests

### DIFF
--- a/spec-grpc/src/test/java/io/a2a/grpc/utils/FromProtoTest.java
+++ b/spec-grpc/src/test/java/io/a2a/grpc/utils/FromProtoTest.java
@@ -1,0 +1,37 @@
+package io.a2a.grpc.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class FromProtoTest {
+    @Test
+    public void testFromProtoPartUnsupportedType() {
+        io.a2a.grpc.Part emptyPart = io.a2a.grpc.Part.newBuilder().build();
+        io.a2a.grpc.Message invalidMessage = io.a2a.grpc.Message.newBuilder()
+                                                                .addContent(emptyPart)
+                                                                .build();
+        io.a2a.spec.InvalidParamsError exception = assertThrows(
+                io.a2a.spec.InvalidParamsError.class,
+                () -> ProtoUtils.FromProto.message(invalidMessage)
+        );
+
+        assertEquals("Invalid parameters", exception.getMessage());
+
+    }
+
+    @Test
+    public void testTaskQueryParamsInvalidName() {
+        io.a2a.grpc.GetTaskRequest request = io.a2a.grpc.GetTaskRequest.newBuilder()
+                                                                       .setName("invalid-name-format")
+                                                                       .build();
+
+        var result = ProtoUtils.FromProto.taskQueryParams(request);
+
+        assertNotNull(result);
+        assertEquals("invalid-name-format", result.id());
+    }
+
+}

--- a/spec-grpc/src/test/java/io/a2a/grpc/utils/ToProtoTest.java
+++ b/spec-grpc/src/test/java/io/a2a/grpc/utils/ToProtoTest.java
@@ -289,4 +289,28 @@ public class ToProtoTest {
         assertNotNull(status.timestamp());
         assertEquals(expectedTimestamp, status.timestamp());
     }
+
+    @Test
+    public void testToProtoPartUnsupportedType() {
+        class FakePart extends io.a2a.spec.Part<Object> {
+            @Override
+            public io.a2a.spec.Part.Kind getKind() { return null; }
+            @Override
+            public Map<String, Object> getMetadata() { return Map.of(); }
+        }
+
+        FakePart fakePart = new FakePart();
+
+        io.a2a.spec.Message message = new io.a2a.spec.Message.Builder()
+                .messageId("msg-unsupported")
+                .contextId("ctx-unsupported")
+                .role(io.a2a.spec.Message.Role.USER)
+                .parts(List.of(fakePart))
+                .build();
+        io.a2a.grpc.Message result = ProtoUtils.ToProto.message(message);
+
+        assertNotNull(result);
+        assertEquals(1, result.getContentCount());
+    }
+
 }


### PR DESCRIPTION
# Description

This PR adds new unit tests to improve coverage for `ProtoUtils.ToProto` and `ProtoUtils.FromProto`.

### Tests Added
- `testFromProtoPartUnsupportedType`: verifies invalid proto parts throw `InvalidParamsError`.
- `testTaskQueryParamsInvalidName`: makes sure invalid task name formats are handled gracefully.
- `testToProtoPartUnsupportedType`: checks handling of unsupported `Part` types during conversion.

Fixes #304 
