### PR TITLE
fix: Change image for the multi instance replicated queuemanager test

### DIFF
--- a/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-1/Dockerfile
+++ b/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-1/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim
+FROM mirror.gcr.io/eclipse-temurin:17-jre-jammy
 
 WORKDIR /app
 

--- a/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-2/Dockerfile
+++ b/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-2/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim
+FROM mirror.gcr.io/eclipse-temurin:17-jre-jammy
 
 WORKDIR /app
 


### PR DESCRIPTION
openjdk:17-slim has disappeared

Upstream: #439