### PR TITLE
feat: Support multiple payload types in push notifications

### DIFF
--- a/extras/push-notification-config-store-database-jpa/src/test/java/io/a2a/extras/pushnotificationconfigstore/database/jpa/MockPushNotificationSender.java
+++ b/extras/push-notification-config-store-database-jpa/src/test/java/io/a2a/extras/pushnotificationconfigstore/database/jpa/MockPushNotificationSender.java
@@ -8,7 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
 
 import io.a2a.server.tasks.PushNotificationSender;
-import io.a2a.spec.Task;
+import io.a2a.spec.StreamingEventKind;
 
 /**
  * Mock implementation of PushNotificationSender for integration testing.
@@ -19,18 +19,18 @@ import io.a2a.spec.Task;
 @Priority(100)
 public class MockPushNotificationSender implements PushNotificationSender {
 
-    private final Queue<Task> capturedTasks = new ConcurrentLinkedQueue<>();
+    private final Queue<StreamingEventKind> capturedEvents = new ConcurrentLinkedQueue<>();
 
     @Override
-    public void sendNotification(Task task) {
-        capturedTasks.add(task);
+    public void sendNotification(StreamingEventKind kind) {
+        capturedEvents.add(kind);
     }
 
-    public Queue<Task> getCapturedTasks() {
-        return capturedTasks;
+    public Queue<StreamingEventKind> getCapturedEvents() {
+        return capturedEvents;
     }
 
     public void clear() {
-        capturedTasks.clear();
+        capturedEvents.clear();
     }
 }

--- a/server-common/src/main/java/io/a2a/server/tasks/BasePushNotificationSender.java
+++ b/server-common/src/main/java/io/a2a/server/tasks/BasePushNotificationSender.java
@@ -3,6 +3,10 @@ package io.a2a.server.tasks;
 import static io.a2a.client.http.A2AHttpClient.APPLICATION_JSON;
 import static io.a2a.client.http.A2AHttpClient.CONTENT_TYPE;
 import static io.a2a.common.A2AHeaders.X_A2A_NOTIFICATION_TOKEN;
+import static io.a2a.spec.Message.MESSAGE;
+import static io.a2a.spec.Task.TASK;
+import static io.a2a.spec.TaskArtifactUpdateEvent.ARTIFACT_UPDATE;
+import static io.a2a.spec.TaskStatusUpdateEvent.STATUS_UPDATE;
 
 import java.io.IOException;
 import java.util.List;
@@ -18,8 +22,12 @@ import org.slf4j.LoggerFactory;
 
 import io.a2a.client.http.A2AHttpClient;
 import io.a2a.client.http.JdkA2AHttpClient;
+import io.a2a.spec.Message;
 import io.a2a.spec.PushNotificationConfig;
+import io.a2a.spec.StreamingEventKind;
 import io.a2a.spec.Task;
+import io.a2a.spec.TaskArtifactUpdateEvent;
+import io.a2a.spec.TaskStatusUpdateEvent;
 import io.a2a.util.Utils;
 
 @ApplicationScoped
@@ -42,15 +50,25 @@ public class BasePushNotificationSender implements PushNotificationSender {
     }
 
     @Override
-    public void sendNotification(Task task) {
-        List<PushNotificationConfig> pushConfigs = configStore.getInfo(task.getId());
+    public void sendNotification(StreamingEventKind kind) {
+        String taskId = switch (kind.getKind()) {
+            case TASK -> ((Task)kind).getId();
+            case MESSAGE -> ((Message)kind).getTaskId();
+            case STATUS_UPDATE -> ((TaskStatusUpdateEvent)kind).getTaskId();
+            case ARTIFACT_UPDATE -> ((TaskArtifactUpdateEvent)kind).getTaskId();
+            default -> null;
+        };
+        if (taskId == null) {
+            return;
+        }
+        List<PushNotificationConfig> pushConfigs = configStore.getInfo(taskId);
         if (pushConfigs == null || pushConfigs.isEmpty()) {
             return;
         }
 
         List<CompletableFuture<Boolean>> dispatchResults = pushConfigs
                 .stream()
-                .map(pushConfig -> dispatch(task, pushConfig))
+                .map(pushConfig -> dispatch(kind, pushConfig))
                 .toList();
         CompletableFuture<Void> allFutures = CompletableFuture.allOf(dispatchResults.toArray(new CompletableFuture[0]));
         CompletableFuture<Boolean> dispatchResult = allFutures.thenApply(v -> dispatchResults.stream()
@@ -58,18 +76,18 @@ public class BasePushNotificationSender implements PushNotificationSender {
         try {
             boolean allSent = dispatchResult.get();
             if (! allSent) {
-                LOGGER.warn("Some push notifications failed to send for taskId: " + task.getId());
+                LOGGER.warn("Some push notifications failed to send for taskId: " + taskId);
             }
         } catch (InterruptedException | ExecutionException e) {
-            LOGGER.warn("Some push notifications failed to send for taskId " + task.getId() + ": {}", e.getMessage(), e);
+            LOGGER.warn("Some push notifications failed to send for taskId " + taskId + ": {}", e.getMessage(), e);
         }
     }
 
-    private CompletableFuture<Boolean> dispatch(Task task, PushNotificationConfig pushInfo) {
-        return CompletableFuture.supplyAsync(() -> dispatchNotification(task, pushInfo));
+    private CompletableFuture<Boolean> dispatch(StreamingEventKind kind, PushNotificationConfig pushInfo) {
+        return CompletableFuture.supplyAsync(() -> dispatchNotification(kind, pushInfo));
     }
 
-    private boolean dispatchNotification(Task task, PushNotificationConfig pushInfo) {
+    private boolean dispatchNotification(StreamingEventKind kind, PushNotificationConfig pushInfo) {
         String url = pushInfo.url();
         String token = pushInfo.token();
 
@@ -80,7 +98,7 @@ public class BasePushNotificationSender implements PushNotificationSender {
 
         String body;
         try {
-            body = Utils.marshalFrom(task);
+            body = Utils.marshalFrom(kind);
         } catch (JsonProcessingException e) {
             LOGGER.debug("Error writing value as string: {}", e.getMessage(), e);
             return false;

--- a/server-common/src/main/java/io/a2a/server/tasks/PushNotificationSender.java
+++ b/server-common/src/main/java/io/a2a/server/tasks/PushNotificationSender.java
@@ -1,6 +1,6 @@
 package io.a2a.server.tasks;
 
-import io.a2a.spec.Task;
+import io.a2a.spec.StreamingEventKind;
 
 /**
  * Interface for sending push notifications for tasks.
@@ -8,8 +8,8 @@ import io.a2a.spec.Task;
 public interface PushNotificationSender {
 
     /**
-     * Sends a push notification containing the latest task state.
-     * @param task the task
+     * Sends a push notification containing payload about a task.
+     * @param kind the payload to push
      */
