### PR TITLE
docs: Add comprehensive Javadoc to spec module classes

### DIFF
--- a/spec/src/main/java/io/a2a/json/JsonUtil.java
+++ b/spec/src/main/java/io/a2a/json/JsonUtil.java
@@ -79,7 +79,7 @@ public class JsonUtil {
      * <p>
      * Used throughout the SDK for consistent JSON serialization and deserialization.
      *
-     * @see GsonBuilder
+     * @see JsonUtil#createBaseGsonBuilder()
      */
     public static final Gson OBJECT_MAPPER = createBaseGsonBuilder()
             .registerTypeHierarchyAdapter(Part.class, new PartTypeAdapter())

--- a/spec/src/main/java/io/a2a/spec/A2AClientHTTPError.java
+++ b/spec/src/main/java/io/a2a/spec/A2AClientHTTPError.java
@@ -33,6 +33,14 @@ public class A2AClientHTTPError extends A2AClientError {
     private final int code;
     private final String message;
 
+    /**
+     * Creates a new HTTP client error with the specified status code and message.
+     *
+     * @param code the HTTP status code
+     * @param message the error message
+     * @param data additional error data (may be the response body)
+     * @throws IllegalArgumentException if code or message is null
+     */
     public A2AClientHTTPError(int code, String message, Object data) {
         Assert.checkNotNullParam("code", code);
         Assert.checkNotNullParam("message", message);

--- a/spec/src/main/java/io/a2a/spec/A2AClientInvalidArgsError.java
+++ b/spec/src/main/java/io/a2a/spec/A2AClientInvalidArgsError.java
@@ -27,13 +27,27 @@ package io.a2a.spec;
  */
 public class A2AClientInvalidArgsError extends A2AClientError {
 
+    /**
+     * Creates a new invalid arguments error with no message.
+     */
     public A2AClientInvalidArgsError() {
     }
 
+    /**
+     * Creates a new invalid arguments error with the specified message.
+     *
+     * @param message the error message
+     */
     public A2AClientInvalidArgsError(String message) {
         super("Invalid arguments error: " + message);
     }
 
+    /**
+     * Creates a new invalid arguments error with the specified message and cause.
+     *
+     * @param message the error message
+     * @param cause the underlying cause
+     */
     public A2AClientInvalidArgsError(String message, Throwable cause) {
         super("Invalid arguments error: " + message, cause);
     }

--- a/spec/src/main/java/io/a2a/spec/A2AClientInvalidStateError.java
+++ b/spec/src/main/java/io/a2a/spec/A2AClientInvalidStateError.java
@@ -26,13 +26,27 @@ package io.a2a.spec;
  */
 public class A2AClientInvalidStateError extends A2AClientError {
 
+    /**
+     * Creates a new invalid state error with no message.
+     */
     public A2AClientInvalidStateError() {
     }
 
+    /**
+     * Creates a new invalid state error with the specified message.
+     *
+     * @param message the error message
+     */
     public A2AClientInvalidStateError(String message) {
         super("Invalid state error: " + message);
     }
 
+    /**
+     * Creates a new invalid state error with the specified message and cause.
+     *
+     * @param message the error message
+     * @param cause the underlying cause
+     */
     public A2AClientInvalidStateError(String message, Throwable cause) {
         super("Invalid state error: " + message, cause);
     }

--- a/spec/src/main/java/io/a2a/spec/A2AClientJSONError.java
+++ b/spec/src/main/java/io/a2a/spec/A2AClientJSONError.java
@@ -27,13 +27,27 @@ package io.a2a.spec;
  */
 public class A2AClientJSONError extends A2AClientError {
 
+    /**
+     * Creates a new JSON error with no message.
+     */
     public A2AClientJSONError() {
     }
 
+    /**
+     * Creates a new JSON error with the specified message.
+     *
+     * @param message the error message
+     */
     public A2AClientJSONError(String message) {
         super(message);
     }
 
+    /**
+     * Creates a new JSON error with the specified message and cause.
+     *
+     * @param message the error message
+     * @param cause the underlying cause
+     */
     public A2AClientJSONError(String message, Throwable cause) {
         super(message, cause);
     }

--- a/spec/src/main/java/io/a2a/spec/A2AErrorCodes.java
+++ b/spec/src/main/java/io/a2a/spec/A2AErrorCodes.java
@@ -5,18 +5,39 @@ package io.a2a.spec;
  */
 public interface A2AErrorCodes {
 
+    /** Error code indicating the requested task was not found (-32001). */
     int TASK_NOT_FOUND_ERROR_CODE = -32001;
+
+    /** Error code indicating the task cannot be canceled in its current state (-32002). */
     int TASK_NOT_CANCELABLE_ERROR_CODE = -32002;
+
+    /** Error code indicating push notifications are not supported by this agent (-32003). */
     int PUSH_NOTIFICATION_NOT_SUPPORTED_ERROR_CODE = -32003;
+
+    /** Error code indicating the requested operation is not supported (-32004). */
     int UNSUPPORTED_OPERATION_ERROR_CODE = -32004;
+
+    /** Error code indicating the content type is not supported (-32005). */
     int CONTENT_TYPE_NOT_SUPPORTED_ERROR_CODE = -32005;
+
+    /** Error code indicating the agent returned an invalid response (-32006). */
     int INVALID_AGENT_RESPONSE_ERROR_CODE = -32006;
+
+    /** Error code indicating authenticated extended card is not configured (-32007). */
     int AUTHENTICATED_EXTENDED_CARD_NOT_CONFIGURED_ERROR_CODE = -32007;
 
+    /** JSON-RPC error code for invalid request structure (-32600). */
     int INVALID_REQUEST_ERROR_CODE = -32600;
+
+    /** JSON-RPC error code for method not found (-32601). */
     int METHOD_NOT_FOUND_ERROR_CODE = -32601;
+
+    /** JSON-RPC error code for invalid method parameters (-32602). */
     int INVALID_PARAMS_ERROR_CODE = -32602;
+
+    /** JSON-RPC error code for internal server errors (-32603). */
     int INTERNAL_ERROR_CODE = -32603;
 
+    /** JSON-RPC error code for JSON parsing errors (-32700). */
     int JSON_PARSE_ERROR_CODE = -32700;
 }

--- a/spec/src/main/java/io/a2a/spec/A2AServerException.java
+++ b/spec/src/main/java/io/a2a/spec/A2AServerException.java
@@ -19,18 +19,37 @@ package io.a2a.spec;
  */
 public class A2AServerException extends A2AException {
 
+    /**
+     * Creates a new A2AServerException with no message.
+     */
     public A2AServerException() {
         super();
     }
 
+    /**
+     * Creates a new A2AServerException with the specified message.
+     *
+     * @param msg the exception message
+     */
     public A2AServerException(final String msg) {
         super(msg);
     }
 
+    /**
+     * Creates a new A2AServerException with the specified cause.
+     *
+     * @param cause the underlying cause
+     */
     public A2AServerException(final Throwable cause) {
         super(cause);
     }
 
+    /**
+     * Creates a new A2AServerException with the specified message and cause.
+     *
+     * @param msg the exception message
+     * @param cause the underlying cause
+     */
     public A2AServerException(final String msg, final Throwable cause) {
         super(msg, cause);
     }

--- a/spec/src/main/java/io/a2a/spec/APIKeySecurityScheme.java
+++ b/spec/src/main/java/io/a2a/spec/APIKeySecurityScheme.java
@@ -18,6 +18,7 @@ import static io.a2a.spec.APIKeySecurityScheme.API_KEY;
  */
 public final class APIKeySecurityScheme implements SecurityScheme {
 
+    /** The security scheme type identifier for API key authentication. */
     public static final String API_KEY = "apiKey";
     private final Location location;
     private final String name;
@@ -28,8 +29,13 @@ public final class APIKeySecurityScheme implements SecurityScheme {
      * Represents the location of the API key.
      */
     public enum Location {
+        /** API key sent in a cookie. */
         COOKIE("cookie"),
+
+        /** API key sent in an HTTP header. */
         HEADER("header"),
+
+        /** API key sent as a query parameter. */
         QUERY("query");
 
         private final String location;
@@ -38,10 +44,22 @@ public final class APIKeySecurityScheme implements SecurityScheme {
             this.location = location;
         }
 
+        /**
+         * Converts this location to its string representation.
+         *
+         * @return the string representation of this location
+         */
         public String asString() {
             return location;
         }
 
+        /**
+         * Converts a string to a Location enum value.
+         *
+         * @param location the string location ("cookie", "header", or "query")
+         * @return the corresponding Location enum value
+         * @throws IllegalArgumentException if the location string is invalid
+         */
         public static Location fromString(String location) {
             switch (location) {
                 case "cookie" -> {
@@ -58,10 +76,27 @@ public final class APIKeySecurityScheme implements SecurityScheme {
         }
     }
 
+    /**
+     * Creates a new APIKeySecurityScheme with the specified location, name, and description.
+     *
+     * @param location the location where the API key is sent (required)
+     * @param name the name of the API key parameter (required)
+     * @param description a human-readable description (optional)
+     * @throws IllegalArgumentException if location or name is null
+     */
     public APIKeySecurityScheme(Location location, String name, String description) {
         this(location, name, description, API_KEY);
     }
 
+    /**
+     * Creates a new APIKeySecurityScheme with explicit type specification.
+     *
+     * @param location the location where the API key is sent (required)
+     * @param name the name of the API key parameter (required)
+     * @param description a human-readable description (optional)
+     * @param type the security scheme type (must be "apiKey")
+     * @throws IllegalArgumentException if location, name, or type is null, or if type is not "apiKey"
+     */
     public APIKeySecurityScheme(Location location, String name,
                                 String description, String type) {
         Assert.checkNotNullParam("location", location);
@@ -76,43 +111,99 @@ public final class APIKeySecurityScheme implements SecurityScheme {
         this.type = type;
     }
 
+    /**
+     * Gets the human-readable description of this security scheme.
+     *
+     * @return the description, or null if not provided
+     */
     @Override
     public String getDescription() {
         return description;
     }
 
+    /**
+     * Gets the location where the API key is sent.
+     *
+     * @return the API key location
+     */
     public Location getLocation() {
         return location;
     }
 
+    /**
+     * Gets the name of the API key parameter.
+     *
+     * @return the parameter name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Gets the security scheme type.
+     *
+     * @return always returns "apiKey"
+     */
     public String getType() {
         return type;
     }
 
+    /**
+     * Builder for constructing immutable {@link APIKeySecurityScheme} instances.
+     * <p>
+     * Example usage:
+     * <pre>{@code
+     * APIKeySecurityScheme scheme = new APIKeySecurityScheme.Builder()
+     *     .location(Location.HEADER)
+     *     .name("X-API-Key")
+     *     .description("API key authentication")
+     *     .build();
+     * }</pre>
+     */
     public static class Builder {
         private Location location;
         private String name;
         private String description;
 
+        /**
+         * Sets the location where the API key should be sent.
+         *
+         * @param location the API key location (header, query, or cookie) (required)
+         * @return this builder for method chaining
+         */
         public Builder location(Location location) {
             this.location = location;
             return this;
         }
 
+        /**
+         * Sets the name of the API key parameter.
+         *
+         * @param name the parameter name (required)
+         * @return this builder for method chaining
+         */
         public Builder name(String name) {
             this.name = name;
             return this;
         }
 
+        /**
+         * Sets the human-readable description of the security scheme.
+         *
+         * @param description the description (optional)
+         * @return this builder for method chaining
+         */
         public Builder description(String description) {
             this.description = description;
             return this;
         }
 
+        /**
+         * Builds a new immutable {@link APIKeySecurityScheme} from the current builder state.
+         *
+         * @return a new APIKeySecurityScheme instance
+         * @throws IllegalArgumentException if location or name is null
+         */
         public APIKeySecurityScheme build() {
             return new APIKeySecurityScheme(location, name, description);
         }

--- a/spec/src/main/java/io/a2a/spec/AgentCapabilities.java
+++ b/spec/src/main/java/io/a2a/spec/AgentCapabilities.java
@@ -57,6 +57,12 @@ public record AgentCapabilities(boolean streaming, boolean pushNotifications, bo
         private List<AgentExtension> extensions;
 
         /**
+         * Creates a new Builder with all capabilities set to false by default.
+         */
+        public Builder() {
+        }
+
+        /**
          * Sets whether the agent supports streaming responses.
          * <p>
          * When enabled, clients can subscribe to task updates and receive

--- a/spec/src/main/java/io/a2a/spec/AgentCardSignature.java
+++ b/spec/src/main/java/io/a2a/spec/AgentCardSignature.java
@@ -34,6 +34,11 @@ import io.a2a.util.Assert;
 public record AgentCardSignature(Map<String, Object> header, @SerializedName("protected")String protectedHeader,
                                  String signature) {
 
+    /**
+     * Compact constructor that validates required fields.
+     *
+     * @throws IllegalArgumentException if protectedHeader or signature is null
+     */
     public AgentCardSignature {
         Assert.checkNotNullParam("protectedHeader", protectedHeader);
         Assert.checkNotNullParam("signature", signature);
@@ -55,6 +60,12 @@ public record AgentCardSignature(Map<String, Object> header, @SerializedName("pr
         private Map<String, Object> header;
         String protectedHeader;
         String signature;
+
+        /**
+         * Creates a new Builder with all fields unset.
+         */
+        public Builder() {
+        }
 
         /**
          * Sets the optional unprotected header with additional metadata.

--- a/spec/src/main/java/io/a2a/spec/AgentExtension.java
+++ b/spec/src/main/java/io/a2a/spec/AgentExtension.java
@@ -25,6 +25,11 @@ import io.a2a.util.Assert;
  */
 public record AgentExtension (String description, Map<String, Object> params, boolean required, String uri) {
 
+    /**
+     * Compact constructor that validates required fields.
+     *
+     * @throws IllegalArgumentException if uri is null
+     */
     public AgentExtension {
         Assert.checkNotNullParam("uri", uri);
     }
@@ -47,6 +52,12 @@ public record AgentExtension (String description, Map<String, Object> params, bo
         Map<String, Object> params;
         boolean required;
         String uri;
+
+        /**
+         * Creates a new Builder with all fields unset.
+         */
+        public Builder() {
+        }
 
         /**
          * Sets a human-readable description of the extension's purpose.

--- a/spec/src/main/java/io/a2a/spec/AgentInterface.java
+++ b/spec/src/main/java/io/a2a/spec/AgentInterface.java
@@ -24,6 +24,11 @@ import io.a2a.util.Assert;
  */
 public record AgentInterface(String protocolBinding, String url) {
 
+    /**
+     * Compact constructor that validates required fields.
+     *
+     * @throws IllegalArgumentException if protocolBinding or url is null
+     */
     public AgentInterface {
         Assert.checkNotNullParam("protocolBinding", protocolBinding);
         Assert.checkNotNullParam("url", url);

--- a/spec/src/main/java/io/a2a/spec/AgentProvider.java
+++ b/spec/src/main/java/io/a2a/spec/AgentProvider.java
@@ -21,6 +21,11 @@ import io.a2a.util.Assert;
  */
 public record AgentProvider(String organization, String url) {
 
+    /**
+     * Compact constructor that validates required fields.
+     *
+     * @throws IllegalArgumentException if organization or url is null
+     */
     public AgentProvider {
         Assert.checkNotNullParam("organization", organization);
         Assert.checkNotNullParam("url", url);

--- a/spec/src/main/java/io/a2a/spec/AgentSkill.java
+++ b/spec/src/main/java/io/a2a/spec/AgentSkill.java
@@ -43,6 +43,11 @@ public record AgentSkill(String id, String name, String description, List<String
                          List<String> examples, List<String> inputModes, List<String> outputModes,
                          List<Map<String, List<String>>> security) {
 
+    /**
+     * Compact constructor that validates required fields.
+     *
+     * @throws IllegalArgumentException if id, name, description, or tags is null
+     */
     public AgentSkill {
         Assert.checkNotNullParam("description", description);
         Assert.checkNotNullParam("id", id);
@@ -83,6 +88,12 @@ public record AgentSkill(String id, String name, String description, List<String
         private List<String> inputModes;
         private List<String> outputModes;
         private List<Map<String, List<String>>> security;
+
+        /**
+         * Creates a new Builder with all fields unset.
+         */
+        public Builder() {
+        }
 
         /**
          * Sets the unique identifier for the skill.

--- a/spec/src/main/java/io/a2a/spec/Artifact.java
+++ b/spec/src/main/java/io/a2a/spec/Artifact.java
@@ -32,6 +32,11 @@ import io.a2a.util.Assert;
 public record Artifact(String artifactId, String name, String description, List<Part<?>> parts, Map<String, Object> metadata,
                        List<String> extensions) {
 
+    /**
+     * Compact constructor that validates required fields.
+     *
+     * @throws IllegalArgumentException if artifactId or parts is null, or if parts is empty
+     */
     public Artifact {
         Assert.checkNotNullParam("artifactId", artifactId);
         Assert.checkNotNullParam("parts", parts);

--- a/spec/src/main/java/io/a2a/spec/AuthenticationInfo.java
+++ b/spec/src/main/java/io/a2a/spec/AuthenticationInfo.java
@@ -24,6 +24,11 @@ import io.a2a.util.Assert;
  */
 public record AuthenticationInfo(List<String> schemes, String credentials) {
 
+    /**
+     * Compact constructor that validates required fields.
+     *
+     * @throws IllegalArgumentException if schemes is null
+     */
     public AuthenticationInfo {
         Assert.checkNotNullParam("schemes", schemes);
     }

--- a/spec/src/main/java/io/a2a/spec/AuthorizationCodeOAuthFlow.java
+++ b/spec/src/main/java/io/a2a/spec/AuthorizationCodeOAuthFlow.java
@@ -28,6 +28,11 @@ import io.a2a.util.Assert;
 public record AuthorizationCodeOAuthFlow(String authorizationUrl, String refreshUrl, Map<String, String> scopes,
                                          String tokenUrl) {
 
+    /**
+     * Compact constructor that validates required fields.
+     *
+     * @throws IllegalArgumentException if authorizationUrl, scopes, or tokenUrl is null
+     */
     public AuthorizationCodeOAuthFlow {
         Assert.checkNotNullParam("authorizationUrl", authorizationUrl);
         Assert.checkNotNullParam("scopes", scopes);

--- a/spec/src/main/java/io/a2a/spec/CancelTaskRequest.java
+++ b/spec/src/main/java/io/a2a/spec/CancelTaskRequest.java
@@ -26,10 +26,20 @@ import io.a2a.util.Assert;
  */
 public final class CancelTaskRequest extends NonStreamingJSONRPCRequest<TaskIdParams> {
 
+    /** The JSON-RPC method name for canceling tasks. */
     public static final String METHOD = "CancelTask";
 
+    /**
+     * Creates a new CancelTaskRequest with the specified JSON-RPC parameters.
+     *
+     * @param jsonrpc the JSON-RPC version (defaults to "2.0" if null)
+     * @param id the request identifier (string, integer, or null)
+     * @param method the method name (must be "CancelTask")
+     * @param params the request parameters containing the task ID
+     * @throws IllegalArgumentException if jsonrpc version is invalid, method is not "CancelTask", params is null, or id is not a String/Integer/null
+     */
     public CancelTaskRequest(String jsonrpc, Object id, String method, TaskIdParams params) {
-        if (jsonrpc != null && ! jsonrpc.equals(JSONRPC_VERSION)) {
+        if (jsonrpc != null && ! JSONRPC_VERSION.equals(jsonrpc)) {
             throw new IllegalArgumentException("Invalid JSON-RPC protocol version");
         }
         Assert.checkNotNullParam("method", method);
@@ -44,36 +54,81 @@ public final class CancelTaskRequest extends NonStreamingJSONRPCRequest<TaskIdPa
         this.params = params;
     }
 
+    /**
+     * Creates a new CancelTaskRequest with default JSON-RPC version and method.
+     *
+     * @param id the request identifier (string, integer, or null)
+     * @param params the request parameters containing the task ID
+     * @throws IllegalArgumentException if params is null or id is not a string/integer/null
+     */
     public CancelTaskRequest(Object id, TaskIdParams params) {
         this(null, id, METHOD, params);
     }
 
+    /**
+     * Builder for constructing {@link CancelTaskRequest} instances.
+     * <p>
+     * Provides a fluent API for setting request parameters. If no id is provided,
+     * a random UUID will be generated when {@link #build()} is called.
+     */
     public static class Builder {
         private String jsonrpc;
         private Object id;
         private String method = METHOD;
         private TaskIdParams params;
 
+        /**
+         * Sets the JSON-RPC protocol version.
+         *
+         * @param jsonrpc the JSON-RPC version (optional, defaults to "2.0")
+         * @return this builder for method chaining
+         */
         public CancelTaskRequest.Builder jsonrpc(String jsonrpc) {
             this.jsonrpc = jsonrpc;
             return this;
         }
 
+        /**
+         * Sets the request identifier.
+         *
+         * @param id the request identifier (string, integer, or null; if null, a UUID will be generated)
+         * @return this builder for method chaining
+         */
         public CancelTaskRequest.Builder id(Object id) {
             this.id = id;
             return this;
         }
 
+        /**
+         * Sets the JSON-RPC method name.
+         *
+         * @param method the method name (should be "CancelTask")
+         * @return this builder for method chaining
+         */
         public CancelTaskRequest.Builder method(String method) {
             this.method = method;
             return this;
         }
 
+        /**
+         * Sets the request parameters containing the task ID to cancel.
+         *
+         * @param params the request parameters (required)
+         * @return this builder for method chaining
+         */
         public CancelTaskRequest.Builder params(TaskIdParams params) {
             this.params = params;
             return this;
         }
 
+        /**
+         * Builds a new {@link CancelTaskRequest} from the current builder state.
+         * <p>
+         * If no id was provided, a random UUID will be generated.
+         *
+         * @return a new CancelTaskRequest instance
+         * @throws IllegalArgumentException if validation fails (invalid method, null params, invalid id type)
+         */
         public CancelTaskRequest build() {
             if (id == null) {
                 id = UUID.randomUUID().toString();

--- a/spec/src/main/java/io/a2a/spec/ClientCredentialsOAuthFlow.java
+++ b/spec/src/main/java/io/a2a/spec/ClientCredentialsOAuthFlow.java
@@ -28,6 +28,11 @@ import io.a2a.util.Assert;
  */
 public record ClientCredentialsOAuthFlow(String refreshUrl, Map<String, String> scopes, String tokenUrl) {
 
+    /**
+     * Compact constructor that validates required fields.
+     *
+     * @throws IllegalArgumentException if scopes or tokenUrl is null
+     */
     public ClientCredentialsOAuthFlow {
         Assert.checkNotNullParam("scopes", scopes);
         Assert.checkNotNullParam("tokenUrl", tokenUrl);

--- a/spec/src/main/java/io/a2a/spec/DataPart.java
+++ b/spec/src/main/java/io/a2a/spec/DataPart.java
@@ -37,6 +37,7 @@ import io.a2a.util.Assert;
  */
 public class DataPart extends Part<Map<String, Object>> {
 
+    /** The type identifier for data parts in messages and artifacts. */
     public static final String DATA = "data";
     private final Map<String, Object> data;
     private final Map<String, Object> metadata;
@@ -58,6 +59,11 @@ public class DataPart extends Part<Map<String, Object>> {
         return kind;
     }
 
+    /**
+     * Gets the structured data contained in this part.
+     *
+     * @return a map of key-value pairs representing the data
+     */
     public Map<String, Object> getData() {
         return data;
     }

--- a/spec/src/main/java/io/a2a/spec/DeleteTaskPushNotificationConfigParams.java
+++ b/spec/src/main/java/io/a2a/spec/DeleteTaskPushNotificationConfigParams.java
@@ -19,35 +19,76 @@ import io.a2a.util.Assert;
  */
 public record DeleteTaskPushNotificationConfigParams(String id, String pushNotificationConfigId, Map<String, Object> metadata) {
 
+    /**
+     * Compact constructor that validates required fields.
+     *
+     * @throws IllegalArgumentException if id or pushNotificationConfigId is null
+     */
     public DeleteTaskPushNotificationConfigParams {
         Assert.checkNotNullParam("id", id);
         Assert.checkNotNullParam("pushNotificationConfigId", pushNotificationConfigId);
     }
 
+    /**
+     * Creates parameters without optional metadata.
+     *
+     * @param id the task identifier (required)
+     * @param pushNotificationConfigId the configuration ID to delete (required)
+     * @throws IllegalArgumentException if id or pushNotificationConfigId is null
+     */
     public DeleteTaskPushNotificationConfigParams(String id, String pushNotificationConfigId) {
         this(id, pushNotificationConfigId, null);
     }
 
+    /**
+     * Builder for constructing {@link DeleteTaskPushNotificationConfigParams} instances.
+     * <p>
+     * Provides a fluent API for setting parameters with optional metadata.
+     */
     public static class Builder {
         String id;
         String pushNotificationConfigId;
         Map<String, Object> metadata;
 
+        /**
+         * Sets the task identifier.
+         *
+         * @param id the task ID (required)
+         * @return this builder for method chaining
+         */
         public Builder id(String id) {
             this.id = id;
             return this;
         }
 
+        /**
+         * Sets the push notification configuration ID to delete.
+         *
+         * @param pushNotificationConfigId the configuration ID (required)
+         * @return this builder for method chaining
+         */
         public Builder pushNotificationConfigId(String pushNotificationConfigId) {
             this.pushNotificationConfigId = pushNotificationConfigId;
             return this;
         }
 
+        /**
+         * Sets optional metadata for the request.
+         *
+         * @param metadata arbitrary key-value metadata (optional)
+         * @return this builder for method chaining
+         */
         public Builder metadata(Map<String, Object> metadata) {
             this.metadata = metadata;
             return this;
         }
 
+        /**
+         * Builds a new {@link DeleteTaskPushNotificationConfigParams} from the current builder state.
+         *
+         * @return a new DeleteTaskPushNotificationConfigParams instance
+         * @throws IllegalArgumentException if id or pushNotificationConfigId is null
+         */
         public DeleteTaskPushNotificationConfigParams build() {
             return new DeleteTaskPushNotificationConfigParams(id, pushNotificationConfigId, metadata);
         }

--- a/spec/src/main/java/io/a2a/spec/DeleteTaskPushNotificationConfigRequest.java
+++ b/spec/src/main/java/io/a2a/spec/DeleteTaskPushNotificationConfigRequest.java
@@ -20,8 +20,18 @@ import io.a2a.util.Utils;
  */
 public final class DeleteTaskPushNotificationConfigRequest extends NonStreamingJSONRPCRequest<DeleteTaskPushNotificationConfigParams> {
 
+    /** The JSON-RPC method name for deleting push notification configurations. */
     public static final String METHOD = "DeleteTaskPushNotificationConfig";
 
+    /**
+     * Creates a new DeleteTaskPushNotificationConfigRequest with the specified JSON-RPC parameters.
+     *
+     * @param jsonrpc the JSON-RPC version (defaults to "2.0" if null)
+     * @param id the request identifier (string, integer, or null)
+     * @param method the method name (must be "DeleteTaskPushNotificationConfig")
+     * @param params the request parameters containing task and config IDs
+     * @throws IllegalArgumentException if jsonrpc version is invalid, method is not "DeleteTaskPushNotificationConfig", or id is not a string/integer/null
+     */
     public DeleteTaskPushNotificationConfigRequest(String jsonrpc, Object id, String method, DeleteTaskPushNotificationConfigParams params) {
         if (jsonrpc != null && ! jsonrpc.equals(JSONRPC_VERSION)) {
             throw new IllegalArgumentException("Invalid JSON-RPC protocol version");
@@ -37,36 +47,81 @@ public final class DeleteTaskPushNotificationConfigRequest extends NonStreamingJ
         this.params = params;
     }
 
+    /**
+     * Creates a new DeleteTaskPushNotificationConfigRequest with default JSON-RPC version and method.
+     *
+     * @param id the request identifier (string, integer, or null)
+     * @param params the request parameters containing task and config IDs
+     * @throws IllegalArgumentException if id is not a string/integer/null
+     */
     public DeleteTaskPushNotificationConfigRequest(String id, DeleteTaskPushNotificationConfigParams params) {
         this(null, id, METHOD, params);
     }
 
+    /**
+     * Builder for constructing {@link DeleteTaskPushNotificationConfigRequest} instances.
+     * <p>
+     * Provides a fluent API for setting request parameters. If no id is provided,
+     * a random UUID will be generated when {@link #build()} is called.
+     */
     public static class Builder {
         private String jsonrpc;
         private Object id;
         private String method;
         private DeleteTaskPushNotificationConfigParams params;
 
+        /**
+         * Sets the JSON-RPC protocol version.
+         *
+         * @param jsonrpc the JSON-RPC version (optional, defaults to "2.0")
+         * @return this builder for method chaining
+         */
         public Builder jsonrpc(String jsonrpc) {
             this.jsonrpc = jsonrpc;
             return this;
         }
 
+        /**
+         * Sets the request identifier.
+         *
+         * @param id the request identifier (string, integer, or null; if null, a UUID will be generated)
+         * @return this builder for method chaining
+         */
         public Builder id(Object id) {
             this.id = id;
             return this;
         }
 
+        /**
+         * Sets the JSON-RPC method name.
+         *
+         * @param method the method name (should be "DeleteTaskPushNotificationConfig")
+         * @return this builder for method chaining
+         */
         public Builder method(String method) {
             this.method = method;
             return this;
         }
 
+        /**
+         * Sets the request parameters.
+         *
+         * @param params the request parameters containing task and config IDs (required)
+         * @return this builder for method chaining
+         */
         public Builder params(DeleteTaskPushNotificationConfigParams params) {
             this.params = params;
             return this;
         }
 
+        /**
+         * Builds a new {@link DeleteTaskPushNotificationConfigRequest} from the current builder state.
+         * <p>
+         * If no id was provided, a random UUID will be generated.
+         *
+         * @return a new DeleteTaskPushNotificationConfigRequest instance
+         * @throws IllegalArgumentException if validation fails (invalid method, invalid id type)
+         */
         public DeleteTaskPushNotificationConfigRequest build() {
             if (id == null) {
                 id = UUID.randomUUID().toString();

--- a/spec/src/main/java/io/a2a/spec/DeleteTaskPushNotificationConfigResponse.java
+++ b/spec/src/main/java/io/a2a/spec/DeleteTaskPushNotificationConfigResponse.java
@@ -13,14 +13,33 @@ package io.a2a.spec;
  */
 public final class DeleteTaskPushNotificationConfigResponse extends JSONRPCResponse<Void> {
 
+    /**
+     * Creates a new DeleteTaskPushNotificationConfigResponse with full JSON-RPC parameters.
+     *
+     * @param jsonrpc the JSON-RPC version
+     * @param id the response identifier matching the request
+     * @param result the result (always null/Void for this response type)
+     * @param error the error if the request failed, null on success
+     */
     public DeleteTaskPushNotificationConfigResponse(String jsonrpc, Object id, Void result,JSONRPCError error) {
         super(jsonrpc, id, result, error, Void.class);
     }
 
+    /**
+     * Creates a new error DeleteTaskPushNotificationConfigResponse with default JSON-RPC version.
+     *
+     * @param id the response identifier matching the request
+     * @param error the error describing why the deletion failed
+     */
     public DeleteTaskPushNotificationConfigResponse(Object id, JSONRPCError error) {
         this(null, id, null, error);
     }
 
+    /**
+     * Creates a new successful DeleteTaskPushNotificationConfigResponse with default JSON-RPC version.
+     *
+     * @param id the response identifier matching the request
+     */
     public DeleteTaskPushNotificationConfigResponse(Object id) {
         this(null, id, null, null);
     }

--- a/spec/src/main/java/io/a2a/spec/FilePart.java
+++ b/spec/src/main/java/io/a2a/spec/FilePart.java
@@ -39,6 +39,7 @@ import static io.a2a.spec.FilePart.FILE;
  */
 public class FilePart extends Part<FileContent> {
 
+    /** The type identifier for file parts in messages and artifacts. */
     public static final String FILE = "file";
     private final FileContent file;
     private final Map<String, Object> metadata;

--- a/spec/src/main/java/io/a2a/spec/JSONRPCResponse.java
+++ b/spec/src/main/java/io/a2a/spec/JSONRPCResponse.java
@@ -6,6 +6,8 @@ import io.a2a.util.Assert;
 
 /**
  * Represents a JSONRPC response.
+ *
+ * @param <T> the type of the result value returned in successful responses
  */
 public abstract sealed class JSONRPCResponse<T> implements JSONRPCMessage permits CancelTaskResponse, DeleteTaskPushNotificationConfigResponse, GetAuthenticatedExtendedCardResponse, GetTaskPushNotificationConfigResponse, GetTaskResponse, JSONRPCErrorResponse, ListTaskPushNotificationConfigResponse, ListTasksResponse, SendMessageResponse, SendStreamingMessageResponse, SetTaskPushNotificationConfigResponse {
 

--- a/spec/src/main/java/io/a2a/spec/NonStreamingJSONRPCRequest.java
+++ b/spec/src/main/java/io/a2a/spec/NonStreamingJSONRPCRequest.java
@@ -2,6 +2,8 @@ package io.a2a.spec;
 
 /**
  * Represents a non-streaming JSON-RPC request.
+ *
+ * @param <T> the type of the request parameters
  */
 public abstract sealed class NonStreamingJSONRPCRequest<T> extends JSONRPCRequest<T> permits GetTaskRequest,
         CancelTaskRequest, SetTaskPushNotificationConfigRequest, GetTaskPushNotificationConfigRequest,

--- a/spec/src/main/java/io/a2a/spec/SecurityScheme.java
+++ b/spec/src/main/java/io/a2a/spec/SecurityScheme.java
@@ -25,5 +25,10 @@ import static io.a2a.spec.APIKeySecurityScheme.API_KEY;
 public sealed interface SecurityScheme permits APIKeySecurityScheme, HTTPAuthSecurityScheme, OAuth2SecurityScheme,
         OpenIdConnectSecurityScheme, MutualTLSSecurityScheme {
 
+    /**
+     * Gets the human-readable description of this security scheme.
+     *
+     * @return the description, or null if not provided
+     */
     String getDescription();
 }

--- a/spec/src/main/java/io/a2a/util/Utils.java
+++ b/spec/src/main/java/io/a2a/util/Utils.java
@@ -1,6 +1,5 @@
 package io.a2a.util;
 
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 


### PR DESCRIPTION
Added Javadoc documentation for:
- Public constants (error codes, method names, type identifiers)
- Generic type parameters in base request/response classes
- Record compact constructors (12 record classes)
- Exception constructors (5 exception classes)
- APIKeySecurityScheme (enum, methods, constructors, Builder)
- Builder classes and methods (CancelTaskRequest, DeleteTaskPushNotificationConfig*)
- Request/response constructors

This resolves all Javadoc warnings and errors  in the spec module, enabling clean builds with the -Prelease profile.