### PR TITLE
fix: Sending an invalid message to the server raises an InternalServerError

### DIFF
--- a/http-client/src/main/java/io/a2a/client/http/A2ACardResolver.java
+++ b/http-client/src/main/java/io/a2a/client/http/A2ACardResolver.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import io.a2a.grpc.utils.JSONRPCUtils;
 import io.a2a.grpc.utils.ProtoUtils;
+import io.a2a.json.JsonProcessingException;
 import io.a2a.spec.A2AClientError;
 import io.a2a.spec.A2AClientJSONError;
 import io.a2a.spec.AgentCard;
@@ -105,13 +106,10 @@ public class A2ACardResolver {
 
         try {
             io.a2a.grpc.AgentCard.Builder agentCardBuilder = io.a2a.grpc.AgentCard.newBuilder();
-            JSONRPCUtils.parseJsonString(body, agentCardBuilder);
+            JSONRPCUtils.parseJsonString(body, agentCardBuilder, null);
             return ProtoUtils.FromProto.agentCard(agentCardBuilder);
-        } catch (JSONRPCError e) {
+        } catch (JSONRPCError | JsonProcessingException e) {
             throw new A2AClientJSONError("Could not unmarshal agent card response", e);
         }
-
     }
-
-
 }

--- a/http-client/src/test/java/io/a2a/client/http/A2ACardResolverTest.java
+++ b/http-client/src/test/java/io/a2a/client/http/A2ACardResolverTest.java
@@ -12,6 +12,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import io.a2a.grpc.utils.JSONRPCUtils;
 import io.a2a.grpc.utils.ProtoUtils;
+import io.a2a.json.JsonProcessingException;
 import io.a2a.spec.A2AClientError;
 import io.a2a.spec.A2AClientJSONError;
 import io.a2a.spec.AgentCard;
@@ -79,9 +80,9 @@ public class A2ACardResolverTest {
         assertEquals(expected, requestCardString);
     }
 
