### PR TITLE
fix: Store push notification config for newly created tasks

### DIFF
--- a/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
@@ -308,7 +308,8 @@ public class DefaultRequestHandler implements RequestHandler {
             kind = etai.eventType();
 
             // Store push notification config for newly created tasks (mirrors streaming logic)
-            if (kind instanceof Task createdTask && shouldAddPushInfo(params)) {
+            // Only for NEW tasks - existing tasks are handled by initMessageSend()
+            if (mss.task() == null && kind instanceof Task createdTask && shouldAddPushInfo(params)) {
                 LOGGER.debug("Storing push notification config for new task {}", createdTask.getId());
                 pushConfigStore.setInfo(createdTask.getId(), params.configuration().pushNotificationConfig());
             }

--- a/server-common/src/test/java/io/a2a/server/requesthandlers/DefaultRequestHandlerTest.java
+++ b/server-common/src/test/java/io/a2a/server/requesthandlers/DefaultRequestHandlerTest.java
@@ -946,8 +946,8 @@ public class DefaultRequestHandlerTest {
         List<PushNotificationConfig> storedConfigs = pushConfigStore.getInfo(taskId);
         assertNotNull(storedConfigs,
             "Push notification config should be stored for existing task");
-        assertTrue(storedConfigs.size() >= 1,
-            "Should have at least 1 push config stored");
+        assertEquals(1, storedConfigs.size(),
+            "Should have exactly 1 push config stored");
         assertEquals("config-existing-1", storedConfigs.get(0).id());
         assertEquals("https://example.com/existing-webhook", storedConfigs.get(0).url());
     }


### PR DESCRIPTION
This was missing in the non-streaming message sends

Follows up on #383 and #482

The TCK is not testing this, but it is introduced in https://github.com/a2aproject/a2a-tck/pull/94