### PR TITLE
fix: Wait for agent completion and ensure all events processed in blo…

### DIFF
--- a/server-common/src/main/java/io/a2a/server/tasks/ResultAggregator.java
+++ b/server-common/src/main/java/io/a2a/server/tasks/ResultAggregator.java
@@ -11,20 +11,20 @@ import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.a2a.server.events.EventConsumer;
 import io.a2a.server.events.EventQueueItem;
 import io.a2a.spec.A2AServerException;
 import io.a2a.spec.Event;
 import io.a2a.spec.EventKind;
+import io.a2a.spec.InternalError;
 import io.a2a.spec.JSONRPCError;
 import io.a2a.spec.Message;
 import io.a2a.spec.Task;
 import io.a2a.spec.TaskState;
 import io.a2a.spec.TaskStatusUpdateEvent;
 import io.a2a.util.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ResultAggregator {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResultAggregator.class);
@@ -106,10 +106,14 @@ public class ResultAggregator {
     }
 
     public EventTypeAndInterrupt consumeAndBreakOnInterrupt(EventConsumer consumer, boolean blocking) throws JSONRPCError {
-        return consumeAndBreakOnInterrupt(consumer, blocking, null);
+        return consumeAndBreakOnInterrupt(consumer, blocking, null, null);
     }
 
     public EventTypeAndInterrupt consumeAndBreakOnInterrupt(EventConsumer consumer, boolean blocking, Runnable eventCallback) throws JSONRPCError {
+        return consumeAndBreakOnInterrupt(consumer, blocking, eventCallback, null);
+    }
+
+    public EventTypeAndInterrupt consumeAndBreakOnInterrupt(EventConsumer consumer, boolean blocking, Runnable eventCallback, CompletableFuture<Void> agentFuture) throws JSONRPCError {
         Flow.Publisher<EventQueueItem> allItems = consumer.consumeAll();
         AtomicReference<Message> message = new AtomicReference<>();
         AtomicBoolean interrupted = new AtomicBoolean(false);
@@ -180,11 +184,11 @@ public class ResultAggregator {
                         shouldInterrupt = true;
                         continueInBackground = true;
                     }
-                    else {
-                        // For ALL blocking calls (both final and non-final events), use background consumption
-                        // This ensures all events are processed and persisted to TaskStore in background
-                        // Queue lifecycle is now managed by DefaultRequestHandler.cleanupProducer()
-                        // which waits for BOTH agent and consumption futures before closing queues
+                    else if (blocking) {
+                        // For blocking calls: Interrupt to free Vert.x thread, but continue in background
+                        // Python's async consumption doesn't block threads, but Java's does
+                        // So we interrupt to return quickly, then rely on background consumption
+                        // DefaultRequestHandler will fetch the final state from TaskStore
                         shouldInterrupt = true;
                         continueInBackground = true;
                         if (LOGGER.isDebugEnabled()) {
@@ -198,10 +202,17 @@ public class ResultAggregator {
                         interrupted.set(true);
                         completionFuture.complete(null);
 
-                        // Signal that cleanup can proceed while consumption continues in background.
-                        // This prevents infinite hangs for fire-and-forget agents that never emit final events.
-                        // Processing continues (return true below) and all events are still persisted to TaskStore.
-                        consumptionCompletionFuture.complete(null);
+                        // For blocking calls, DON'T complete consumptionCompletionFuture here.
+                        // Let it complete naturally when subscription finishes (onComplete callback below).
+                        // This ensures all events are processed and persisted to TaskStore before
+                        // DefaultRequestHandler.cleanupProducer() proceeds with cleanup.
+                        //
+                        // For non-blocking and auth-required calls, complete immediately to allow
+                        // cleanup to proceed while consumption continues in background.
+                        if (!blocking) {
+                            consumptionCompletionFuture.complete(null);
+                        }
+                        // else: blocking calls wait for actual consumption completion in onComplete
 
                         // Continue consuming in background - keep requesting events
                         // Note: continueInBackground is always true when shouldInterrupt is true
@@ -244,8 +255,8 @@ public class ResultAggregator {
             }
         }
 
-        // Background consumption continues automatically via the subscription
-        // returning true in the consumer function keeps the subscription alive
+        // Note: For blocking calls that were interrupted, the wait logic has been moved
+        // to DefaultRequestHandler.onMessageSend() to avoid blocking Vert.x worker threads.
         // Queue lifecycle is managed by DefaultRequestHandler.cleanupProducer()
 
         Throwable error = errorRef.get();

--- a/server-common/src/test/java/io/a2a/server/requesthandlers/DefaultRequestHandlerTest.java
+++ b/server-common/src/test/java/io/a2a/server/requesthandlers/DefaultRequestHandlerTest.java
@@ -1,7 +1,10 @@
 package io.a2a.server.requesthandlers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -16,6 +19,7 @@ import io.a2a.server.auth.UnauthenticatedUser;
 import io.a2a.server.events.EventQueue;
 import io.a2a.server.events.InMemoryQueueManager;
 import io.a2a.server.tasks.InMemoryTaskStore;
+import io.a2a.server.tasks.TaskUpdater;
 import io.a2a.spec.JSONRPCError;
 import io.a2a.spec.Message;
 import io.a2a.spec.MessageSendConfiguration;
@@ -418,35 +422,99 @@ public class DefaultRequestHandlerTest {
     }
 
     /**
-     * Test that blocking message calls persist all events in background.
-     * This test proves the bug where blocking calls stop consuming events after
-     * the first event is returned, causing subsequent events to be lost.
+     * Test that blocking message call waits for agent to finish and returns complete Task
+     * even when agent does fire-and-forget (emits non-final state and returns).
      *
      * Expected behavior:
-     * 1. Blocking call returns immediately with first event (WORKING state)
-     * 2. Agent continues running in background and produces more events
-     * 3. Background consumption continues and persists all events to TaskStore
-     * 4. Final task state (COMPLETED) is persisted despite blocking call having returned
+     * 1. Agent emits WORKING state with artifacts
+     * 2. Agent's execute() method returns WITHOUT emitting final state
+     * 3. Blocking onMessageSend() should wait for agent execution to complete
+     * 4. Blocking onMessageSend() should wait for all queued events to be processed
+     * 5. Returned Task should have WORKING state with all artifacts included
      *
-     * This test will FAIL before the fix is applied, demonstrating the bug.
+     * This tests fire-and-forget pattern with blocking calls.
      */
     @Test
     @Timeout(15)
-    void testBlockingMessagePersistsAllEventsInBackground() throws Exception {
-        String taskId = "blocking-persist-task";
-        String contextId = "blocking-persist-ctx";
+    void testBlockingFireAndForgetReturnsNonFinalTask() throws Exception {
+        String taskId = "blocking-fire-forget-task";
+        String contextId = "blocking-fire-forget-ctx";
 
         Message message = new Message.Builder()
-            .messageId("msg-blocking-persist")
+            .messageId("msg-blocking-fire-forget")
             .role(Message.Role.USER)
             .parts(new TextPart("test message"))
             .taskId(taskId)
             .contextId(contextId)
             .build();
 
-        // Explicitly set blocking=true (though it's the default)
         MessageSendConfiguration config = new MessageSendConfiguration.Builder()
                 .blocking(true)
+                .build();
+
+        MessageSendParams params = new MessageSendParams(message, config, null);
+
+        // Agent that does fire-and-forget: emits WORKING with artifact but never completes
+        agentExecutor.setExecuteCallback((context, queue) -> {
+            TaskUpdater updater = new TaskUpdater(context, queue);
+
+            // Start work (WORKING state)
+            updater.startWork();
+
+            // Add artifact
+            updater.addArtifact(
+                List.of(new TextPart("Fire and forget artifact", null)),
+                "artifact-1", "FireForget", null);
+
+            // Agent returns WITHOUT calling updater.complete()
+            // Task stays in WORKING state (non-final)
+        });
+
+        // Call blocking onMessageSend - should wait for agent to finish
+        Object result = requestHandler.onMessageSend(params, serverCallContext);
+
+        // The returned result should be a Task in WORKING state with artifact
+        assertTrue(result instanceof Task, "Result should be a Task");
+        Task returnedTask = (Task) result;
+
+        // Verify task is in WORKING state (non-final, fire-and-forget)
+        assertEquals(TaskState.WORKING, returnedTask.getStatus().state(),
+            "Returned task should be WORKING (fire-and-forget), got: " + returnedTask.getStatus().state());
+
+        // Verify artifacts are included in the returned task
+        assertNotNull(returnedTask.getArtifacts(),
+            "Returned task should have artifacts");
+        assertTrue(returnedTask.getArtifacts().size() >= 1,
+            "Returned task should have at least 1 artifact, got: " +
+            (returnedTask.getArtifacts() != null ? returnedTask.getArtifacts().size() : 0));
+    }
+
+    /**
+     * Test that non-blocking message call returns immediately and persists all events in background.
+     *
+     * Expected behavior:
+     * 1. Non-blocking call returns immediately with first event (WORKING state)
+     * 2. Agent continues running in background and produces more events
+     * 3. Background consumption continues and persists all events to TaskStore
+     * 4. Final task state (COMPLETED) is persisted in background
+     */
+    @Test
+    @Timeout(15)
+    void testNonBlockingMessagePersistsAllEventsInBackground() throws Exception {
+        String taskId = "blocking-persist-task";
+        String contextId = "blocking-persist-ctx";
+
+        Message message = new Message.Builder()
+            .messageId("msg-nonblocking-persist")
+            .role(Message.Role.USER)
+            .parts(new TextPart("test message"))
+            .taskId(taskId)
+            .contextId(contextId)
+            .build();
+
+        // Set blocking=false for non-blocking behavior
+        MessageSendConfiguration config = new MessageSendConfiguration.Builder()
+                .blocking(false)
                 .build();
 
         MessageSendParams params = new MessageSendParams(message, config, null);
@@ -468,7 +536,7 @@ public class DefaultRequestHandlerTest {
             queue.enqueueEvent(workingTask);
             firstEventEmitted.countDown();
 
-            // Sleep to ensure the blocking call has returned before we emit more events
+            // Sleep to ensure the non-blocking call has returned before we emit more events
             try {
                 Thread.sleep(1000);
             } catch (InterruptedException e) {
@@ -485,8 +553,7 @@ public class DefaultRequestHandlerTest {
             }
 
             // Emit final event (COMPLETED state)
-            // This event will be LOST with the current bug, because the consumer
-            // has already stopped after returning the first event
+            // This event should be persisted to TaskStore in background
             Task completedTask = new Task.Builder()
                 .id(taskId)
                 .contextId(contextId)
@@ -495,21 +562,21 @@ public class DefaultRequestHandlerTest {
             queue.enqueueEvent(completedTask);
         });
 
-        // Call blocking onMessageSend
+        // Call non-blocking onMessageSend
         Object result = requestHandler.onMessageSend(params, serverCallContext);
 
         // Assertion 1: The immediate result should be the first event (WORKING)
         assertTrue(result instanceof Task, "Result should be a Task");
         Task immediateTask = (Task) result;
-        assertTrue(immediateTask.getStatus().state() == TaskState.WORKING,
-            "Immediate return should show WORKING state, got: " + immediateTask.getStatus().state());
+        assertEquals(TaskState.WORKING, immediateTask.getStatus().state(),
+            "Non-blocking should return immediately with WORKING state, got: " + immediateTask.getStatus().state());
 
-        // At this point, the blocking call has returned, but the agent is still running
+        // At this point, the non-blocking call has returned, but the agent is still running
 
         // Allow the agent to emit the final COMPLETED event
         allowCompletion.countDown();
 
-        // Assertion 2: Poll for the final task state to be persisted
+        // Assertion 2: Poll for the final task state to be persisted in background
         // Use polling loop instead of fixed sleep for faster and more reliable test
         long timeoutMs = 5000;
         long startTime = System.currentTimeMillis();
@@ -530,8 +597,7 @@ public class DefaultRequestHandlerTest {
             completedStateFound,
             "Final task state should be COMPLETED (background consumption should have processed it), got: " +
             (persistedTask != null ? persistedTask.getStatus().state() : "null") +
-            " after " + (System.currentTimeMillis() - startTime) + "ms. " +
-            "This failure proves the bug - events after the first are lost."
+            " after " + (System.currentTimeMillis() - startTime) + "ms"
         );
     }
 
@@ -652,6 +718,80 @@ public class DefaultRequestHandlerTest {
         EventQueue queue = queueManager.get(taskId);
         assertTrue(queue == null || queue.isClosed(),
             "Queue for finalized task should be null or closed");
+    }
+
+    /**
+     * Test that blocking message call returns a Task with ALL artifacts included.
+     * This reproduces the reported bug: blocking call returns before artifacts are processed.
+     *
+     * Expected behavior:
+     * 1. Agent emits multiple artifacts via TaskUpdater
+     * 2. Blocking onMessageSend() should wait for ALL events to be processed
+     * 3. Returned Task should have all artifacts included in COMPLETED state
+     *
+     * Bug manifestation:
+     * - onMessageSend() returns after first event
+     * - Artifacts are still being processed in background
+     * - Returned Task is incomplete
+     */
+    @Test
+    @Timeout(15)
+    void testBlockingCallReturnsCompleteTaskWithArtifacts() throws Exception {
+        String taskId = "blocking-artifacts-task";
+        String contextId = "blocking-artifacts-ctx";
+
+        Message message = new Message.Builder()
+            .messageId("msg-blocking-artifacts")
+            .role(Message.Role.USER)
+            .parts(new TextPart("test message"))
+            .taskId(taskId)
+            .contextId(contextId)
+            .build();
+
+        MessageSendConfiguration config = new MessageSendConfiguration.Builder()
+                .blocking(true)
+                .build();
+
+        MessageSendParams params = new MessageSendParams(message, config, null);
+
+        // Agent that uses TaskUpdater to emit multiple artifacts (like real agents do)
+        agentExecutor.setExecuteCallback((context, queue) -> {
+            TaskUpdater updater = new TaskUpdater(context, queue);
+
+            // Start work (WORKING state)
+            updater.startWork();
+
+            // Add first artifact
+            updater.addArtifact(
+                List.of(new TextPart("First artifact", null)),
+                "artifact-1", "First", null);
+
+            // Add second artifact
+            updater.addArtifact(
+                List.of(new TextPart("Second artifact", null)),
+                "artifact-2", "Second", null);
+
+            // Complete the task
+            updater.complete();
+        });
+
+        // Call blocking onMessageSend - should wait for ALL events
+        Object result = requestHandler.onMessageSend(params, serverCallContext);
+
+        // The returned result should be a Task with ALL artifacts
+        assertTrue(result instanceof Task, "Result should be a Task");
+        Task returnedTask = (Task) result;
+
+        // Verify task is completed
+        assertTrue(returnedTask.getStatus().state() == TaskState.COMPLETED,
+            "Returned task should be COMPLETED, got: " + returnedTask.getStatus().state());
+
+        // Verify artifacts are included in the returned task
+        assertNotNull(returnedTask.getArtifacts(),
+            "Returned task should have artifacts");
+        assertTrue(returnedTask.getArtifacts().size() >= 2,
+            "Returned task should have at least 2 artifacts, got: " +
+            (returnedTask.getArtifacts() != null ? returnedTask.getArtifacts().size() : 0));
     }
 
     /**

--- a/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -1245,6 +1245,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
                                 .when(mock).consumeAndBreakOnInterrupt(
                                         Mockito.any(EventConsumer.class),
                                         Mockito.anyBoolean(),
+                                        Mockito.any(),
                                         Mockito.any());
                 })){
             response = handler.onMessageSend(request, callContext);


### PR DESCRIPTION
…cking calls

Fixes race condition where DefaultRequestHandler.onMessageSend() returns before all task events are fully processed and persisted to TaskStore, resulting in incomplete Task objects being returned to clients (missing artifacts, incorrect state).

Root Cause:
- Blocking calls interrupted immediately after first event and returned to client before background event consumption completed
- Agent execution and event processing happened asynchronously in background
- No synchronization to ensure all events were consumed and persisted before returning Task to client

Solution (4-step process):
1. Wait for agent to finish enqueueing events (5s timeout)
2. Close the queue to signal consumption can complete (breaks dependency)
3. Wait for consumption to finish processing events (2s timeout)
4. Fetch final task state from TaskStore (has all artifacts and correct state)

This ensures blocking calls return complete Task objects with all artifacts and correct state, including support for fire-and-forget tasks that never emit final state events.

Added unit tests:
- testBlockingFireAndForgetReturnsNonFinalTask: Validates fire-and-forget pattern
- testBlockingCallReturnsCompleteTaskWithArtifacts: Ensures all artifacts included

Fixes #428