-    private AgentCard unmarshalFrom(String body) {
+    private AgentCard unmarshalFrom(String body) throws JsonProcessingException {
         io.a2a.grpc.AgentCard.Builder agentCardBuilder = io.a2a.grpc.AgentCard.newBuilder();
-        JSONRPCUtils.parseJsonString(body, agentCardBuilder);
+        JSONRPCUtils.parseJsonString(body, agentCardBuilder, null);
         return ProtoUtils.FromProto.agentCard(agentCardBuilder);
     }
 

--- a/reference/jsonrpc/src/main/java/io/a2a/server/apps/quarkus/A2AServerRoutes.java
+++ b/reference/jsonrpc/src/main/java/io/a2a/server/apps/quarkus/A2AServerRoutes.java
@@ -6,6 +6,7 @@ import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static jakarta.ws.rs.core.MediaType.SERVER_SENT_EVENTS;
 
+import com.google.gson.JsonSyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +40,7 @@ import io.a2a.spec.GetTaskPushNotificationConfigRequest;
 import io.a2a.spec.GetTaskPushNotificationConfigResponse;
 import io.a2a.spec.GetTaskRequest;
 import io.a2a.spec.GetTaskResponse;
+import io.a2a.spec.IdJsonMappingException;
 import io.a2a.spec.InternalError;
 import io.a2a.spec.InvalidParamsJsonMappingException;
 import io.a2a.spec.JSONParseError;
@@ -113,12 +115,12 @@ public class A2AServerRoutes {
             error = new JSONRPCErrorResponse(e.getId(), new io.a2a.spec.InvalidParamsError(null, e.getMessage(), null));
         } catch (MethodNotFoundJsonMappingException e) {
             error = new JSONRPCErrorResponse(e.getId(), new io.a2a.spec.MethodNotFoundError(null, e.getMessage(), null));
-        } catch (io.a2a.spec.IdJsonMappingException e) {
+        } catch (IdJsonMappingException e) {
             error = new JSONRPCErrorResponse(e.getId(), new io.a2a.spec.InvalidRequestError(null, e.getMessage(), null));
         } catch (JsonMappingException e) {
             // General JsonMappingException - treat as InvalidRequest
             error = new JSONRPCErrorResponse(new io.a2a.spec.InvalidRequestError(null, e.getMessage(), null));
-        } catch (com.google.gson.JsonSyntaxException e) {
+        } catch (JsonSyntaxException e) {
             error = new JSONRPCErrorResponse(new JSONParseError(e.getMessage()));
         } catch (JsonProcessingException e) {
             error = new JSONRPCErrorResponse(new JSONParseError(e.getMessage()));

--- a/spec-grpc/src/main/java/io/a2a/grpc/utils/ProtoUtils.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/utils/ProtoUtils.java
@@ -189,67 +189,75 @@ public class ProtoUtils {
 
     public static class FromProto {
 
+        private static <T> T convert(java.util.function.Supplier<T> s) {
+            try {
+                return s.get();
+            } catch (IllegalArgumentException ex) {
+                throw new InvalidParamsError(ex.getMessage());
+            }
+        }
+
         public static AgentCard agentCard(io.a2a.grpc.AgentCardOrBuilder agentCard) {
             io.a2a.grpc.AgentCard agentCardProto = agentCard instanceof io.a2a.grpc.AgentCard
                     ? (io.a2a.grpc.AgentCard) agentCard
                     : ((io.a2a.grpc.AgentCard.Builder) agentCard).build();
-            return AgentCardMapper.INSTANCE.fromProto(agentCardProto);
+            return convert(() -> AgentCardMapper.INSTANCE.fromProto(agentCardProto));
         }
 
         public static TaskQueryParams taskQueryParams(io.a2a.grpc.GetTaskRequestOrBuilder request) {
             io.a2a.grpc.GetTaskRequest reqProto = request instanceof io.a2a.grpc.GetTaskRequest
                     ? (io.a2a.grpc.GetTaskRequest) request
                     : ((io.a2a.grpc.GetTaskRequest.Builder) request).build();
-            return TaskQueryParamsMapper.INSTANCE.fromProto(reqProto);
+            return convert(() -> TaskQueryParamsMapper.INSTANCE.fromProto(reqProto));
         }
 
         public static ListTasksParams listTasksParams(io.a2a.grpc.ListTasksRequestOrBuilder request) {
             io.a2a.grpc.ListTasksRequest reqProto = request instanceof io.a2a.grpc.ListTasksRequest
                     ? (io.a2a.grpc.ListTasksRequest) request
                     : ((io.a2a.grpc.ListTasksRequest.Builder) request).build();
-            return ListTasksParamsMapper.INSTANCE.fromProto(reqProto);
+            return convert(() -> ListTasksParamsMapper.INSTANCE.fromProto(reqProto));
         }
 
         public static TaskIdParams taskIdParams(io.a2a.grpc.CancelTaskRequestOrBuilder request) {
             io.a2a.grpc.CancelTaskRequest reqProto = request instanceof io.a2a.grpc.CancelTaskRequest
                     ? (io.a2a.grpc.CancelTaskRequest) request
                     : ((io.a2a.grpc.CancelTaskRequest.Builder) request).build();
-            return TaskIdParamsMapper.INSTANCE.fromProtoCancelTaskRequest(reqProto);
+            return convert(() -> TaskIdParamsMapper.INSTANCE.fromProtoCancelTaskRequest(reqProto));
         }
 
         public static MessageSendParams messageSendParams(io.a2a.grpc.SendMessageRequestOrBuilder request) {
             io.a2a.grpc.SendMessageRequest requestProto = request instanceof io.a2a.grpc.SendMessageRequest
                     ? (io.a2a.grpc.SendMessageRequest) request
                     : ((io.a2a.grpc.SendMessageRequest.Builder) request).build();
-            return MessageSendParamsMapper.INSTANCE.fromProto(requestProto);
+            return convert(() -> MessageSendParamsMapper.INSTANCE.fromProto(requestProto));
         }
 
         public static TaskPushNotificationConfig setTaskPushNotificationConfig(io.a2a.grpc.SetTaskPushNotificationConfigRequestOrBuilder config) {
             io.a2a.grpc.SetTaskPushNotificationConfigRequest reqProto = config instanceof io.a2a.grpc.SetTaskPushNotificationConfigRequest
                     ? (io.a2a.grpc.SetTaskPushNotificationConfigRequest) config
                     : ((io.a2a.grpc.SetTaskPushNotificationConfigRequest.Builder) config).build();
-            return SetTaskPushNotificationConfigMapper.INSTANCE.fromProto(reqProto);
+            return convert(() -> SetTaskPushNotificationConfigMapper.INSTANCE.fromProto(reqProto));
         }
 
         public static TaskPushNotificationConfig taskPushNotificationConfig(io.a2a.grpc.TaskPushNotificationConfigOrBuilder config) {
             io.a2a.grpc.TaskPushNotificationConfig proto = config instanceof io.a2a.grpc.TaskPushNotificationConfig
                     ? (io.a2a.grpc.TaskPushNotificationConfig) config
                     : ((io.a2a.grpc.TaskPushNotificationConfig.Builder) config).build();
-            return TaskPushNotificationConfigMapper.INSTANCE.fromProto(proto);
+            return convert(() -> TaskPushNotificationConfigMapper.INSTANCE.fromProto(proto));
         }
 
         public static GetTaskPushNotificationConfigParams getTaskPushNotificationConfigParams(io.a2a.grpc.GetTaskPushNotificationConfigRequestOrBuilder request) {
             io.a2a.grpc.GetTaskPushNotificationConfigRequest reqProto = request instanceof io.a2a.grpc.GetTaskPushNotificationConfigRequest
                     ? (io.a2a.grpc.GetTaskPushNotificationConfigRequest) request
                     : ((io.a2a.grpc.GetTaskPushNotificationConfigRequest.Builder) request).build();
-            return GetTaskPushNotificationConfigParamsMapper.INSTANCE.fromProto(reqProto);
+            return convert(() -> GetTaskPushNotificationConfigParamsMapper.INSTANCE.fromProto(reqProto));
         }
 
         public static TaskIdParams taskIdParams(io.a2a.grpc.SubscribeToTaskRequestOrBuilder request) {
             io.a2a.grpc.SubscribeToTaskRequest reqProto = request instanceof io.a2a.grpc.SubscribeToTaskRequest
                     ? (io.a2a.grpc.SubscribeToTaskRequest) request
                     : ((io.a2a.grpc.SubscribeToTaskRequest.Builder) request).build();
-            return TaskIdParamsMapper.INSTANCE.fromProtoSubscribeToTaskRequest(reqProto);
+            return convert(() -> TaskIdParamsMapper.INSTANCE.fromProtoSubscribeToTaskRequest(reqProto));
         }
 
         public static List<TaskPushNotificationConfig> listTaskPushNotificationConfigParams(io.a2a.grpc.ListTaskPushNotificationConfigResponseOrBuilder response) {
@@ -265,21 +273,21 @@ public class ProtoUtils {
             io.a2a.grpc.ListTaskPushNotificationConfigRequest reqProto = request instanceof io.a2a.grpc.ListTaskPushNotificationConfigRequest
                     ? (io.a2a.grpc.ListTaskPushNotificationConfigRequest) request
                     : ((io.a2a.grpc.ListTaskPushNotificationConfigRequest.Builder) request).build();
-            return ListTaskPushNotificationConfigParamsMapper.INSTANCE.fromProto(reqProto);
+            return convert(() -> ListTaskPushNotificationConfigParamsMapper.INSTANCE.fromProto(reqProto));
         }
 
         public static DeleteTaskPushNotificationConfigParams deleteTaskPushNotificationConfigParams(io.a2a.grpc.DeleteTaskPushNotificationConfigRequestOrBuilder request) {
             io.a2a.grpc.DeleteTaskPushNotificationConfigRequest reqProto = request instanceof io.a2a.grpc.DeleteTaskPushNotificationConfigRequest
                     ? (io.a2a.grpc.DeleteTaskPushNotificationConfigRequest) request
                     : ((io.a2a.grpc.DeleteTaskPushNotificationConfigRequest.Builder) request).build();
-            return DeleteTaskPushNotificationConfigParamsMapper.INSTANCE.fromProto(reqProto);
+            return convert(() -> DeleteTaskPushNotificationConfigParamsMapper.INSTANCE.fromProto(reqProto));
         }
 
         public static Task task(io.a2a.grpc.TaskOrBuilder task) {
             io.a2a.grpc.Task taskProto = task instanceof io.a2a.grpc.Task
                     ? (io.a2a.grpc.Task) task
                     : ((io.a2a.grpc.Task.Builder) task).build();
-            return TaskMapper.INSTANCE.fromProto(taskProto);
+            return convert(() -> TaskMapper.INSTANCE.fromProto(taskProto));
         }
 
         public static Message message(io.a2a.grpc.MessageOrBuilder message) {
@@ -289,35 +297,35 @@ public class ProtoUtils {
             io.a2a.grpc.Message messageProto = message instanceof io.a2a.grpc.Message
                     ? (io.a2a.grpc.Message) message
                     : ((io.a2a.grpc.Message.Builder) message).build();
-            return MessageMapper.INSTANCE.fromProto(messageProto);
+            return convert(() -> MessageMapper.INSTANCE.fromProto(messageProto));
         }
 
         public static TaskStatusUpdateEvent taskStatusUpdateEvent(io.a2a.grpc.TaskStatusUpdateEventOrBuilder taskStatusUpdateEvent) {
             io.a2a.grpc.TaskStatusUpdateEvent eventProto = taskStatusUpdateEvent instanceof io.a2a.grpc.TaskStatusUpdateEvent
                     ? (io.a2a.grpc.TaskStatusUpdateEvent) taskStatusUpdateEvent
                     : ((io.a2a.grpc.TaskStatusUpdateEvent.Builder) taskStatusUpdateEvent).build();
-            return TaskStatusUpdateEventMapper.INSTANCE.fromProto(eventProto);
+            return convert(() -> TaskStatusUpdateEventMapper.INSTANCE.fromProto(eventProto));
         }
 
         public static TaskArtifactUpdateEvent taskArtifactUpdateEvent(io.a2a.grpc.TaskArtifactUpdateEventOrBuilder taskArtifactUpdateEvent) {
             io.a2a.grpc.TaskArtifactUpdateEvent eventProto = taskArtifactUpdateEvent instanceof io.a2a.grpc.TaskArtifactUpdateEvent
                     ? (io.a2a.grpc.TaskArtifactUpdateEvent) taskArtifactUpdateEvent
                     : ((io.a2a.grpc.TaskArtifactUpdateEvent.Builder) taskArtifactUpdateEvent).build();
-            return TaskArtifactUpdateEventMapper.INSTANCE.fromProto(eventProto);
+            return convert(() -> TaskArtifactUpdateEventMapper.INSTANCE.fromProto(eventProto));
         }
 
         public static ListTasksResult listTasksResult(io.a2a.grpc.ListTasksResponseOrBuilder listTasksResponse) {
             io.a2a.grpc.ListTasksResponse eventProto = listTasksResponse instanceof io.a2a.grpc.ListTasksResponse
                     ? (io.a2a.grpc.ListTasksResponse) listTasksResponse
                     : ((io.a2a.grpc.ListTasksResponse.Builder) listTasksResponse).build();
-            return ListTasksResultMapper.INSTANCE.fromProto(eventProto);
+            return convert(() -> ListTasksResultMapper.INSTANCE.fromProto(eventProto));
         }
 
         public static StreamingEventKind streamingEventKind(io.a2a.grpc.StreamResponseOrBuilder streamResponse) {
             io.a2a.grpc.StreamResponse streamResponseProto = streamResponse instanceof io.a2a.grpc.StreamResponse
                     ? (io.a2a.grpc.StreamResponse) streamResponse
                     : ((io.a2a.grpc.StreamResponse.Builder) streamResponse).build();
-            return StreamResponseMapper.INSTANCE.fromProto(streamResponseProto);
+            return convert(() -> StreamResponseMapper.INSTANCE.fromProto(streamResponseProto));
         }
     }
 

--- a/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
@@ -1490,7 +1490,6 @@ public abstract class AbstractA2AServerTest {
                     SendStreamingMessageResponse jsonResponse = extractJsonResponseFromSseLine(line);
                     if (jsonResponse != null) {
                         assertNull(jsonResponse.getError());
-                        System.out.println("#################################### Response " + jsonResponse);
                         Message messageResponse = (Message) jsonResponse.getResult();
                         assertEquals(MESSAGE.getMessageId(), messageResponse.getMessageId());
                         assertEquals(MESSAGE.getRole(), messageResponse.getRole());


### PR DESCRIPTION
* When the json is converted to an Object, internal validation may throw IllegalArgumentException which should be converted in a proper error.

This fixes issue#512

Fixes #512 🦕