### PR TITLE
feat: add ArtifactUtils utility class and corresponding tests (#303)

### DIFF
--- a/server-common/src/main/java/io/a2a/server/util/ArtifactUtils.java
+++ b/server-common/src/main/java/io/a2a/server/util/ArtifactUtils.java
@@ -21,12 +21,12 @@ public final class ArtifactUtils {
     /**
      * Creates a new Artifact object.
      *
-     * @param parts The list of {@code Part} objects forming the artifact's content.
      * @param name The human-readable name of the artifact.
+     * @param parts The list of {@code Part} objects forming the artifact's content.
      * @param description An optional description of the artifact.
      * @return A new {@code Artifact} object with a generated artifact_id.
      */
-    public static Artifact newArtifact(List<Part<?>> parts, String name, String description) {
+    public static Artifact newArtifact(String name, List<Part<?>> parts, String description) {
         return new Artifact(
             UUID.randomUUID().toString(),
             name,
@@ -39,12 +39,12 @@ public final class ArtifactUtils {
     /**
      * Creates a new Artifact object with empty description.
      *
-     * @param parts The list of {@code Part} objects forming the artifact's content.
      * @param name The human-readable name of the artifact.
+     * @param parts The list of {@code Part} objects forming the artifact's content.
      * @return A new {@code Artifact} object with a generated artifact_id.
      */
-    public static Artifact newArtifact(List<Part<?>> parts, String name) {
-        return newArtifact(parts, name, null);
+    public static Artifact newArtifact(String name, List<Part<?>> parts) {
+        return newArtifact(name, parts, null);
     }
 
     /**
@@ -57,8 +57,8 @@ public final class ArtifactUtils {
      */
     public static Artifact newTextArtifact(String name, String text, String description) {
         return newArtifact(
-            List.of(new TextPart(text)),
             name,
+            List.of(new TextPart(text)),
             description
         );
     }
@@ -84,8 +84,8 @@ public final class ArtifactUtils {
      */
     public static Artifact newDataArtifact(String name, Map<String, Object> data, String description) {
         return newArtifact(
-            List.of(new DataPart(data)),
             name,
+            List.of(new DataPart(data)),
             description
         );
     }

--- a/server-common/src/test/java/io/a2a/server/util/ArtifactUtilsTest.java
+++ b/server-common/src/test/java/io/a2a/server/util/ArtifactUtilsTest.java
@@ -1,59 +1,43 @@
 package io.a2a.server.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 
 import io.a2a.spec.Artifact;
 import io.a2a.spec.DataPart;
 import io.a2a.spec.Part;
 import io.a2a.spec.TextPart;
-
-import static org.mockito.Mockito.mockStatic;
 class ArtifactUtilsTest {
 
     @Test
-    void testNewArtifactGeneratesId() {
-        // Given
-        UUID mockUuid = UUID.fromString("abcdef12-1234-5678-1234-567812345678");
-        
-        try (MockedStatic<UUID> mockedUuid = mockStatic(UUID.class)) {
-            mockedUuid.when(UUID::randomUUID).thenReturn(mockUuid);
-            
-            // When
-            Artifact artifact = ArtifactUtils.newArtifact(
-            List.of(new TextPart("")),
-            "test_artifact"
-        );
-            
-            // Then
-            assertEquals(mockUuid.toString(), artifact.artifactId());
-        }
-    }
-
-    @Test
     void testNewArtifactAssignsPartsNameDescription() {
-        // Given
-        List<Part<?>> parts = List.of(new TextPart("Sample text"));
-        String name = "My Artifact";
-        String description = "This is a test artifact.";
-        
-        // When
-        Artifact artifact = ArtifactUtils.newArtifact(parts, name, description);
-        
-        // Then
-        assertEquals(parts, artifact.parts());
-        assertEquals(name, artifact.name());
-        assertEquals(description, artifact.description());
+            // Given
+            List<Part<?>> parts = List.of(new TextPart("Sample text"));
+            String name = "My Artifact";
+            String description = "This is a test artifact.";
+    
+            // When
+            Artifact artifact = ArtifactUtils.newArtifact(name, parts, description);
+    
+            // Then
+            assertEquals(parts, artifact.parts());
+            assertEquals(name, artifact.name());
+            assertEquals(description, artifact.description());
+    
+            // Then
+            assertNotNull(artifact.artifactId());
+            assertFalse(artifact.artifactId().isBlank());
+            assertDoesNotThrow(() -> UUID.fromString(artifact.artifactId()));
     }
 
     @Test
@@ -63,7 +47,7 @@ class ArtifactUtilsTest {
         String name = "Artifact_No_Desc";
         
         // When
-        Artifact artifact = ArtifactUtils.newArtifact(parts, name);
+        Artifact artifact = ArtifactUtils.newArtifact(name, parts);
         
         // Then
         assertEquals(null, artifact.description());    }
@@ -161,7 +145,7 @@ class ArtifactUtilsTest {
         String name = "Test_Artifact";
         
         // When
-        Artifact artifact = ArtifactUtils.newArtifact(parts, name);
+        Artifact artifact = ArtifactUtils.newArtifact(name, parts);
         
         // Then
         assertNotNull(artifact.artifactId());


### PR DESCRIPTION
## feat: add `ArtifactUtils` utility class and corresponding unit tests

### Description

This PR introduces the `ArtifactUtils` utility class, which provides a set of static helper methods for creating `Artifact` instances in a standardized and concise way.  
It simplifies the creation of artifacts with different content types (`TextPart`, `DataPart`, etc.) while ensuring consistent ID generation and description handling.

### Details

- Added `ArtifactUtils` as a `final` utility class with a private constructor to prevent instantiation.  
- Implemented multiple overloaded factory methods for flexible artifact creation:
  - `newArtifact(List<Part<?>> parts, String name, String description)`
  - `newArtifact(List<Part<?>> parts, String name)`
  - `newTextArtifact(String name, String text, String description)`
  - `newTextArtifact(String name, String text)`
  - `newDataArtifact(String name, Map<String, Object> data, String description)`
  - `newDataArtifact(String name, Map<String, Object> data)`
- Each artifact automatically receives a unique `artifactId` via `UUID.randomUUID()`.  
- Uses `List.of()` for concise creation of single-part artifacts (`TextPart`, `DataPart`).

### Tests

Added comprehensive unit tests in `ArtifactUtilsTest` to verify:
- UUID generation through mocking  
- Proper assignment of `name`, `description`, and `parts`  
- Correct creation of both text-based and data-based artifacts  
- Non-null and non-empty `artifactId` values  

### Example Usage

```java
Artifact textArtifact = ArtifactUtils.newTextArtifact("User Profile", "Basic user info");
Artifact dataArtifact = ArtifactUtils.newDataArtifact("Config", Map.of("version", "1.0"));

```
Fixes:#303
