### PR TITLE
fix: fixing the handling of historyLength being set to 0 by default in gRPC.

### DIFF
--- a/client/transport/grpc/src/main/java/io/a2a/client/transport/grpc/GrpcTransport.java
+++ b/client/transport/grpc/src/main/java/io/a2a/client/transport/grpc/GrpcTransport.java
@@ -1,9 +1,5 @@
 package io.a2a.client.transport.grpc;
 
-import static io.a2a.grpc.A2AServiceGrpc.A2AServiceBlockingV2Stub;
-import static io.a2a.grpc.A2AServiceGrpc.A2AServiceStub;
-import static io.a2a.grpc.utils.ProtoUtils.FromProto;
-import static io.a2a.grpc.utils.ProtoUtils.ToProto;
 import static io.a2a.util.Assert.checkNotNullParam;
 
 import java.util.List;
@@ -127,9 +123,7 @@ public class GrpcTransport implements ClientTransport {
 
         GetTaskRequest.Builder requestBuilder = GetTaskRequest.newBuilder();
         requestBuilder.setName("tasks/" + request.id());
-        if (request.historyLength() != null) {
-            requestBuilder.setHistoryLength(request.historyLength());
-        }
+        requestBuilder.setHistoryLength(request.historyLength());
         GetTaskRequest getTaskRequest = requestBuilder.build();
         PayloadAndHeaders payloadAndHeaders = applyInterceptors(io.a2a.spec.GetTaskRequest.METHOD, getTaskRequest,
                 agentCard, context);

--- a/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestTransport.java
+++ b/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestTransport.java
@@ -125,7 +125,7 @@ public class RestTransport implements ClientTransport {
                 agentCard, context);
         try {
             String url;
-            if (taskQueryParams.historyLength() != null) {
+            if (taskQueryParams.historyLength() > 0) {
                 url = agentUrl + String.format("/v1/tasks/%1s?historyLength=%2d", taskQueryParams.id(), taskQueryParams.historyLength());
             } else {
                 url = agentUrl + String.format("/v1/tasks/%1s", taskQueryParams.id());

--- a/reference/rest/src/main/java/io/a2a/server/rest/quarkus/A2AServerRoutes.java
+++ b/reference/rest/src/main/java/io/a2a/server/rest/quarkus/A2AServerRoutes.java
@@ -122,9 +122,9 @@ public class A2AServerRoutes {
             if (taskId == null || taskId.isEmpty()) {
                 response = jsonRestHandler.createErrorResponse(new InvalidParamsError("bad task id"));
             } else {
-                Integer historyLength = null;
+                int historyLength = 0;
                 if (rc.request().params().contains("history_length")) {
-                    historyLength = Integer.valueOf(rc.request().params().get("history_length"));
+                    historyLength = Integer.parseInt(rc.request().params().get("history_length"));
                 }
                 response = jsonRestHandler.getTask(taskId, historyLength, context);
             }

--- a/reference/rest/src/test/java/io/a2a/server/rest/quarkus/A2AServerRoutesTest.java
+++ b/reference/rest/src/test/java/io/a2a/server/rest/quarkus/A2AServerRoutesTest.java
@@ -4,6 +4,7 @@ import static io.a2a.transport.rest.context.RestContextKeys.METHOD_NAME_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -137,7 +138,7 @@ public class A2AServerRoutesTest {
         when(mockHttpResponse.getStatusCode()).thenReturn(200);
         when(mockHttpResponse.getContentType()).thenReturn("application/json");
         when(mockHttpResponse.getBody()).thenReturn("{test:value}");
-        when(mockRestHandler.getTask(anyString(), any(), any(ServerCallContext.class))).thenReturn(mockHttpResponse);
+        when(mockRestHandler.getTask(anyString(), anyInt(), any(ServerCallContext.class))).thenReturn(mockHttpResponse);
 
         ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
 
@@ -145,7 +146,7 @@ public class A2AServerRoutesTest {
         routes.getTask(mockRoutingContext);
 
         // Assert
-        verify(mockRestHandler).getTask(eq("task123"), eq(null), contextCaptor.capture());
+        verify(mockRestHandler).getTask(eq("task123"), anyInt(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
         assertEquals(GetTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));

--- a/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 import io.a2a.server.ServerCallContext;
@@ -34,7 +33,6 @@ import io.a2a.server.events.QueueManager;
 import io.a2a.server.events.TaskQueueExistsException;
 import io.a2a.server.tasks.PushNotificationConfigStore;
 import io.a2a.server.tasks.PushNotificationSender;
-import io.a2a.server.tasks.TaskStateProvider;
 import io.a2a.server.tasks.ResultAggregator;
 import io.a2a.server.tasks.TaskManager;
 import io.a2a.server.tasks.TaskStore;
@@ -103,14 +101,14 @@ public class DefaultRequestHandler implements RequestHandler {
             LOGGER.debug("No task found for {}. Throwing TaskNotFoundError", params.id());
             throw new TaskNotFoundError();
         }
-        if (params.historyLength() != null && task.getHistory() != null && params.historyLength() < task.getHistory().size()) {
+        if (task.getHistory() != null && params.historyLength() < task.getHistory().size()) {
             List<Message> history;
             if (params.historyLength() <= 0) {
-                history = new ArrayList<>();
+                history = task.getHistory();
             } else {
                 history = task.getHistory().subList(
                         task.getHistory().size() - params.historyLength(),
-                        task.getHistory().size() - 1);
+                        task.getHistory().size());
             }
 
             task = new Task.Builder(task)

--- a/server-common/src/test/java/io/a2a/server/requesthandlers/DefaultRequestHandlerUnitTest.java
+++ b/server-common/src/test/java/io/a2a/server/requesthandlers/DefaultRequestHandlerUnitTest.java
@@ -1,0 +1,731 @@
+package io.a2a.server.requesthandlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import io.a2a.server.ServerCallContext;
+import io.a2a.server.agentexecution.AgentExecutor;
+import io.a2a.server.auth.UnauthenticatedUser;
+import io.a2a.server.events.EventQueue;
+import io.a2a.server.events.QueueManager;
+import io.a2a.server.tasks.PushNotificationConfigStore;
+import io.a2a.server.tasks.PushNotificationSender;
+import io.a2a.server.tasks.TaskStore;
+import io.a2a.spec.DeleteTaskPushNotificationConfigParams;
+import io.a2a.spec.GetTaskPushNotificationConfigParams;
+import io.a2a.spec.InternalError;
+import io.a2a.spec.ListTaskPushNotificationConfigParams;
+import io.a2a.spec.Message;
+import io.a2a.spec.PushNotificationConfig;
+import io.a2a.spec.Task;
+import io.a2a.spec.TaskIdParams;
+import io.a2a.spec.TaskNotCancelableError;
+import io.a2a.spec.TaskNotFoundError;
+import io.a2a.spec.TaskPushNotificationConfig;
+import io.a2a.spec.TaskQueryParams;
+import io.a2a.spec.TaskState;
+import io.a2a.spec.TaskStatus;
+import io.a2a.spec.TextPart;
+import io.a2a.spec.UnsupportedOperationError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Unit tests for DefaultRequestHandler using Mockito.
+ * These tests focus on individual methods and edge cases, particularly the history truncation logic.
+ */
+public class DefaultRequestHandlerUnitTest {
+
+    @Mock
+    private AgentExecutor agentExecutor;
+
+    @Mock
+    private TaskStore taskStore;
+
+    @Mock
+    private QueueManager queueManager;
+
+    @Mock
+    private PushNotificationConfigStore pushConfigStore;
+
+    @Mock
+    private PushNotificationSender pushSender;
+
+    private Executor executor;
+    private DefaultRequestHandler requestHandler;
+    private ServerCallContext serverCallContext;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        executor = Executors.newCachedThreadPool();
+        requestHandler = new DefaultRequestHandler(
+                agentExecutor,
+                taskStore,
+                queueManager,
+                pushConfigStore,
+                pushSender,
+                executor
+        );
+        serverCallContext = new ServerCallContext(UnauthenticatedUser.INSTANCE, Map.of(), Set.of());
+    }
+
+    @Nested
+    class OnGetTaskTests {
+
+        @Test
+        void testGetTask_TaskNotFound() {
+            // Given
+            TaskQueryParams params = new TaskQueryParams("non-existent-task", 0);
+            when(taskStore.get("non-existent-task")).thenReturn(null);
+
+            // When/Then
+            assertThrows(TaskNotFoundError.class, ()
+                    -> requestHandler.onGetTask(params, serverCallContext)
+            );
+        }
+
+        @Test
+        void testGetTask_NoHistoryTruncation_WhenHistoryLengthIsZero() throws Exception {
+            // Given
+            List<Message> fullHistory = createMessageList(5);
+            Task task = createTaskWithHistory("task-1", fullHistory);
+            TaskQueryParams params = new TaskQueryParams("task-1", 0);
+
+            when(taskStore.get("task-1")).thenReturn(task);
+
+            // When
+            Task result = requestHandler.onGetTask(params, serverCallContext);
+
+            // Then
+            assertNotNull(result);
+            assertEquals(5, result.getHistory().size());
+            assertEquals(fullHistory, result.getHistory());
+        }
+
+        @Test
+        void testGetTask_NoHistoryTruncation_WhenHistoryLengthEqualsHistorySize() throws Exception {
+            // Given
+            List<Message> fullHistory = createMessageList(5);
+            Task task = createTaskWithHistory("task-1", fullHistory);
+            TaskQueryParams params = new TaskQueryParams("task-1", 5);
+
+            when(taskStore.get("task-1")).thenReturn(task);
+
+            // When
+            Task result = requestHandler.onGetTask(params, serverCallContext);
+
+            // Then
+            assertNotNull(result);
+            assertEquals(5, result.getHistory().size());
+            assertEquals(fullHistory, result.getHistory());
+        }
+
+        @Test
+        void testGetTask_NoHistoryTruncation_WhenHistoryLengthGreaterThanHistorySize() throws Exception {
+            // Given
+            List<Message> fullHistory = createMessageList(5);
+            Task task = createTaskWithHistory("task-1", fullHistory);
+            TaskQueryParams params = new TaskQueryParams("task-1", 10);
+
+            when(taskStore.get("task-1")).thenReturn(task);
+
+            // When
+            Task result = requestHandler.onGetTask(params, serverCallContext);
+
+            // Then
+            assertNotNull(result);
+            assertEquals(5, result.getHistory().size());
+            assertEquals(fullHistory, result.getHistory());
+        }
+
+        @Test
+        void testGetTask_HistoryTruncation_ReturnsLastNMessages() throws Exception {
+            // Given - 10 messages in history
+            List<Message> fullHistory = createMessageList(10);
+            Task task = createTaskWithHistory("task-1", fullHistory);
+            TaskQueryParams params = new TaskQueryParams("task-1", 3);
+
+            when(taskStore.get("task-1")).thenReturn(task);
+
+            // When - request last 3 messages
+            Task result = requestHandler.onGetTask(params, serverCallContext);
+
+            // Then - should get messages at indices 7, 8, 9 (the last 3)
+            assertNotNull(result);
+            assertEquals(3, result.getHistory().size());
+            assertEquals("msg-7", result.getHistory().get(0).getMessageId());
+            assertEquals("msg-8", result.getHistory().get(1).getMessageId());
+            assertEquals("msg-9", result.getHistory().get(2).getMessageId());
+        }
+
+        @Test
+        void testGetTask_HistoryTruncation_IncludesMostRecentMessage() throws Exception {
+            // Given - This tests the bug fix where size()-1 was excluding the last message
+            List<Message> fullHistory = createMessageList(10);
+            Task task = createTaskWithHistory("task-1", fullHistory);
+            TaskQueryParams params = new TaskQueryParams("task-1", 1);
+
+            when(taskStore.get("task-1")).thenReturn(task);
+
+            // When - request last 1 message
+            Task result = requestHandler.onGetTask(params, serverCallContext);
+
+            // Then - should get the LAST message (msg-9), not msg-8
+            assertNotNull(result);
+            assertEquals(1, result.getHistory().size());
+            assertEquals("msg-9", result.getHistory().get(0).getMessageId());
+        }
+
+        @Test
+        void testGetTask_NullHistory_ReturnsTaskAsIs() throws Exception {
+            // Given
+            Task task = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.COMPLETED))
+                    .build();
+            TaskQueryParams params = new TaskQueryParams("task-1", 3);
+
+            when(taskStore.get("task-1")).thenReturn(task);
+
+            // When
+            Task result = requestHandler.onGetTask(params, serverCallContext);
+
+            // Then
+            assertNotNull(result);
+            assertEquals(task, result);
+        }
+
+        @Test
+        void testGetTask_EmptyHistory_ReturnsTaskAsIs() throws Exception {
+            // Given
+            Task task = createTaskWithHistory("task-1", new ArrayList<>());
+            TaskQueryParams params = new TaskQueryParams("task-1", 3);
+
+            when(taskStore.get("task-1")).thenReturn(task);
+
+            // When
+            Task result = requestHandler.onGetTask(params, serverCallContext);
+
+            // Then
+            assertNotNull(result);
+            assertEquals(0, result.getHistory().size());
+        }
+
+        private List<Message> createMessageList(int count) {
+            List<Message> messages = new ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                messages.add(new Message.Builder()
+                        .messageId("msg-" + i)
+                        .role(Message.Role.USER)
+                        .parts(new TextPart("Message " + i))
+                        .build());
+            }
+            return messages;
+        }
+
+        private Task createTaskWithHistory(String taskId, List<Message> history) {
+            return new Task.Builder()
+                    .id(taskId)
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.COMPLETED))
+                    .history(history)
+                    .build();
+        }
+    }
+
+    @Nested
+    class OnCancelTaskTests {
+
+        @Test
+        void testCancelTask_TaskNotFound() {
+            // Given
+            TaskIdParams params = new TaskIdParams("non-existent-task");
+            when(taskStore.get("non-existent-task")).thenReturn(null);
+
+            // When/Then
+            assertThrows(TaskNotFoundError.class, ()
+                    -> requestHandler.onCancelTask(params, serverCallContext)
+            );
+        }
+
+        @Test
+        void testCancelTask_TaskAlreadyCompleted() {
+            // Given
+            Task completedTask = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.COMPLETED))
+                    .build();
+            TaskIdParams params = new TaskIdParams("task-1");
+
+            when(taskStore.get("task-1")).thenReturn(completedTask);
+
+            // When/Then
+            TaskNotCancelableError exception = assertThrows(TaskNotCancelableError.class, ()
+                    -> requestHandler.onCancelTask(params, serverCallContext)
+            );
+
+            assertEquals(-32002 , exception.getCode());
+            assertTrue(exception.getMessage().contains("completed"));
+        }
+
+        @Test
+        void testCancelTask_TaskAlreadyCanceled() {
+            // Given
+            Task canceledTask = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.CANCELED))
+                    .build();
+            TaskIdParams params = new TaskIdParams("task-1");
+
+            when(taskStore.get("task-1")).thenReturn(canceledTask);
+
+            // When/Then
+            TaskNotCancelableError exception = assertThrows(TaskNotCancelableError.class, ()
+                    -> requestHandler.onCancelTask(params, serverCallContext)
+            );
+
+            assertEquals(-32002 , exception.getCode());
+            assertTrue(exception.getMessage().contains("canceled"));
+        }
+
+        @Test
+        void testCancelTask_TaskAlreadyFailed() {
+            // Given
+            Task failedTask = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.FAILED))
+                    .build();
+            TaskIdParams params = new TaskIdParams("task-1");
+
+            when(taskStore.get("task-1")).thenReturn(failedTask);
+
+            // When/Then
+            TaskNotCancelableError exception = assertThrows(TaskNotCancelableError.class, ()
+                    -> requestHandler.onCancelTask(params, serverCallContext)
+            );
+
+            assertEquals(-32002 , exception.getCode());
+            assertTrue(exception.getMessage().contains("failed"));
+        }
+
+        @Test
+        void testCancelTask_TaskAlreadyRejected() {
+            // Given
+            Task rejectedTask = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.REJECTED))
+                    .build();
+            TaskIdParams params = new TaskIdParams("task-1");
+
+            when(taskStore.get("task-1")).thenReturn(rejectedTask);
+
+            // When/Then
+            TaskNotCancelableError exception = assertThrows(TaskNotCancelableError.class, ()
+                    -> requestHandler.onCancelTask(params, serverCallContext)
+            );
+
+
+            assertEquals(-32002 , exception.getCode());
+            assertTrue(exception.getMessage().contains("rejected"));
+        }
+    }
+
+    @Nested
+    class PushNotificationConfigTests {
+
+        @Test
+        void testSetTaskPushNotificationConfig_NoConfigStore() {
+            // Given
+            requestHandler = new DefaultRequestHandler(
+                    agentExecutor, taskStore, queueManager, null, pushSender, executor
+            );
+            TaskPushNotificationConfig params = new TaskPushNotificationConfig(
+                    "task-1",
+                    new PushNotificationConfig.Builder().id("config-1").url("http://localhost:8080").build()
+            );
+
+            // When/Then
+            assertThrows(UnsupportedOperationError.class, ()
+                    -> requestHandler.onSetTaskPushNotificationConfig(params, serverCallContext)
+            );
+        }
+
+        @Test
+        void testSetTaskPushNotificationConfig_TaskNotFound() {
+            // Given
+            TaskPushNotificationConfig params = new TaskPushNotificationConfig(
+                    "non-existent-task",
+                    new PushNotificationConfig.Builder().id("config-1").url("http://localhost:8080").build()
+            );
+            when(taskStore.get("non-existent-task")).thenReturn(null);
+
+            // When/Then
+            assertThrows(TaskNotFoundError.class, ()
+                    -> requestHandler.onSetTaskPushNotificationConfig(params, serverCallContext)
+            );
+        }
+
+        @Test
+        void testSetTaskPushNotificationConfig_Success() throws Exception {
+            // Given
+            Task task = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.WORKING))
+                    .build();
+            PushNotificationConfig config = new PushNotificationConfig.Builder()
+                    .id("config-1")
+                    .url("http://localhost:8080")
+                    .build();
+            TaskPushNotificationConfig params = new TaskPushNotificationConfig("task-1", config);
+
+            when(taskStore.get("task-1")).thenReturn(task);
+            when(pushConfigStore.setInfo("task-1", config)).thenReturn(config);
+
+            // When
+            TaskPushNotificationConfig result = requestHandler.onSetTaskPushNotificationConfig(params, serverCallContext);
+
+            // Then
+            assertNotNull(result);
+            assertEquals("task-1", result.taskId());
+            assertEquals("config-1", result.pushNotificationConfig().id());
+            verify(pushConfigStore).setInfo("task-1", config);
+        }
+
+        @Test
+        void testGetTaskPushNotificationConfig_NoConfigStore() {
+            // Given
+            requestHandler = new DefaultRequestHandler(
+                    agentExecutor, taskStore, queueManager, null, pushSender, executor
+            );
+            GetTaskPushNotificationConfigParams params = new GetTaskPushNotificationConfigParams("task-1", null);
+
+            // When/Then
+            assertThrows(UnsupportedOperationError.class, ()
+                    -> requestHandler.onGetTaskPushNotificationConfig(params, serverCallContext)
+            );
+        }
+
+        @Test
+        void testGetTaskPushNotificationConfig_TaskNotFound() {
+            // Given
+            GetTaskPushNotificationConfigParams params = new GetTaskPushNotificationConfigParams("non-existent-task", null);
+            when(taskStore.get("non-existent-task")).thenReturn(null);
+
+            // When/Then
+            assertThrows(TaskNotFoundError.class, ()
+                    -> requestHandler.onGetTaskPushNotificationConfig(params, serverCallContext)
+            );
+        }
+
+        @Test
+        void testGetTaskPushNotificationConfig_NoConfigFound() {
+            // Given
+            Task task = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.WORKING))
+                    .build();
+            GetTaskPushNotificationConfigParams params = new GetTaskPushNotificationConfigParams("task-1", null);
+
+            when(taskStore.get("task-1")).thenReturn(task);
+            when(pushConfigStore.getInfo("task-1")).thenReturn(null);
+
+            // When/Then
+            assertThrows(InternalError.class, ()
+                    -> requestHandler.onGetTaskPushNotificationConfig(params, serverCallContext)
+            );
+        }
+
+        @Test
+        void testGetTaskPushNotificationConfig_EmptyConfigList() {
+            // Given
+            Task task = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.WORKING))
+                    .build();
+            GetTaskPushNotificationConfigParams params = new GetTaskPushNotificationConfigParams("task-1", null);
+
+            when(taskStore.get("task-1")).thenReturn(task);
+            when(pushConfigStore.getInfo("task-1")).thenReturn(new ArrayList<>());
+
+            // When/Then
+            assertThrows(InternalError.class, ()
+                    -> requestHandler.onGetTaskPushNotificationConfig(params, serverCallContext)
+            );
+        }
+
+        @Test
+        void testGetTaskPushNotificationConfig_ReturnsFirstConfig_WhenNoIdSpecified() throws Exception {
+            // Given
+            Task task = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.WORKING))
+                    .build();
+            PushNotificationConfig config1 = new PushNotificationConfig.Builder().id("config-1").url("http://localhost:8080").build();
+            PushNotificationConfig config2 = new PushNotificationConfig.Builder().id("config-2").url("http://localhost:8080").build();
+            List<PushNotificationConfig> configs = List.of(config1, config2);
+            GetTaskPushNotificationConfigParams params = new GetTaskPushNotificationConfigParams("task-1", null);
+
+            when(taskStore.get("task-1")).thenReturn(task);
+            when(pushConfigStore.getInfo("task-1")).thenReturn(configs);
+
+            // When
+            TaskPushNotificationConfig result = requestHandler.onGetTaskPushNotificationConfig(params, serverCallContext);
+
+            // Then
+            assertNotNull(result);
+            assertEquals("task-1", result.taskId());
+            assertEquals("config-1", result.pushNotificationConfig().id());
+        }
+
+        @Test
+        void testGetTaskPushNotificationConfig_ReturnsSpecificConfig_WhenIdSpecified() throws Exception {
+            // Given
+            Task task = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.WORKING))
+                    .build();
+            PushNotificationConfig config1 = new PushNotificationConfig.Builder().id("config-1").url("http://localhost:8080").build();
+            PushNotificationConfig config2 = new PushNotificationConfig.Builder().id("config-2").url("http://localhost:8080").build();
+            List<PushNotificationConfig> configs = List.of(config1, config2);
+            GetTaskPushNotificationConfigParams params = new GetTaskPushNotificationConfigParams("task-1", "config-2");
+
+            when(taskStore.get("task-1")).thenReturn(task);
+            when(pushConfigStore.getInfo("task-1")).thenReturn(configs);
+
+            // When
+            TaskPushNotificationConfig result = requestHandler.onGetTaskPushNotificationConfig(params, serverCallContext);
+
+            // Then
+            assertNotNull(result);
+            assertEquals("task-1", result.taskId());
+            assertEquals("config-2", result.pushNotificationConfig().id());
+        }
+
+        @Test
+        void testListTaskPushNotificationConfig_NoConfigStore() {
+            // Given
+            requestHandler = new DefaultRequestHandler(
+                    agentExecutor, taskStore, queueManager, null, pushSender, executor
+            );
+            ListTaskPushNotificationConfigParams params = new ListTaskPushNotificationConfigParams("task-1");
+
+            // When/Then
+            assertThrows(UnsupportedOperationError.class, ()
+                    -> requestHandler.onListTaskPushNotificationConfig(params, serverCallContext)
+            );
+        }
+
+        @Test
+        void testListTaskPushNotificationConfig_TaskNotFound() {
+            // Given
+            ListTaskPushNotificationConfigParams params = new ListTaskPushNotificationConfigParams("non-existent-task");
+            when(taskStore.get("non-existent-task")).thenReturn(null);
+
+            // When/Then
+            assertThrows(TaskNotFoundError.class, ()
+                    -> requestHandler.onListTaskPushNotificationConfig(params, serverCallContext)
+            );
+        }
+
+        @Test
+        void testListTaskPushNotificationConfig_ReturnsEmptyList_WhenNoConfigs() throws Exception {
+            // Given
+            Task task = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.WORKING))
+                    .build();
+            ListTaskPushNotificationConfigParams params = new ListTaskPushNotificationConfigParams("task-1");
+
+            when(taskStore.get("task-1")).thenReturn(task);
+            when(pushConfigStore.getInfo("task-1")).thenReturn(null);
+
+            // When
+            List<TaskPushNotificationConfig> result = requestHandler.onListTaskPushNotificationConfig(params, serverCallContext);
+
+            // Then
+            assertNotNull(result);
+            assertEquals(0, result.size());
+        }
+
+        @Test
+        void testListTaskPushNotificationConfig_ReturnsAllConfigs() throws Exception {
+            // Given
+            Task task = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.WORKING))
+                    .build();
+            PushNotificationConfig config1 = new PushNotificationConfig.Builder().id("config-1").url("http://localhost:8080").build();
+            PushNotificationConfig config2 = new PushNotificationConfig.Builder().id("config-2").url("http://localhost:8080").build();
+            List<PushNotificationConfig> configs = List.of(config1, config2);
+            ListTaskPushNotificationConfigParams params = new ListTaskPushNotificationConfigParams("task-1");
+
+            when(taskStore.get("task-1")).thenReturn(task);
+            when(pushConfigStore.getInfo("task-1")).thenReturn(configs);
+
+            // When
+            List<TaskPushNotificationConfig> result = requestHandler.onListTaskPushNotificationConfig(params, serverCallContext);
+
+            // Then
+            assertNotNull(result);
+            assertEquals(2, result.size());
+            assertEquals("config-1", result.get(0).pushNotificationConfig().id());
+            assertEquals("config-2", result.get(1).pushNotificationConfig().id());
+        }
+
+        @Test
+        void testDeleteTaskPushNotificationConfig_NoConfigStore() {
+            // Given
+            requestHandler = new DefaultRequestHandler(
+                    agentExecutor, taskStore, queueManager, null, pushSender, executor
+            );
+            DeleteTaskPushNotificationConfigParams params = new DeleteTaskPushNotificationConfigParams("task-1", "config-1");
+
+            // When/Then
+            assertThrows(UnsupportedOperationError.class, ()
+                    -> requestHandler.onDeleteTaskPushNotificationConfig(params, serverCallContext)
+            );
+        }
+
+        @Test
+        void testDeleteTaskPushNotificationConfig_TaskNotFound() {
+            // Given
+            DeleteTaskPushNotificationConfigParams params = new DeleteTaskPushNotificationConfigParams("non-existent-task", "config-1");
+            when(taskStore.get("non-existent-task")).thenReturn(null);
+
+            // When/Then
+            assertThrows(TaskNotFoundError.class, ()
+                    -> requestHandler.onDeleteTaskPushNotificationConfig(params, serverCallContext)
+            );
+        }
+
+        @Test
+        void testDeleteTaskPushNotificationConfig_Success() {
+            // Given
+            Task task = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.WORKING))
+                    .build();
+            DeleteTaskPushNotificationConfigParams params = new DeleteTaskPushNotificationConfigParams("task-1", "config-1");
+
+            when(taskStore.get("task-1")).thenReturn(task);
+
+            // When
+            requestHandler.onDeleteTaskPushNotificationConfig(params, serverCallContext);
+
+            // Then
+            verify(pushConfigStore).deleteInfo("task-1", "config-1");
+        }
+    }
+
+    @Nested
+    class OnResubscribeToTaskTests {
+
+        @Test
+        void testResubscribeToTask_TaskNotFound() {
+            // Given
+            TaskIdParams params = new TaskIdParams("non-existent-task");
+            when(taskStore.get("non-existent-task")).thenReturn(null);
+
+            // When/Then
+            assertThrows(TaskNotFoundError.class, ()
+                    -> requestHandler.onResubscribeToTask(params, serverCallContext)
+            );
+        }
+
+        @Test
+        void testResubscribeToTask_QueueNotFound_FinalTask() {
+            // Given
+            Task finalTask = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.COMPLETED))
+                    .build();
+            TaskIdParams params = new TaskIdParams("task-1");
+
+            when(taskStore.get("task-1")).thenReturn(finalTask);
+            when(queueManager.tap("task-1")).thenReturn(null);
+
+            // When/Then - Should throw TaskNotFoundError for final tasks with no queue
+            assertThrows(TaskNotFoundError.class, ()
+                    -> requestHandler.onResubscribeToTask(params, serverCallContext)
+            );
+        }
+
+        @Test
+        void testResubscribeToTask_QueueNotFound_NonFinalTask_CreatesNewQueue() throws Exception {
+            // Given
+            Task workingTask = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.WORKING))
+                    .build();
+            TaskIdParams params = new TaskIdParams("task-1");
+            EventQueue newQueue = mock(EventQueue.class);
+
+            when(taskStore.get("task-1")).thenReturn(workingTask);
+            when(queueManager.tap("task-1")).thenReturn(null);
+            when(queueManager.createOrTap("task-1")).thenReturn(newQueue);
+
+            // When
+            var result = requestHandler.onResubscribeToTask(params, serverCallContext);
+
+            // Then
+            assertNotNull(result);
+            verify(queueManager).createOrTap("task-1");
+        }
+
+        @Test
+        void testResubscribeToTask_QueueExists_ReturnsPublisher() throws Exception {
+            // Given
+            Task workingTask = new Task.Builder()
+                    .id("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(TaskState.WORKING))
+                    .build();
+            TaskIdParams params = new TaskIdParams("task-1");
+            EventQueue existingQueue = mock(EventQueue.class);
+
+            when(taskStore.get("task-1")).thenReturn(workingTask);
+            when(queueManager.tap("task-1")).thenReturn(existingQueue);
+
+            // When
+            var result = requestHandler.onResubscribeToTask(params, serverCallContext);
+
+            // Then
+            assertNotNull(result);
+            verify(queueManager).tap("task-1");
+            verify(queueManager, never()).createOrTap(anyString());
+        }
+    }
+}

