### PR TITLE
chore: Disable TCK runs for PRs while updating to 1.0.0

### DIFF
--- a/.github/workflows/run-tck.yml
+++ b/.github/workflows/run-tck.yml
@@ -8,7 +8,8 @@ on:
       - 0.3.x
   pull_request:
     branches:
-      - main
+# Disable TCK runs on main PRs for now, since we are making spec and TCK updates for 1.0.0
+#      - main
       - 0.3.x
   workflow_dispatch:
 


### PR DESCRIPTION
https://github.com/a2aproject/a2a-java/issues/495 Tracks reenabling the TCK runs for PRs