### PR TITLE
chore: add a dedicated javadoc Maven profile

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven and run tests
-      run: mvn -B package --file pom.xml -fae
+      run: mvn -Pjavadoc -B package --file pom.xml -fae
     - name: Upload Test Reports
       if: failure()
       uses: actions/upload-artifact@v4

--- a/pom.xml
+++ b/pom.xml
@@ -456,10 +456,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
@@ -510,6 +506,20 @@
     <profiles>
         <profile>
             <!--
+                 This profile generates the required javadoc.
+            -->
+            <id>javadoc</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!--
                 This profile generates the required sources and javadoc in order to be able to deploy.
                 The central-publishing-maven-plugin generates the required checksums upon deploy.
             -->
@@ -519,6 +529,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Javadoc is not generated by default.
The "Build and Test" GitHub action is run with that profile to validate Javadoc.

This fixes #525