-    void sendNotification(Task task);
+    void sendNotification(StreamingEventKind kind);
 }

--- a/server-common/src/test/java/io/a2a/server/requesthandlers/AbstractA2ARequestHandlerTest.java
+++ b/server-common/src/test/java/io/a2a/server/requesthandlers/AbstractA2ARequestHandlerTest.java
@@ -16,7 +16,6 @@ import java.util.function.Consumer;
 
 import jakarta.enterprise.context.Dependent;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.arc.profile.IfBuildProfile;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -40,6 +39,7 @@ import io.a2a.spec.AgentCard;
 import io.a2a.spec.Event;
 import io.a2a.spec.JSONRPCError;
 import io.a2a.spec.Message;
+import io.a2a.spec.StreamingEventKind;
 import io.a2a.spec.Task;
 import io.a2a.spec.TaskState;
 import io.a2a.spec.TaskStatus;
@@ -200,11 +200,10 @@ public class AbstractA2ARequestHandlerTest {
 
             @Override
             public A2AHttpResponse post() throws IOException, InterruptedException {
-                JsonNode root = Utils.OBJECT_MAPPER.readTree(body);
-                // This will need to be updated for #490 to unmarshall based on the kind of payload
-                JsonNode taskNode = root.elements().next();
-                Task task = Utils.OBJECT_MAPPER.treeToValue(taskNode, Task.TYPE_REFERENCE);
-                tasks.add(task);
+                StreamingEventKind kind = Utils.unmarshalStreamingEventKindFrom(body);
+                if (kind instanceof Task task) {
+                    tasks.add(task);
+                }
                 try {
                     return new A2AHttpResponse() {
                         @Override

--- a/spec/src/main/java/io/a2a/spec/TaskArtifactUpdateEvent.java
+++ b/spec/src/main/java/io/a2a/spec/TaskArtifactUpdateEvent.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import io.a2a.util.Assert;
 
 import static io.a2a.spec.TaskArtifactUpdateEvent.ARTIFACT_UPDATE;
@@ -43,6 +45,8 @@ import static io.a2a.spec.TaskArtifactUpdateEvent.ARTIFACT_UPDATE;
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class TaskArtifactUpdateEvent implements EventKind, StreamingEventKind, UpdateEvent {
+
+    public static final TypeReference<TaskArtifactUpdateEvent> TYPE_REFERENCE = new TypeReference<>() {};
 
     public static final String ARTIFACT_UPDATE = "artifact-update";
     private final String taskId;

--- a/spec/src/main/java/io/a2a/spec/TaskStatusUpdateEvent.java
+++ b/spec/src/main/java/io/a2a/spec/TaskStatusUpdateEvent.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import io.a2a.util.Assert;
 
 import static io.a2a.spec.TaskStatusUpdateEvent.STATUS_UPDATE;
@@ -19,6 +21,8 @@ import static io.a2a.spec.TaskStatusUpdateEvent.STATUS_UPDATE;
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class TaskStatusUpdateEvent implements EventKind, StreamingEventKind, UpdateEvent {
+
+    public static final TypeReference<TaskStatusUpdateEvent> TYPE_REFERENCE = new TypeReference<>() {};
 
     public static final String STATUS_UPDATE = "status-update";
     private final String taskId;


### PR DESCRIPTION
Expand PushNotificationSender to support all StreamingEventKind payload types
as defined in the A2A specification, not just Task objects.

Fixes: #490

- [X] Follow the [`CONTRIBUTING` Guide](../CONTRIBUTING.md).
- [X] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
    - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
        - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
        - `feat:` represents a new feature, and correlates to a SemVer minor.
        - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [X] Ensure the tests pass
- [X] Appropriate READMEs were updated (if necessary)

Fixes #490 🦕