### PR TITLE
fix: fixing the handling of historyLength being set to 0 by default in gRPC

### DIFF
--- a/client/transport/grpc/src/main/java/io/a2a/client/transport/grpc/GrpcTransport.java
+++ b/client/transport/grpc/src/main/java/io/a2a/client/transport/grpc/GrpcTransport.java
@@ -1,9 +1,5 @@
 package io.a2a.client.transport.grpc;
 
-import static io.a2a.grpc.A2AServiceGrpc.A2AServiceBlockingV2Stub;
-import static io.a2a.grpc.A2AServiceGrpc.A2AServiceStub;
-import static io.a2a.grpc.utils.ProtoUtils.FromProto;
-import static io.a2a.grpc.utils.ProtoUtils.ToProto;
 import static io.a2a.util.Assert.checkNotNullParam;
 
 import java.util.List;
@@ -127,9 +123,7 @@ public class GrpcTransport implements ClientTransport {
 
         GetTaskRequest.Builder requestBuilder = GetTaskRequest.newBuilder();
         requestBuilder.setName("tasks/" + request.id());
-        if (request.historyLength() != null) {
-            requestBuilder.setHistoryLength(request.historyLength());
-        }
+        requestBuilder.setHistoryLength(request.historyLength());
         GetTaskRequest getTaskRequest = requestBuilder.build();
         PayloadAndHeaders payloadAndHeaders = applyInterceptors(io.a2a.spec.GetTaskRequest.METHOD, getTaskRequest,
                 agentCard, context);

--- a/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestTransport.java
+++ b/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestTransport.java
@@ -125,7 +125,7 @@ public class RestTransport implements ClientTransport {
                 agentCard, context);
         try {
             String url;
-            if (taskQueryParams.historyLength() != null) {
+            if (taskQueryParams.historyLength() > 0) {
                 url = agentUrl + String.format("/v1/tasks/%1s?historyLength=%2d", taskQueryParams.id(), taskQueryParams.historyLength());
             } else {
                 url = agentUrl + String.format("/v1/tasks/%1s", taskQueryParams.id());

--- a/reference/rest/src/main/java/io/a2a/server/rest/quarkus/A2AServerRoutes.java
+++ b/reference/rest/src/main/java/io/a2a/server/rest/quarkus/A2AServerRoutes.java
@@ -122,9 +122,9 @@ public class A2AServerRoutes {
             if (taskId == null || taskId.isEmpty()) {
                 response = jsonRestHandler.createErrorResponse(new InvalidParamsError("bad task id"));
             } else {
-                Integer historyLength = null;
+                int historyLength = 0;
                 if (rc.request().params().contains("history_length")) {
-                    historyLength = Integer.valueOf(rc.request().params().get("history_length"));
+                    historyLength = Integer.parseInt(rc.request().params().get("history_length"));
                 }
                 response = jsonRestHandler.getTask(taskId, historyLength, context);
             }

--- a/reference/rest/src/test/java/io/a2a/server/rest/quarkus/A2AServerRoutesTest.java
+++ b/reference/rest/src/test/java/io/a2a/server/rest/quarkus/A2AServerRoutesTest.java
@@ -4,6 +4,7 @@ import static io.a2a.transport.rest.context.RestContextKeys.METHOD_NAME_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -137,7 +138,7 @@ public class A2AServerRoutesTest {
         when(mockHttpResponse.getStatusCode()).thenReturn(200);
         when(mockHttpResponse.getContentType()).thenReturn("application/json");
         when(mockHttpResponse.getBody()).thenReturn("{test:value}");
-        when(mockRestHandler.getTask(anyString(), any(), any(ServerCallContext.class))).thenReturn(mockHttpResponse);
+        when(mockRestHandler.getTask(anyString(), anyInt(), any(ServerCallContext.class))).thenReturn(mockHttpResponse);
 
         ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
 
@@ -145,7 +146,7 @@ public class A2AServerRoutesTest {
         routes.getTask(mockRoutingContext);
 
         // Assert
-        verify(mockRestHandler).getTask(eq("task123"), eq(null), contextCaptor.capture());
+        verify(mockRestHandler).getTask(eq("task123"), anyInt(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
         assertEquals(GetTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));

--- a/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 import io.a2a.server.ServerCallContext;
@@ -34,7 +33,6 @@ import io.a2a.server.events.QueueManager;
 import io.a2a.server.events.TaskQueueExistsException;
 import io.a2a.server.tasks.PushNotificationConfigStore;
 import io.a2a.server.tasks.PushNotificationSender;
-import io.a2a.server.tasks.TaskStateProvider;
 import io.a2a.server.tasks.ResultAggregator;
 import io.a2a.server.tasks.TaskManager;
 import io.a2a.server.tasks.TaskStore;
@@ -103,10 +101,10 @@ public class DefaultRequestHandler implements RequestHandler {
             LOGGER.debug("No task found for {}. Throwing TaskNotFoundError", params.id());
             throw new TaskNotFoundError();
         }
-        if (params.historyLength() != null && task.getHistory() != null && params.historyLength() < task.getHistory().size()) {
+        if (task.getHistory() != null && params.historyLength() < task.getHistory().size()) {
             List<Message> history;
             if (params.historyLength() <= 0) {
-                history = new ArrayList<>();
+                history = task.getHistory();
             } else {
                 history = task.getHistory().subList(
                         task.getHistory().size() - params.historyLength(),

--- a/spec/src/main/java/io/a2a/spec/TaskQueryParams.java
+++ b/spec/src/main/java/io/a2a/spec/TaskQueryParams.java
@@ -17,20 +17,20 @@ import org.jspecify.annotations.Nullable;
 
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record TaskQueryParams(String id, @Nullable Integer historyLength, @Nullable Map<String, Object> metadata) {
+public record TaskQueryParams(String id, int historyLength, @Nullable Map<String, Object> metadata) {
 
     public TaskQueryParams {
         Assert.checkNotNullParam("id", id);
-        if (historyLength != null && historyLength < 0) {
+        if (historyLength < 0) {
             throw new IllegalArgumentException("Invalid history length");
         }
     }
 
     public TaskQueryParams(String id) {
-        this(id, null, null);
+        this(id, 0, null);
     }
 
-    public TaskQueryParams(String id, @Nullable Integer historyLength) {
+    public TaskQueryParams(String id, int historyLength) {
         this(id, historyLength, null);
     }
 }

--- a/transport/rest/src/main/java/io/a2a/transport/rest/handler/RestHandler.java
+++ b/transport/rest/src/main/java/io/a2a/transport/rest/handler/RestHandler.java
@@ -162,7 +162,7 @@ public class RestHandler {
         }
     }
 
-    public HTTPRestResponse getTask(String taskId, @Nullable Integer historyLength, ServerCallContext context) {
+    public HTTPRestResponse getTask(String taskId, int historyLength, ServerCallContext context) {
         try {
             TaskQueryParams params = new TaskQueryParams(taskId, historyLength);
             Task task = requestHandler.onGetTask(params, context);

--- a/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
+++ b/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
@@ -26,7 +26,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
         taskStore.save(MINIMAL_TASK);
 
-        RestHandler.HTTPRestResponse response = handler.getTask(MINIMAL_TASK.getId(),null,  callContext);
+        RestHandler.HTTPRestResponse response = handler.getTask(MINIMAL_TASK.getId(), 0, callContext);
 
         Assertions.assertEquals(200, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
@@ -43,7 +43,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
     public void testGetTaskNotFound() {
         RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
 
-        RestHandler.HTTPRestResponse response = handler.getTask("nonexistent", null, callContext);
+        RestHandler.HTTPRestResponse response = handler.getTask("nonexistent", 0, callContext);
 
         Assertions.assertEquals(404, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
@@ -315,7 +315,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         Assertions.assertEquals(400, response.getStatusCode());
 
         // Test 404 for not found
-        response = handler.getTask("nonexistent", null, callContext);
+        response = handler.getTask("nonexistent", 0, callContext);
         Assertions.assertEquals(404, response.getStatusCode());
     }
 


### PR DESCRIPTION
* Using int instead of Integer and setting the default value to 0.
* If historyLength == 0 then we should return the full history
* Removing the handling of null

Issue: https://github.com/a2aproject/a2a-java/issues/423

Fixes #423 🦕