### PR TITLE
fix: NPE with test JSONRPCHandlerTest.testOnMessageNewMessageSuccessMocks

### DIFF
--- a/server-common/src/main/java/io/a2a/server/events/EnhancedRunnable.java
+++ b/server-common/src/main/java/io/a2a/server/events/EnhancedRunnable.java
@@ -1,6 +1,5 @@
 package io.a2a.server.events;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 

--- a/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -186,7 +186,8 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
         SendMessageResponse response;
         try (MockedConstruction<EventConsumer> mocked = Mockito.mockConstruction(
                 EventConsumer.class,
-                (mock, context) -> {Mockito.doReturn(ZeroPublisher.fromItems(wrapEvent(MINIMAL_TASK))).when(mock).consumeAll();})){
+                (mock, context) -> {Mockito.doReturn(ZeroPublisher.fromItems(wrapEvent(MINIMAL_TASK))).when(mock).consumeAll();
+                Mockito.doCallRealMethod().when(mock).createAgentRunnableDoneCallback();})){
             response = handler.onMessageSend(request, callContext);
         }
         assertNull(response.getError());


### PR DESCRIPTION
Simple fix for JSONRPCHandlerTest.testOnMessageNewMessageSuccessMocks ensuring that the DoneCallback is not null when mocking.