### PR TITLE
chore: Use strict TCK mode

### DIFF
--- a/.github/workflows/run-tck.yml
+++ b/.github/workflows/run-tck.yml
@@ -14,8 +14,12 @@ on:
 
 env:
   # TODO this is currently running the TCK off the main branch which included changes needed for 0.4.0
-  # Tag of the TCK
+  # Tag/branch of the TCK
   TCK_VERSION: main
+  # Tell the TCK runner to report failure if the quality tests fail
+  A2A_TCK_FAIL_ON_QUALITY: 1
+  # Tell the TCK runner to report failure if the features tests fail
+  A2A_TCK_FAIL_ON_FEATURES: 1
   # Tells uv to not need a venv, and instead use system
   UV_SYSTEM_PYTHON: 1
   # SUT_JSONRPC_URL to use for the TCK and the server agent


### PR DESCRIPTION
The possibility to do this was introduced in https://github.com/a2aproject/a2a-tck/pull/92.

Without this, we would get TCK runs reported as passing, despite failures in the capabilities/features tests.