### PR TITLE
chore: Update repository path for a2a-tck checkout

### DIFF
--- a/.github/workflows/run-tck-1.0-wip.yml
+++ b/.github/workflows/run-tck-1.0-wip.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout a2a-tck
         uses: actions/checkout@v4
         with:
-          repository: jmesnil/a2a-tck
+          repository: a2aproject/a2a-tck
           path: tck/a2a-tck
           ref: ${{ env.TCK_VERSION }}
       - name: Set up JDK ${{ matrix.java-version }}


### PR DESCRIPTION
We now use https://github.com/a2aproject/a2a-tck/tree/spec_1.0 as the upstream for the TCK
