### PR TITLE
chore: Add a temporary TCK job to run against a 1.0 WIP branch

### DIFF
--- a/.github/workflows/run-tck-1.0-wip.yml
+++ b/.github/workflows/run-tck-1.0-wip.yml
@@ -1,0 +1,175 @@
+name: Run TCK 1.0 (WIP)
+
+on:
+  # Handle all branches for now
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  # TODO this is currently running the TCK off the main branch which included changes needed for 0.4.0
+  # Tag/branch of the TCK
+  TCK_VERSION: spec_1.0
+  # Tell the TCK runner to report failure if the quality tests fail
+  A2A_TCK_FAIL_ON_QUALITY: 1
+  # Tell the TCK runner to report failure if the features tests fail
+  A2A_TCK_FAIL_ON_FEATURES: 1
+  # Tells uv to not need a venv, and instead use system
+  UV_SYSTEM_PYTHON: 1
+  # SUT_JSONRPC_URL to use for the TCK and the server agent
+  SUT_JSONRPC_URL: http://localhost:9999
+  # Slow system on CI
+  TCK_STREAMING_TIMEOUT: 5.0
+
+# Only run the latest job
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  tck-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [17]
+    steps:
+      - name: Checkout a2a-java
+        uses: actions/checkout@v4
+      - name: Checkout a2a-tck
+        uses: actions/checkout@v4
+        with:
+          repository: jmesnil/a2a-tck
+          path: tck/a2a-tck
+          ref: ${{ env.TCK_VERSION }}
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
+          cache: maven
+      - name: check java_home
+        run: echo $JAVA_HOME
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "tck/a2a-tck/pyproject.toml"
+      - name: Install uv and Python dependencies
+        run: |
+          pip install uv
+          uv pip install -e .
+        working-directory: tck/a2a-tck
+      - name: Build with Maven, skipping tests
+        run: mvn -B install -DskipTests
+      - name: Start SUT
+        run: SUT_GRPC_URL=${{ env.SUT_JSONRPC_URL }} SUT_REST_URL=${{ env.SUT_JSONRPC_URL }} mvn -B quarkus:dev & #SUT_JSONRPC_URL already set
+        working-directory: tck
+      - name: Wait for SUT to start
+        run: |
+          URL="${{ env.SUT_JSONRPC_URL }}/.well-known/agent-card.json"
+          EXPECTED_STATUS=200
+          TIMEOUT=120
+          RETRY_INTERVAL=2
+          START_TIME=$(date +%s)
+
+          while true; do
+            # Calculate elapsed time
+            CURRENT_TIME=$(date +%s)
+            ELAPSED_TIME=$((CURRENT_TIME - START_TIME))
+
+            # Check for timeout
+            if [ "$ELAPSED_TIME" -ge "$TIMEOUT" ]; then
+                echo "❌ Timeout: Server did not respond with status $EXPECTED_STATUS within $TIMEOUT seconds."
+                exit 1
+            fi
+
+            # Get HTTP status code. || true is to reporting a failure to connect as an error
+            HTTP_STATUS=$(curl --output /dev/null --silent --write-out "%{http_code}" "$URL") || true
+            echo "STATUS: ${HTTP_STATUS}"
+
+            # Check if we got the correct status code
+            if [ "$HTTP_STATUS" -eq "$EXPECTED_STATUS" ]; then
+                echo "✅ Server is up! Received status $HTTP_STATUS after $ELAPSED_TIME seconds."
+                break;
+            fi
+
+            # Wait before retrying
+            echo "⏳ Server not ready (status: $HTTP_STATUS). Retrying in $RETRY_INTERVAL seconds..."
+            sleep "$RETRY_INTERVAL"
+          done
+          
+      - name: Run TCK (JSONRPC)
+        id: run-tck
+        timeout-minutes: 5
+        run: |
+          ./run_tck.py --sut-url ${{ env.SUT_JSONRPC_URL }} --category all --transports jsonrpc --compliance-report report.json 2>&1 | tee tck-output.log
+        working-directory: tck/a2a-tck
+      - name: Capture Diagnostics on Failure
+        if: failure()
+        run: |
+          echo "=== Capturing diagnostic information ==="
+
+          # Create diagnostics directory
+          mkdir -p tck/target/diagnostics
+
+          # Capture process list
+          echo "📋 Capturing process list..."
+          ps auxww > tck/target/diagnostics/processes.txt
+
+          # Find the actual Quarkus JVM (child of Maven process), not the Maven parent
+          # Look for the dev.jar process which is the actual application
+          QUARKUS_PID=$(pgrep -f "a2a-tck-server-dev.jar" || echo "")
+          if [ -n "$QUARKUS_PID" ]; then
+            echo "📊 Capturing thread dump for Quarkus JVM PID $QUARKUS_PID"
+            jstack $QUARKUS_PID > tck/target/diagnostics/thread-dump.txt || echo "Failed to capture thread dump"
+            if [ -f tck/target/diagnostics/thread-dump.txt ]; then
+              echo "✅ Thread dump captured ($(wc -l < tck/target/diagnostics/thread-dump.txt) lines)"
+            fi
+          else
+            echo "⚠️ No Quarkus JVM process found for thread dump"
+            echo "Available Java processes:"
+            ps aux | grep java | tee -a tck/target/diagnostics/processes.txt || true
+          fi
+
+          # Capture Quarkus application logs (if available)
+          echo "📝 Checking for Quarkus logs..."
+          if [ -f tck/target/quarkus.log ]; then
+            cp tck/target/quarkus.log tck/target/diagnostics/
+            echo "✅ Copied quarkus.log ($(wc -l < tck/target/quarkus.log) lines)"
+          fi
+
+          # Copy TCK server logs
+          if [ -f tck/target/tck-test.log ]; then
+            cp tck/target/tck-test.log tck/target/diagnostics/
+            echo "✅ Copied tck-test.log ($(wc -l < tck/target/tck-test.log) lines)"
+          fi
+
+          echo ""
+          echo "=== Diagnostic capture complete ==="
+      - name: Stop Quarkus Server
+        if: always()
+        run: |
+          # Find and kill the Quarkus process to ensure logs are flushed
+          pkill -f "quarkus:dev" || true
+          sleep 2
+      - name: Upload TCK Diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tck-diagnostics-java-${{ matrix.java-version }}
+          path: |
+            tck/target/diagnostics/
+            tck/a2a-tck/tck-output.log
+          retention-days: 7
+          if-no-files-found: warn
+      - name: Upload TCK Compliance Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tck-compliance-report-java-${{ matrix.java-version }}
+          path: tck/a2a-tck/report.json
+          retention-days: 14
+          if-no-files-found: ignore


### PR DESCRIPTION
This runs the TCK from my WIP 1.0 branch at https://github.com/jmesnil/a2a-tck/tree/spec_1.0

* Runs only with the `jsonrpc` transport 
* Only with Java 17
