### PR TITLE
feat: Support multiple payload types in push notifications

### DIFF
--- a/extras/push-notification-config-store-database-jpa/src/test/java/io/a2a/extras/pushnotificationconfigstore/database/jpa/JpaDatabasePushNotificationConfigStoreIntegrationTest.java
+++ b/extras/push-notification-config-store-database-jpa/src/test/java/io/a2a/extras/pushnotificationconfigstore/database/jpa/JpaDatabasePushNotificationConfigStoreIntegrationTest.java
@@ -88,7 +88,7 @@ public class JpaDatabasePushNotificationConfigStoreIntegrationTest {
         mockPushNotificationSender.sendNotification(testTask);
 
         // Verify it was captured
-        Queue<Task> captured = mockPushNotificationSender.getCapturedTasks();
+        Queue<Task> captured = mockPushNotificationSender.getCapturedEvents();
         assertEquals(1, captured.size());
         assertEquals("direct-test-task", captured.peek().getId());
     }
@@ -151,7 +151,7 @@ public class JpaDatabasePushNotificationConfigStoreIntegrationTest {
         boolean notificationReceived = false;
 
         while (System.currentTimeMillis() < end) {
-            if (!mockPushNotificationSender.getCapturedTasks().isEmpty()) {
+            if (!mockPushNotificationSender.getCapturedEvents().isEmpty()) {
                 notificationReceived = true;
                 break;
             }
@@ -161,7 +161,7 @@ public class JpaDatabasePushNotificationConfigStoreIntegrationTest {
         assertTrue(notificationReceived, "Timeout waiting for push notification.");
 
         // Step 6: Verify the captured notification
-        Queue<Task> capturedTasks = mockPushNotificationSender.getCapturedTasks();
+        Queue<Task> capturedTasks = mockPushNotificationSender.getCapturedEvents();
 
         // Verify the notification contains the correct task with artifacts
         Task notifiedTaskWithArtifact = capturedTasks.stream()

--- a/extras/push-notification-config-store-database-jpa/src/test/java/io/a2a/extras/pushnotificationconfigstore/database/jpa/MockPushNotificationSender.java
+++ b/extras/push-notification-config-store-database-jpa/src/test/java/io/a2a/extras/pushnotificationconfigstore/database/jpa/MockPushNotificationSender.java
@@ -3,12 +3,12 @@ package io.a2a.extras.pushnotificationconfigstore.database.jpa;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import io.a2a.spec.StreamingEventKind;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
 
 import io.a2a.server.tasks.PushNotificationSender;
-import io.a2a.spec.Task;
 
 /**
  * Mock implementation of PushNotificationSender for integration testing.
@@ -19,18 +19,18 @@ import io.a2a.spec.Task;
 @Priority(100)
 public class MockPushNotificationSender implements PushNotificationSender {
 
-    private final Queue<Task> capturedTasks = new ConcurrentLinkedQueue<>();
+    private final Queue<StreamingEventKind> capturedEvents = new ConcurrentLinkedQueue<>();
 
     @Override
-    public void sendNotification(Task task) {
-        capturedTasks.add(task);
+    public void sendNotification(StreamingEventKind kind) {
+        capturedEvents.add(kind);
     }
 
-    public Queue<Task> getCapturedTasks() {
-        return capturedTasks;
+    public Queue<StreamingEventKind> getCapturedEvents() {
+        return capturedEvents;
     }
 
     public void clear() {
-        capturedTasks.clear();
+        capturedEvents.clear();
     }
 }

--- a/server-common/src/main/java/io/a2a/server/tasks/PushNotificationSender.java
+++ b/server-common/src/main/java/io/a2a/server/tasks/PushNotificationSender.java
@@ -1,6 +1,6 @@
 package io.a2a.server.tasks;
 
-import io.a2a.spec.Task;
+import io.a2a.spec.StreamingEventKind;
 
 /**
  * Interface for sending push notifications for tasks.
@@ -8,8 +8,8 @@ import io.a2a.spec.Task;
 public interface PushNotificationSender {
 
     /**
-     * Sends a push notification containing the latest task state.
-     * @param task the task
+     * Sends a push notification with a payload related to the task.
+     * @param kind the payload to push
      */
-    void sendNotification(Task task);
+    void sendNotification(StreamingEventKind kind);
 }


### PR DESCRIPTION
Expand PushNotificationSender to support all StreamingEventKind payload types
as defined in the A2A specification, not just Task objects.

Fixes: #490

- [X] Follow the [`CONTRIBUTING` Guide](../CONTRIBUTING.md).
- [X] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
    - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
        - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
        - `feat:` represents a new feature, and correlates to a SemVer minor.
        - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [X] Ensure the tests pass
- [X] Appropriate READMEs were updated (if necessary)

Fixes #490 🦕