--- a/spec/src/main/java/io/a2a/spec/TaskQueryParams.java
+++ b/spec/src/main/java/io/a2a/spec/TaskQueryParams.java
@@ -17,20 +17,20 @@ import org.jspecify.annotations.Nullable;
 
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record TaskQueryParams(String id, @Nullable Integer historyLength, @Nullable Map<String, Object> metadata) {
+public record TaskQueryParams(String id, int historyLength, @Nullable Map<String, Object> metadata) {
 
     public TaskQueryParams {
         Assert.checkNotNullParam("id", id);
-        if (historyLength != null && historyLength < 0) {
+        if (historyLength < 0) {
             throw new IllegalArgumentException("Invalid history length");
         }
     }
 
     public TaskQueryParams(String id) {
-        this(id, null, null);
+        this(id, 0, null);
     }
 
-    public TaskQueryParams(String id, @Nullable Integer historyLength) {
+    public TaskQueryParams(String id, int historyLength) {
         this(id, historyLength, null);
     }
 }

--- a/transport/rest/src/main/java/io/a2a/transport/rest/handler/RestHandler.java
+++ b/transport/rest/src/main/java/io/a2a/transport/rest/handler/RestHandler.java
@@ -162,7 +162,7 @@ public class RestHandler {
         }
     }
 
-    public HTTPRestResponse getTask(String taskId, @Nullable Integer historyLength, ServerCallContext context) {
+    public HTTPRestResponse getTask(String taskId, int historyLength, ServerCallContext context) {
         try {
             TaskQueryParams params = new TaskQueryParams(taskId, historyLength);
             Task task = requestHandler.onGetTask(params, context);

--- a/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
+++ b/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
@@ -26,7 +26,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
         taskStore.save(MINIMAL_TASK);
 
-        RestHandler.HTTPRestResponse response = handler.getTask(MINIMAL_TASK.getId(),null,  callContext);
+        RestHandler.HTTPRestResponse response = handler.getTask(MINIMAL_TASK.getId(), 0, callContext);
 
         Assertions.assertEquals(200, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
@@ -43,7 +43,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
     public void testGetTaskNotFound() {
         RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
 
-        RestHandler.HTTPRestResponse response = handler.getTask("nonexistent", null, callContext);
+        RestHandler.HTTPRestResponse response = handler.getTask("nonexistent", 0, callContext);
 
         Assertions.assertEquals(404, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
@@ -315,7 +315,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         Assertions.assertEquals(400, response.getStatusCode());
 
         // Test 404 for not found
-        response = handler.getTask("nonexistent", null, callContext);
+        response = handler.getTask("nonexistent", 0, callContext);
         Assertions.assertEquals(404, response.getStatusCode());
     }
 


### PR DESCRIPTION
* Using int instead of Integer and setting the default value to 0.
* If historyLength == 0 then we should return the full history
* Removing the handling of null

Issue: https://github.com/a2aproject/a2a-java/issues/423

Fixes #423 🦕