### PR TITLE
feat: add JSON-RPC method to ServerCallContext.state

### DIFF
--- a/reference/jsonrpc/pom.xml
+++ b/reference/jsonrpc/pom.xml
@@ -77,5 +77,15 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/A2AServerRoutesTest.java
+++ b/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/A2AServerRoutesTest.java
@@ -1,0 +1,442 @@
+package io.a2a.server.apps.quarkus;
+
+import static io.a2a.transport.jsonrpc.context.JSONRPCContextKeys.METHOD_NAME_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Flow;
+
+import jakarta.enterprise.inject.Instance;
+
+import io.a2a.server.ServerCallContext;
+import io.a2a.spec.CancelTaskRequest;
+import io.a2a.spec.CancelTaskResponse;
+import io.a2a.spec.DeleteTaskPushNotificationConfigRequest;
+import io.a2a.spec.DeleteTaskPushNotificationConfigResponse;
+import io.a2a.spec.GetAuthenticatedExtendedCardRequest;
+import io.a2a.spec.GetAuthenticatedExtendedCardResponse;
+import io.a2a.spec.GetTaskPushNotificationConfigRequest;
+import io.a2a.spec.GetTaskPushNotificationConfigResponse;
+import io.a2a.spec.GetTaskRequest;
+import io.a2a.spec.GetTaskResponse;
+import io.a2a.spec.ListTaskPushNotificationConfigRequest;
+import io.a2a.spec.ListTaskPushNotificationConfigResponse;
+import io.a2a.spec.SendMessageRequest;
+import io.a2a.spec.SendMessageResponse;
+import io.a2a.spec.SendStreamingMessageRequest;
+import io.a2a.spec.SendStreamingMessageResponse;
+import io.a2a.spec.SetTaskPushNotificationConfigRequest;
+import io.a2a.spec.SetTaskPushNotificationConfigResponse;
+import io.a2a.spec.TaskResubscriptionRequest;
+import io.a2a.transport.jsonrpc.handler.JSONRPCHandler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RequestBody;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit test for JSON-RPC A2AServerRoutes that verifies the method names are properly set
+ * in the ServerCallContext for all request types.
+ */
+public class A2AServerRoutesTest {
+
+    private A2AServerRoutes routes;
+    private JSONRPCHandler mockJsonRpcHandler;
+    private Executor mockExecutor;
+    private Instance<CallContextFactory> mockCallContextFactory;
+    private RoutingContext mockRoutingContext;
+    private HttpServerRequest mockRequest;
+    private HttpServerResponse mockHttpResponse;
+    private MultiMap mockHeaders;
+    private RequestBody mockRequestBody;
+
+    @BeforeEach
+    public void setUp() {
+        routes = new A2AServerRoutes();
+        mockJsonRpcHandler = mock(JSONRPCHandler.class);
+        mockExecutor = mock(Executor.class);
+        mockCallContextFactory = mock(Instance.class);
+        mockRoutingContext = mock(RoutingContext.class);
+        mockRequest = mock(HttpServerRequest.class);
+        mockHttpResponse = mock(HttpServerResponse.class);
+        mockHeaders = MultiMap.caseInsensitiveMultiMap();
+        mockRequestBody = mock(RequestBody.class);
+
+        // Inject mocks via reflection since we can't use @InjectMocks
+        setField(routes, "jsonRpcHandler", mockJsonRpcHandler);
+        setField(routes, "executor", mockExecutor);
+        setField(routes, "callContextFactory", mockCallContextFactory);
+
+        // Setup common mock behavior
+        when(mockCallContextFactory.isUnsatisfied()).thenReturn(true);
+        when(mockRoutingContext.request()).thenReturn(mockRequest);
+        when(mockRoutingContext.response()).thenReturn(mockHttpResponse);
+        when(mockRoutingContext.user()).thenReturn(null);
+        when(mockRequest.headers()).thenReturn(mockHeaders);
+        when(mockRoutingContext.body()).thenReturn(mockRequestBody);
+
+        // Chain the response methods properly
+        when(mockHttpResponse.setStatusCode(any(Integer.class))).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.putHeader(any(CharSequence.class), any(CharSequence.class))).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.end(anyString())).thenReturn(null);
+        when(mockHttpResponse.setChunked(any(Boolean.class))).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.headers()).thenReturn(mockHeaders);
+    }
+
+    @Test
+    public void testSendMessage_MethodNameSetInContext() {
+        // Arrange - using valid JSON from JsonMessages test file
+        String jsonRpcRequest = """
+            {
+             "jsonrpc": "2.0",
+             "method": "message/send",
+             "params": {
+              "message": {
+               "role": "user",
+               "parts": [
+                {
+                 "kind": "text",
+                 "text": "tell me a joke"
+                }
+               ],
+               "messageId": "message-1234",
+               "contextId": "context-1234",
+               "kind": "message"
+              },
+              "configuration": {
+                "acceptedOutputModes": ["text"],
+                "blocking": true
+              }
+             }
+            }""";
+        when(mockRequestBody.asString()).thenReturn(jsonRpcRequest);
+
+        SendMessageResponse mockResponse = mock(SendMessageResponse.class);
+        when(mockJsonRpcHandler.onMessageSend(any(SendMessageRequest.class), any(ServerCallContext.class)))
+                .thenReturn(mockResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.invokeJSONRPCHandler(jsonRpcRequest, mockRoutingContext);
+
+        // Assert
+        verify(mockJsonRpcHandler).onMessageSend(any(SendMessageRequest.class), contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(SendMessageRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testSendStreamingMessage_MethodNameSetInContext() {
+        // Arrange - using the same valid format as testSendMessage
+        String jsonRpcRequest = """
+            {
+             "jsonrpc": "2.0",
+             "method": "message/stream",
+             "params": {
+              "message": {
+               "role": "user",
+               "parts": [
+                {
+                 "kind": "text",
+                 "text": "tell me a joke"
+                }
+               ],
+               "messageId": "message-1234",
+               "contextId": "context-1234",
+               "kind": "message"
+              },
+              "configuration": {
+                "acceptedOutputModes": ["text"],
+                "blocking": true
+              }
+             }
+            }""";
+        when(mockRequestBody.asString()).thenReturn(jsonRpcRequest);
+
+        @SuppressWarnings("unchecked")
+        Flow.Publisher<SendStreamingMessageResponse> mockPublisher = mock(Flow.Publisher.class);
+        when(mockJsonRpcHandler.onMessageSendStream(any(SendStreamingMessageRequest.class),
+                any(ServerCallContext.class))).thenReturn(mockPublisher);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.invokeJSONRPCHandler(jsonRpcRequest, mockRoutingContext);
+
+        // Assert
+        verify(mockJsonRpcHandler).onMessageSendStream(any(SendStreamingMessageRequest.class),
+                contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(SendStreamingMessageRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testGetTask_MethodNameSetInContext() {
+        // Arrange - based on GET_TASK_TEST_REQUEST from JsonMessages
+        String jsonRpcRequest = """
+            {
+             "jsonrpc": "2.0",
+             "method": "tasks/get",
+             "params": {
+              "id": "de38c76d-d54c-436c-8b9f-4c2703648d64",
+              "historyLength": 10
+             }
+            }""";
+        when(mockRequestBody.asString()).thenReturn(jsonRpcRequest);
+
+        GetTaskResponse mockResponse = mock(GetTaskResponse.class);
+        when(mockJsonRpcHandler.onGetTask(any(GetTaskRequest.class), any(ServerCallContext.class)))
+                .thenReturn(mockResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.invokeJSONRPCHandler(jsonRpcRequest, mockRoutingContext);
+
+        // Assert
+        verify(mockJsonRpcHandler).onGetTask(any(GetTaskRequest.class), contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(GetTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testCancelTask_MethodNameSetInContext() {
+        // Arrange - based on CANCEL_TASK_TEST_REQUEST from JsonMessages
+        String jsonRpcRequest = """
+            {
+             "jsonrpc": "2.0",
+             "method": "tasks/cancel",
+             "params": {
+              "id": "de38c76d-d54c-436c-8b9f-4c2703648d64",
+              "metadata": {}
+             }
+            }""";
+        when(mockRequestBody.asString()).thenReturn(jsonRpcRequest);
+
+        CancelTaskResponse mockResponse = mock(CancelTaskResponse.class);
+        when(mockJsonRpcHandler.onCancelTask(any(CancelTaskRequest.class), any(ServerCallContext.class)))
+                .thenReturn(mockResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.invokeJSONRPCHandler(jsonRpcRequest, mockRoutingContext);
+
+        // Assert
+        verify(mockJsonRpcHandler).onCancelTask(any(CancelTaskRequest.class), contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(CancelTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testTaskResubscription_MethodNameSetInContext() {
+        // Arrange - minimal valid JSON for task resubscription
+        String jsonRpcRequest = """
+            {
+             "jsonrpc": "2.0",
+             "method": "tasks/resubscribe",
+             "params": {
+              "id": "de38c76d-d54c-436c-8b9f-4c2703648d64"
+             }
+            }""";
+        when(mockRequestBody.asString()).thenReturn(jsonRpcRequest);
+
+        @SuppressWarnings("unchecked")
+        Flow.Publisher<SendStreamingMessageResponse> mockPublisher = mock(Flow.Publisher.class);
+        when(mockJsonRpcHandler.onResubscribeToTask(any(TaskResubscriptionRequest.class),
+                any(ServerCallContext.class))).thenReturn(mockPublisher);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.invokeJSONRPCHandler(jsonRpcRequest, mockRoutingContext);
+
+        // Assert
+        verify(mockJsonRpcHandler).onResubscribeToTask(any(TaskResubscriptionRequest.class),
+                contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(TaskResubscriptionRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testSetTaskPushNotificationConfig_MethodNameSetInContext() {
+        // Arrange - based on SET_TASK_PUSH_NOTIFICATION_CONFIG_TEST_REQUEST from JsonMessages
+        String jsonRpcRequest = """
+            {
+             "jsonrpc": "2.0",
+             "method": "tasks/pushNotificationConfig/set",
+             "params": {
+              "taskId": "de38c76d-d54c-436c-8b9f-4c2703648d64",
+              "pushNotificationConfig": {
+               "url": "https://example.com/callback",
+               "authentication": {
+                "schemes": ["jwt"]
+               }
+              }
+             }
+            }""";
+        when(mockRequestBody.asString()).thenReturn(jsonRpcRequest);
+
+        SetTaskPushNotificationConfigResponse mockResponse = mock(SetTaskPushNotificationConfigResponse.class);
+        when(mockJsonRpcHandler.setPushNotificationConfig(any(SetTaskPushNotificationConfigRequest.class),
+                any(ServerCallContext.class))).thenReturn(mockResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.invokeJSONRPCHandler(jsonRpcRequest, mockRoutingContext);
+
+        // Assert
+        verify(mockJsonRpcHandler).setPushNotificationConfig(any(SetTaskPushNotificationConfigRequest.class),
+                contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(SetTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testGetTaskPushNotificationConfig_MethodNameSetInContext() {
+        // Arrange - based on GET_TASK_PUSH_NOTIFICATION_CONFIG_TEST_REQUEST from JsonMessages
+        String jsonRpcRequest = """
+            {
+             "jsonrpc": "2.0",
+             "method": "tasks/pushNotificationConfig/get",
+             "params": {
+              "id": "de38c76d-d54c-436c-8b9f-4c2703648d64",
+              "metadata": {}
+             }
+            }""";
+        when(mockRequestBody.asString()).thenReturn(jsonRpcRequest);
+
+        GetTaskPushNotificationConfigResponse mockResponse = mock(GetTaskPushNotificationConfigResponse.class);
+        when(mockJsonRpcHandler.getPushNotificationConfig(any(GetTaskPushNotificationConfigRequest.class),
+                any(ServerCallContext.class))).thenReturn(mockResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.invokeJSONRPCHandler(jsonRpcRequest, mockRoutingContext);
+
+        // Assert
+        verify(mockJsonRpcHandler).getPushNotificationConfig(any(GetTaskPushNotificationConfigRequest.class),
+                contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(GetTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testListTaskPushNotificationConfig_MethodNameSetInContext() {
+        // Arrange - minimal valid JSON for list task push notification config
+        String jsonRpcRequest = """
+            {
+             "jsonrpc": "2.0",
+             "method": "tasks/pushNotificationConfig/list",
+             "params": {
+              "id": "de38c76d-d54c-436c-8b9f-4c2703648d64"
+             }
+            }""";
+        when(mockRequestBody.asString()).thenReturn(jsonRpcRequest);
+
+        ListTaskPushNotificationConfigResponse mockResponse = mock(ListTaskPushNotificationConfigResponse.class);
+        when(mockJsonRpcHandler.listPushNotificationConfig(any(ListTaskPushNotificationConfigRequest.class),
+                any(ServerCallContext.class))).thenReturn(mockResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.invokeJSONRPCHandler(jsonRpcRequest, mockRoutingContext);
+
+        // Assert
+        verify(mockJsonRpcHandler).listPushNotificationConfig(any(ListTaskPushNotificationConfigRequest.class),
+                contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(ListTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testDeleteTaskPushNotificationConfig_MethodNameSetInContext() {
+        // Arrange - minimal valid JSON for delete task push notification config
+        String jsonRpcRequest = """
+            {
+             "jsonrpc": "2.0",
+             "method": "tasks/pushNotificationConfig/delete",
+             "params": {
+              "id": "de38c76d-d54c-436c-8b9f-4c2703648d64",
+              "pushNotificationConfigId": "config-456"
+             }
+            }""";
+        when(mockRequestBody.asString()).thenReturn(jsonRpcRequest);
+
+        DeleteTaskPushNotificationConfigResponse mockResponse = mock(DeleteTaskPushNotificationConfigResponse.class);
+        when(mockJsonRpcHandler.deletePushNotificationConfig(any(DeleteTaskPushNotificationConfigRequest.class),
+                any(ServerCallContext.class))).thenReturn(mockResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.invokeJSONRPCHandler(jsonRpcRequest, mockRoutingContext);
+
+        // Assert
+        verify(mockJsonRpcHandler).deletePushNotificationConfig(any(DeleteTaskPushNotificationConfigRequest.class),
+                contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(DeleteTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testGetAuthenticatedExtendedCard_MethodNameSetInContext() {
+        // Arrange
+        String jsonRpcRequest = "{\"jsonrpc\":\"2.0\",\"method\":\"" + GetAuthenticatedExtendedCardRequest.METHOD
+                + "\",\"id\":1}";
+        when(mockRequestBody.asString()).thenReturn(jsonRpcRequest);
+
+        GetAuthenticatedExtendedCardResponse mockResponse = mock(GetAuthenticatedExtendedCardResponse.class);
+        when(mockJsonRpcHandler.onGetAuthenticatedExtendedCardRequest(
+                any(GetAuthenticatedExtendedCardRequest.class), any(ServerCallContext.class)))
+                .thenReturn(mockResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.invokeJSONRPCHandler(jsonRpcRequest, mockRoutingContext);
+
+        // Assert
+        verify(mockJsonRpcHandler).onGetAuthenticatedExtendedCardRequest(
+                any(GetAuthenticatedExtendedCardRequest.class), contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(GetAuthenticatedExtendedCardRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    /**
+     * Helper method to set a field via reflection for testing purposes.
+     */
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            var field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set field: " + fieldName, e);
+        }
+    }
+}

--- a/reference/rest/pom.xml
+++ b/reference/rest/pom.xml
@@ -87,6 +87,16 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/reference/rest/src/test/java/io/a2a/server/rest/quarkus/A2AServerRoutesTest.java
+++ b/reference/rest/src/test/java/io/a2a/server/rest/quarkus/A2AServerRoutesTest.java
@@ -1,0 +1,307 @@
+package io.a2a.server.rest.quarkus;
+
+import static io.a2a.transport.rest.context.RestContextKeys.METHOD_NAME_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.Executor;
+
+import jakarta.enterprise.inject.Instance;
+
+import io.a2a.server.ServerCallContext;
+import io.a2a.spec.CancelTaskRequest;
+import io.a2a.spec.DeleteTaskPushNotificationConfigRequest;
+import io.a2a.spec.GetTaskPushNotificationConfigRequest;
+import io.a2a.spec.GetTaskRequest;
+import io.a2a.spec.ListTaskPushNotificationConfigRequest;
+import io.a2a.spec.SendMessageRequest;
+import io.a2a.spec.SendStreamingMessageRequest;
+import io.a2a.spec.SetTaskPushNotificationConfigRequest;
+import io.a2a.spec.TaskResubscriptionRequest;
+import io.a2a.transport.rest.handler.RestHandler;
+import io.a2a.transport.rest.handler.RestHandler.HTTPRestResponse;
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RequestBody;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit test for A2AServerRoutes that verifies the method names are properly set
+ * in the ServerCallContext for all route handlers.
+ */
+public class A2AServerRoutesTest {
+
+    private A2AServerRoutes routes;
+    private RestHandler mockRestHandler;
+    private Executor mockExecutor;
+    private Instance<CallContextFactory> mockCallContextFactory;
+    private RoutingContext mockRoutingContext;
+    private HttpServerRequest mockRequest;
+    private HttpServerResponse mockResponse;
+    private MultiMap mockHeaders;
+    private MultiMap mockParams;
+    private RequestBody mockRequestBody;
+
+    @BeforeEach
+    public void setUp() {
+        routes = new A2AServerRoutes();
+        mockRestHandler = mock(RestHandler.class);
+        mockExecutor = mock(Executor.class);
+        mockCallContextFactory = mock(Instance.class);
+        mockRoutingContext = mock(RoutingContext.class);
+        mockRequest = mock(HttpServerRequest.class);
+        mockResponse = mock(HttpServerResponse.class);
+        mockHeaders = MultiMap.caseInsensitiveMultiMap();
+        mockParams = MultiMap.caseInsensitiveMultiMap();
+        mockRequestBody = mock(RequestBody.class);
+
+        // Inject mocks via reflection since we can't use @InjectMocks
+        setField(routes, "jsonRestHandler", mockRestHandler);
+        setField(routes, "executor", mockExecutor);
+        setField(routes, "callContextFactory", mockCallContextFactory);
+
+        // Setup common mock behavior
+        when(mockCallContextFactory.isUnsatisfied()).thenReturn(true);
+        when(mockRoutingContext.request()).thenReturn(mockRequest);
+        when(mockRoutingContext.response()).thenReturn(mockResponse);
+        when(mockRoutingContext.user()).thenReturn(null);
+        when(mockRequest.headers()).thenReturn(mockHeaders);
+        when(mockRequest.params()).thenReturn(mockParams);
+        when(mockRoutingContext.body()).thenReturn(mockRequestBody);
+        when(mockRequestBody.asString()).thenReturn("{}");
+        when(mockResponse.setStatusCode(any(Integer.class))).thenReturn(mockResponse);
+        when(mockResponse.putHeader(any(CharSequence.class), any(CharSequence.class))).thenReturn(mockResponse);
+        when(mockResponse.end()).thenReturn(Future.succeededFuture());
+        when(mockResponse.end(anyString())).thenReturn(Future.succeededFuture());
+    }
+
+    @Test
+    public void testSendMessage_MethodNameSetInContext() {
+        // Arrange
+        HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
+        when(mockHttpResponse.getStatusCode()).thenReturn(200);
+        when(mockHttpResponse.getContentType()).thenReturn("application/json");
+        when(mockHttpResponse.getBody()).thenReturn("{}");
+        when(mockRestHandler.sendMessage(anyString(), any(ServerCallContext.class))).thenReturn(mockHttpResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.sendMessage("{}", mockRoutingContext);
+
+        // Assert
+        verify(mockRestHandler).sendMessage(eq("{}"), contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(SendMessageRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testSendMessageStreaming_MethodNameSetInContext() {
+        // Arrange
+        HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
+        when(mockHttpResponse.getStatusCode()).thenReturn(200);
+        when(mockHttpResponse.getContentType()).thenReturn("application/json");
+        when(mockHttpResponse.getBody()).thenReturn("{}");
+        when(mockRestHandler.sendStreamingMessage(anyString(), any(ServerCallContext.class)))
+                .thenReturn(mockHttpResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.sendMessageStreaming("{}", mockRoutingContext);
+
+        // Assert
+        verify(mockRestHandler).sendStreamingMessage(eq("{}"), contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(SendStreamingMessageRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testGetTask_MethodNameSetInContext() {
+        // Arrange
+        when(mockRoutingContext.pathParam("id")).thenReturn("task123");
+        HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
+        when(mockHttpResponse.getStatusCode()).thenReturn(200);
+        when(mockHttpResponse.getContentType()).thenReturn("application/json");
+        when(mockHttpResponse.getBody()).thenReturn("{test:value}");
+        when(mockRestHandler.getTask(anyString(), any(), any(ServerCallContext.class))).thenReturn(mockHttpResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.getTask(mockRoutingContext);
+
+        // Assert
+        verify(mockRestHandler).getTask(eq("task123"), eq(null), contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(GetTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testCancelTask_MethodNameSetInContext() {
+        // Arrange
+        when(mockRoutingContext.pathParam("param0")).thenReturn("task123");
+        HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
+        when(mockHttpResponse.getStatusCode()).thenReturn(200);
+        when(mockHttpResponse.getContentType()).thenReturn("application/json");
+        when(mockHttpResponse.getBody()).thenReturn("{}");
+        when(mockRestHandler.cancelTask(anyString(), any(ServerCallContext.class))).thenReturn(mockHttpResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.cancelTask(mockRoutingContext);
+
+        // Assert
+        verify(mockRestHandler).cancelTask(eq("task123"), contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(CancelTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testResubscribeTask_MethodNameSetInContext() {
+        // Arrange
+        when(mockRoutingContext.pathParam("param0")).thenReturn("task123");
+        HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
+        when(mockHttpResponse.getStatusCode()).thenReturn(200);
+        when(mockHttpResponse.getContentType()).thenReturn("application/json");
+        when(mockHttpResponse.getBody()).thenReturn("{}");
+        when(mockRestHandler.resubscribeTask(anyString(), any(ServerCallContext.class)))
+                .thenReturn(mockHttpResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.resubscribeTask(mockRoutingContext);
+
+        // Assert
+        verify(mockRestHandler).resubscribeTask(eq("task123"), contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(TaskResubscriptionRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testSetTaskPushNotificationConfiguration_MethodNameSetInContext() {
+        // Arrange
+        when(mockRoutingContext.pathParam("id")).thenReturn("task123");
+        HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
+        when(mockHttpResponse.getStatusCode()).thenReturn(200);
+        when(mockHttpResponse.getContentType()).thenReturn("application/json");
+        when(mockHttpResponse.getBody()).thenReturn("{}");
+        when(mockRestHandler.setTaskPushNotificationConfiguration(anyString(), anyString(),
+                any(ServerCallContext.class))).thenReturn(mockHttpResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.setTaskPushNotificationConfiguration("{}", mockRoutingContext);
+
+        // Assert
+        verify(mockRestHandler).setTaskPushNotificationConfiguration(eq("task123"), eq("{}"), contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(SetTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testGetTaskPushNotificationConfiguration_MethodNameSetInContext() {
+        // Arrange
+        when(mockRoutingContext.pathParam("id")).thenReturn("task123");
+        when(mockRoutingContext.pathParam("configId")).thenReturn("config456");
+        HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
+        when(mockHttpResponse.getStatusCode()).thenReturn(200);
+        when(mockHttpResponse.getContentType()).thenReturn("application/json");
+        when(mockHttpResponse.getBody()).thenReturn("{}");
+        when(mockRestHandler.getTaskPushNotificationConfiguration(anyString(), anyString(),
+                any(ServerCallContext.class))).thenReturn(mockHttpResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.getTaskPushNotificationConfiguration(mockRoutingContext);
+
+        // Assert
+        verify(mockRestHandler).getTaskPushNotificationConfiguration(eq("task123"), eq("config456"),
+                contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(GetTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testListTaskPushNotificationConfigurations_MethodNameSetInContext() {
+        // Arrange
+        when(mockRoutingContext.pathParam("id")).thenReturn("task123");
+        HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
+        when(mockHttpResponse.getStatusCode()).thenReturn(200);
+        when(mockHttpResponse.getContentType()).thenReturn("application/json");
+        when(mockHttpResponse.getBody()).thenReturn("{}");
+        when(mockRestHandler.listTaskPushNotificationConfigurations(anyString(), any(ServerCallContext.class)))
+                .thenReturn(mockHttpResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.listTaskPushNotificationConfigurations(mockRoutingContext);
+
+        // Assert
+        verify(mockRestHandler).listTaskPushNotificationConfigurations(eq("task123"), contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(ListTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testDeleteTaskPushNotificationConfiguration_MethodNameSetInContext() {
+        // Arrange
+        when(mockRoutingContext.pathParam("id")).thenReturn("task123");
+        when(mockRoutingContext.pathParam("configId")).thenReturn("config456");
+        HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
+        when(mockHttpResponse.getStatusCode()).thenReturn(200);
+        when(mockHttpResponse.getContentType()).thenReturn("application/json");
+        when(mockHttpResponse.getBody()).thenReturn("{}");
+        when(mockRestHandler.deleteTaskPushNotificationConfiguration(anyString(), anyString(),
+                any(ServerCallContext.class))).thenReturn(mockHttpResponse);
+
+        ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
+
+        // Act
+        routes.deleteTaskPushNotificationConfiguration(mockRoutingContext);
+
+        // Assert
+        verify(mockRestHandler).deleteTaskPushNotificationConfiguration(eq("task123"), eq("config456"),
+                contextCaptor.capture());
+        ServerCallContext capturedContext = contextCaptor.getValue();
+        assertNotNull(capturedContext);
+        assertEquals(DeleteTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    /**
+     * Helper method to set a field via reflection for testing purposes.
+     */
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            var field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set field: " + fieldName, e);
+        }
+    }
+}

--- a/transport/jsonrpc/src/main/java/io/a2a/transport/jsonrpc/context/JSONRPCContextKeys.java
+++ b/transport/jsonrpc/src/main/java/io/a2a/transport/jsonrpc/context/JSONRPCContextKeys.java
@@ -1,0 +1,24 @@
+package io.a2a.transport.jsonrpc.context;
+
+/**
+ * Shared JSON-RPC context keys for A2A protocol data.
+ *
+ * These keys provide access to JSON-RPC context information,
+ * enabling rich context access in service method implementations.
+ */
+public final class JSONRPCContextKeys {
+    
+    /**
+     * Context key for storing the headers.
+     */
+    public static final String HEADERS_KEY = "headers";
+
+    /**
+     * Context key for storing the method name being called.
+     */
+    public static final String METHOD_NAME_KEY = "method";
+
+    private JSONRPCContextKeys() {
+        // Utility class
+    }
+}

--- a/transport/rest/src/main/java/io/a2a/transport/rest/context/RestContextKeys.java
+++ b/transport/rest/src/main/java/io/a2a/transport/rest/context/RestContextKeys.java
@@ -1,0 +1,24 @@
+package io.a2a.transport.rest.context;
+
+/**
+ * Shared REST context keys for A2A protocol data.
+ *
+ * These keys provide access to REST context information,
+ * enabling rich context access in service method implementations.
+ */
+public final class RestContextKeys {
+    
+    /**
+     * Context key for storing the headers.
+     */
+    public static final String HEADERS_KEY = "headers";
+
+    /**
+     * Context key for storing the method name being called.
+     */
+    public static final String METHOD_NAME_KEY = "method";
+
+    private RestContextKeys() {
+        // Utility class
+    }
+}


### PR DESCRIPTION
* Added a `method` field to `ServerCallContext.state`, similar to `headers`.

Issue: https://github.com/a2aproject/a2a-java/issues/352


Fixes #352 🦕