### PR TITLE
feat: Add tenant parameter to REST push notification config endpoints

### DIFF
--- a/client/base/src/test/java/io/a2a/client/AuthenticationAuthorizationTest.java
+++ b/client/base/src/test/java/io/a2a/client/AuthenticationAuthorizationTest.java
@@ -194,7 +194,7 @@ public class AuthenticationAuthorizationTest {
         server.when(
                 request()
                         .withMethod("POST")
-                        .withPath("/v1/message:send")
+                        .withPath("/message:send")
         ).respond(
                 response()
                         .withStatusCode(401)
@@ -215,7 +215,7 @@ public class AuthenticationAuthorizationTest {
         server.when(
                 request()
                         .withMethod("POST")
-                        .withPath("/v1/message:send")
+                        .withPath("/message:send")
         ).respond(
                 response()
                         .withStatusCode(403)
@@ -236,7 +236,7 @@ public class AuthenticationAuthorizationTest {
         server.when(
                 request()
                         .withMethod("POST")
-                        .withPath("/v1/message:stream")
+                        .withPath("/message:stream")
         ).respond(
                 response()
                         .withStatusCode(401)
@@ -253,7 +253,7 @@ public class AuthenticationAuthorizationTest {
         server.when(
                 request()
                         .withMethod("POST")
-                        .withPath("/v1/message:stream")
+                        .withPath("/message:stream")
         ).respond(
                 response()
                         .withStatusCode(403)

--- a/client/transport/rest/src/test/java/io/a2a/client/transport/rest/RestTransportTest.java
+++ b/client/transport/rest/src/test/java/io/a2a/client/transport/rest/RestTransportTest.java
@@ -117,7 +117,7 @@ public class RestTransportTest {
         this.server.when(
                 request()
                         .withMethod("POST")
-                        .withPath("/v1/message:send")
+                        .withPath("/message:send")
                         .withBody(JsonBody.json(SEND_MESSAGE_TEST_REQUEST, MatchType.ONLY_MATCHING_FIELDS))
         )
                 .respond(
@@ -160,7 +160,7 @@ public class RestTransportTest {
         this.server.when(
                 request()
                         .withMethod("POST")
-                        .withPath("/v1/tasks/de38c76d-d54c-436c-8b9f-4c2703648d64:cancel")
+                        .withPath("/tasks/de38c76d-d54c-436c-8b9f-4c2703648d64:cancel")
                         .withBody(JsonBody.json(CANCEL_TASK_TEST_REQUEST, MatchType.ONLY_MATCHING_FIELDS))
         )
                 .respond(
@@ -186,7 +186,7 @@ public class RestTransportTest {
         this.server.when(
                 request()
                         .withMethod("GET")
-                        .withPath("/v1/tasks/de38c76d-d54c-436c-8b9f-4c2703648d64")
+                        .withPath("/tasks/de38c76d-d54c-436c-8b9f-4c2703648d64")
         )
                 .respond(
                         response()
@@ -238,7 +238,7 @@ public class RestTransportTest {
         this.server.when(
                 request()
                         .withMethod("POST")
-                        .withPath("/v1/message:stream")
+                        .withPath("/message:stream")
                         .withBody(JsonBody.json(SEND_MESSAGE_STREAMING_TEST_REQUEST, MatchType.ONLY_MATCHING_FIELDS))
         )
                 .respond(
@@ -290,7 +290,7 @@ public class RestTransportTest {
         this.server.when(
                 request()
                         .withMethod("POST")
-                        .withPath("/v1/tasks/de38c76d-d54c-436c-8b9f-4c2703648d64/pushNotificationConfigs")
+                        .withPath("/tenant/tasks/de38c76d-d54c-436c-8b9f-4c2703648d64/pushNotificationConfigs")
                         .withBody(JsonBody.json(SET_TASK_PUSH_NOTIFICATION_CONFIG_TEST_REQUEST, MatchType.ONLY_MATCHING_FIELDS))
         )
                 .respond(
@@ -324,7 +324,7 @@ public class RestTransportTest {
         this.server.when(
                 request()
                         .withMethod("GET")
-                        .withPath("/v1/tasks/de38c76d-d54c-436c-8b9f-4c2703648d64/pushNotificationConfigs/10")
+                        .withPath("/tasks/de38c76d-d54c-436c-8b9f-4c2703648d64/pushNotificationConfigs/10")
         )
                 .respond(
                         response()
@@ -351,7 +351,7 @@ public class RestTransportTest {
         this.server.when(
                 request()
                         .withMethod("GET")
-                        .withPath("/v1/tasks/de38c76d-d54c-436c-8b9f-4c2703648d64/pushNotificationConfigs")
+                        .withPath("/tasks/de38c76d-d54c-436c-8b9f-4c2703648d64/pushNotificationConfigs")
         )
                 .respond(
                         response()
@@ -388,7 +388,7 @@ public class RestTransportTest {
         this.server.when(
                 request()
                         .withMethod("DELETE")
-                        .withPath("/v1/tasks/de38c76d-d54c-436c-8b9f-4c2703648d64/pushNotificationConfigs/10")
+                        .withPath("/tasks/de38c76d-d54c-436c-8b9f-4c2703648d64/pushNotificationConfigs/10")
         )
                 .respond(
                         response()
@@ -409,7 +409,7 @@ public class RestTransportTest {
         this.server.when(
                         request()
                                 .withMethod("POST")
-                                .withPath("/v1/tasks/task-1234:subscribe")
+                                .withPath("/tasks/task-1234:subscribe")
                 )
                 .respond(
                         response()

--- a/reference/rest/src/test/java/io/a2a/server/rest/quarkus/A2AServerRoutesTest.java
+++ b/reference/rest/src/test/java/io/a2a/server/rest/quarkus/A2AServerRoutesTest.java
@@ -4,7 +4,6 @@ import static io.a2a.transport.rest.context.RestContextKeys.METHOD_NAME_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -94,7 +93,7 @@ public class A2AServerRoutesTest {
         when(mockHttpResponse.getStatusCode()).thenReturn(200);
         when(mockHttpResponse.getContentType()).thenReturn("application/json");
         when(mockHttpResponse.getBody()).thenReturn("{}");
-        when(mockRestHandler.sendMessage(anyString(), any(ServerCallContext.class))).thenReturn(mockHttpResponse);
+        when(mockRestHandler.sendMessage(anyString(), anyString(), any(ServerCallContext.class))).thenReturn(mockHttpResponse);
 
         ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
 
@@ -102,7 +101,7 @@ public class A2AServerRoutesTest {
         routes.sendMessage("{}", mockRoutingContext);
 
         // Assert
-        verify(mockRestHandler).sendMessage(eq("{}"), contextCaptor.capture());
+        verify(mockRestHandler).sendMessage(eq("{}"), anyString(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
         assertEquals(SendMessageRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
@@ -115,7 +114,7 @@ public class A2AServerRoutesTest {
         when(mockHttpResponse.getStatusCode()).thenReturn(200);
         when(mockHttpResponse.getContentType()).thenReturn("application/json");
         when(mockHttpResponse.getBody()).thenReturn("{}");
-        when(mockRestHandler.sendStreamingMessage(anyString(), any(ServerCallContext.class)))
+        when(mockRestHandler.sendStreamingMessage(anyString(), anyString(), any(ServerCallContext.class)))
                 .thenReturn(mockHttpResponse);
 
         ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
@@ -124,7 +123,7 @@ public class A2AServerRoutesTest {
         routes.sendMessageStreaming("{}", mockRoutingContext);
 
         // Assert
-        verify(mockRestHandler).sendStreamingMessage(eq("{}"), contextCaptor.capture());
+        verify(mockRestHandler).sendStreamingMessage(eq("{}"), anyString(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
         assertEquals(SendStreamingMessageRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
@@ -133,12 +132,12 @@ public class A2AServerRoutesTest {
     @Test
     public void testGetTask_MethodNameSetInContext() {
         // Arrange
-        when(mockRoutingContext.pathParam("id")).thenReturn("task123");
+        when(mockRoutingContext.pathParam("taskId")).thenReturn("task123");
         HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
         when(mockHttpResponse.getStatusCode()).thenReturn(200);
         when(mockHttpResponse.getContentType()).thenReturn("application/json");
         when(mockHttpResponse.getBody()).thenReturn("{test:value}");
-        when(mockRestHandler.getTask(anyString(), anyInt(), any(ServerCallContext.class))).thenReturn(mockHttpResponse);
+        when(mockRestHandler.getTask(anyString(), any(), anyString(), any(ServerCallContext.class))).thenReturn(mockHttpResponse);
 
         ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
 
@@ -146,7 +145,7 @@ public class A2AServerRoutesTest {
         routes.getTask(mockRoutingContext);
 
         // Assert
-        verify(mockRestHandler).getTask(eq("task123"), anyInt(), contextCaptor.capture());
+        verify(mockRestHandler).getTask(eq("task123"), any(), anyString(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
         assertEquals(GetTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
@@ -155,12 +154,12 @@ public class A2AServerRoutesTest {
     @Test
     public void testCancelTask_MethodNameSetInContext() {
         // Arrange
-        when(mockRoutingContext.pathParam("param0")).thenReturn("task123");
+        when(mockRoutingContext.pathParam("taskId")).thenReturn("task123");
         HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
         when(mockHttpResponse.getStatusCode()).thenReturn(200);
         when(mockHttpResponse.getContentType()).thenReturn("application/json");
         when(mockHttpResponse.getBody()).thenReturn("{}");
-        when(mockRestHandler.cancelTask(anyString(), any(ServerCallContext.class))).thenReturn(mockHttpResponse);
+        when(mockRestHandler.cancelTask(anyString(), anyString(), any(ServerCallContext.class))).thenReturn(mockHttpResponse);
 
         ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
 
@@ -168,7 +167,7 @@ public class A2AServerRoutesTest {
         routes.cancelTask(mockRoutingContext);
 
         // Assert
-        verify(mockRestHandler).cancelTask(eq("task123"), contextCaptor.capture());
+        verify(mockRestHandler).cancelTask(eq("task123"), anyString(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
         assertEquals(CancelTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
@@ -177,21 +176,21 @@ public class A2AServerRoutesTest {
     @Test
     public void testResubscribeTask_MethodNameSetInContext() {
         // Arrange
-        when(mockRoutingContext.pathParam("param0")).thenReturn("task123");
+        when(mockRoutingContext.pathParam("taskId")).thenReturn("task123");
         HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
         when(mockHttpResponse.getStatusCode()).thenReturn(200);
         when(mockHttpResponse.getContentType()).thenReturn("application/json");
         when(mockHttpResponse.getBody()).thenReturn("{}");
-        when(mockRestHandler.resubscribeTask(anyString(), any(ServerCallContext.class)))
+        when(mockRestHandler.subscribeToTask(anyString(), anyString(), any(ServerCallContext.class)))
                 .thenReturn(mockHttpResponse);
 
         ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
 
         // Act
-        routes.resubscribeTask(mockRoutingContext);
+        routes.subscribeToTask(mockRoutingContext);
 
         // Assert
-        verify(mockRestHandler).resubscribeTask(eq("task123"), contextCaptor.capture());
+        verify(mockRestHandler).subscribeToTask(eq("task123"), anyString(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
         assertEquals(SubscribeToTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
@@ -200,12 +199,12 @@ public class A2AServerRoutesTest {
     @Test
     public void testSetTaskPushNotificationConfiguration_MethodNameSetInContext() {
         // Arrange
-        when(mockRoutingContext.pathParam("id")).thenReturn("task123");
+        when(mockRoutingContext.pathParam("taskId")).thenReturn("task123");
         HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
         when(mockHttpResponse.getStatusCode()).thenReturn(200);
         when(mockHttpResponse.getContentType()).thenReturn("application/json");
         when(mockHttpResponse.getBody()).thenReturn("{}");
-        when(mockRestHandler.setTaskPushNotificationConfiguration(anyString(), anyString(),
+        when(mockRestHandler.setTaskPushNotificationConfiguration(anyString(), anyString(), anyString(),
                 any(ServerCallContext.class))).thenReturn(mockHttpResponse);
 
         ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
@@ -214,7 +213,7 @@ public class A2AServerRoutesTest {
         routes.setTaskPushNotificationConfiguration("{}", mockRoutingContext);
 
         // Assert
-        verify(mockRestHandler).setTaskPushNotificationConfiguration(eq("task123"), eq("{}"), contextCaptor.capture());
+        verify(mockRestHandler).setTaskPushNotificationConfiguration(eq("task123"), eq("{}"), anyString(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
         assertEquals(SetTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
@@ -223,13 +222,13 @@ public class A2AServerRoutesTest {
     @Test
     public void testGetTaskPushNotificationConfiguration_MethodNameSetInContext() {
         // Arrange
-        when(mockRoutingContext.pathParam("id")).thenReturn("task123");
+        when(mockRoutingContext.pathParam("taskId")).thenReturn("task123");
         when(mockRoutingContext.pathParam("configId")).thenReturn("config456");
         HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
         when(mockHttpResponse.getStatusCode()).thenReturn(200);
         when(mockHttpResponse.getContentType()).thenReturn("application/json");
         when(mockHttpResponse.getBody()).thenReturn("{}");
-        when(mockRestHandler.getTaskPushNotificationConfiguration(anyString(), anyString(),
+        when(mockRestHandler.getTaskPushNotificationConfiguration(anyString(), anyString(), anyString(),
                 any(ServerCallContext.class))).thenReturn(mockHttpResponse);
 
         ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
@@ -238,7 +237,7 @@ public class A2AServerRoutesTest {
         routes.getTaskPushNotificationConfiguration(mockRoutingContext);
 
         // Assert
-        verify(mockRestHandler).getTaskPushNotificationConfiguration(eq("task123"), eq("config456"),
+        verify(mockRestHandler).getTaskPushNotificationConfiguration(eq("task123"), eq("config456"), anyString(),
                 contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
@@ -248,12 +247,12 @@ public class A2AServerRoutesTest {
     @Test
     public void testListTaskPushNotificationConfigurations_MethodNameSetInContext() {
         // Arrange
-        when(mockRoutingContext.pathParam("id")).thenReturn("task123");
+        when(mockRoutingContext.pathParam("taskId")).thenReturn("task123");
         HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
         when(mockHttpResponse.getStatusCode()).thenReturn(200);
         when(mockHttpResponse.getContentType()).thenReturn("application/json");
         when(mockHttpResponse.getBody()).thenReturn("{}");
-        when(mockRestHandler.listTaskPushNotificationConfigurations(anyString(), any(ServerCallContext.class)))
+        when(mockRestHandler.listTaskPushNotificationConfigurations(anyString(), anyString(), any(ServerCallContext.class)))
                 .thenReturn(mockHttpResponse);
 
         ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
@@ -262,7 +261,7 @@ public class A2AServerRoutesTest {
         routes.listTaskPushNotificationConfigurations(mockRoutingContext);
 
         // Assert
-        verify(mockRestHandler).listTaskPushNotificationConfigurations(eq("task123"), contextCaptor.capture());
+        verify(mockRestHandler).listTaskPushNotificationConfigurations(eq("task123"), anyString(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
         assertEquals(ListTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
@@ -271,13 +270,13 @@ public class A2AServerRoutesTest {
     @Test
     public void testDeleteTaskPushNotificationConfiguration_MethodNameSetInContext() {
         // Arrange
-        when(mockRoutingContext.pathParam("id")).thenReturn("task123");
+        when(mockRoutingContext.pathParam("taskId")).thenReturn("task123");
         when(mockRoutingContext.pathParam("configId")).thenReturn("config456");
         HTTPRestResponse mockHttpResponse = mock(HTTPRestResponse.class);
         when(mockHttpResponse.getStatusCode()).thenReturn(200);
         when(mockHttpResponse.getContentType()).thenReturn("application/json");
         when(mockHttpResponse.getBody()).thenReturn("{}");
-        when(mockRestHandler.deleteTaskPushNotificationConfiguration(anyString(), anyString(),
+        when(mockRestHandler.deleteTaskPushNotificationConfiguration(anyString(), anyString(), anyString(),
                 any(ServerCallContext.class))).thenReturn(mockHttpResponse);
 
         ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
@@ -286,7 +285,7 @@ public class A2AServerRoutesTest {
         routes.deleteTaskPushNotificationConfiguration(mockRoutingContext);
 
         // Assert
-        verify(mockRestHandler).deleteTaskPushNotificationConfiguration(eq("task123"), eq("config456"),
+        verify(mockRestHandler).deleteTaskPushNotificationConfiguration(eq("task123"), eq("config456"), anyString(),
                 contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);

--- a/reference/rest/src/test/java/io/a2a/server/rest/quarkus/QuarkusA2ARestTest.java
+++ b/reference/rest/src/test/java/io/a2a/server/rest/quarkus/QuarkusA2ARestTest.java
@@ -35,22 +35,22 @@ public class QuarkusA2ARestTest extends AbstractA2AServerTest {
     protected void configureTransport(ClientBuilder builder) {
         builder.withTransport(RestTransport.class, new RestTransportConfigBuilder());
     }
+
     @Test
     public void testMethodNotFound() throws Exception {
-        
         // Create the client
         HttpClient client = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_2)
                 .build();
         // Create the request
         HttpRequest.Builder builder = HttpRequest.newBuilder()
-                .uri(URI.create("http://localhost:" + serverPort + "/v1/message:send"))
+                .uri(URI.create("http://localhost:" + serverPort + "/message:send"))
                 .PUT(HttpRequest.BodyPublishers.ofString("test"))
                 .header("Content-Type", APPLICATION_JSON);
         HttpResponse<String> response = client.send(builder.build(), HttpResponse.BodyHandlers.ofString());
         Assertions.assertEquals(405, response.statusCode());
         builder = HttpRequest.newBuilder()
-                .uri(URI.create("http://localhost:" + serverPort + "/v1/message:send"))
+                .uri(URI.create("http://localhost:" + serverPort + "/message:send"))
                 .DELETE()
                 .header("Content-Type", APPLICATION_JSON);
         response = client.send(builder.build(), HttpResponse.BodyHandlers.ofString());

--- a/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
@@ -570,7 +570,7 @@ public class DefaultRequestHandler implements RequestHandler {
         }
 
         PushNotificationConfig pushNotificationConfig = pushConfigStore.setInfo(params.taskId(), params.pushNotificationConfig());
-        return new TaskPushNotificationConfig(params.taskId(), pushNotificationConfig, null);
+        return new TaskPushNotificationConfig(params.taskId(), pushNotificationConfig, params.tenant());
     }
 
     @Override
@@ -590,7 +590,7 @@ public class DefaultRequestHandler implements RequestHandler {
         }
 
         @Nullable String configId = params.pushNotificationConfigId();
-        return new TaskPushNotificationConfig(params.id(), getPushNotificationConfig(pushNotificationConfigList, configId), null);
+        return new TaskPushNotificationConfig(params.id(), getPushNotificationConfig(pushNotificationConfigList, configId), params.tenant());
     }
 
     private PushNotificationConfig getPushNotificationConfig(List<PushNotificationConfig> notificationConfigList,
@@ -652,7 +652,7 @@ public class DefaultRequestHandler implements RequestHandler {
         List<TaskPushNotificationConfig> taskPushNotificationConfigList = new ArrayList<>();
         if (pushNotificationConfigList != null) {
             for (PushNotificationConfig pushNotificationConfig : pushNotificationConfigList) {
-                TaskPushNotificationConfig taskPushNotificationConfig = new TaskPushNotificationConfig(params.id(), pushNotificationConfig, null);
+                TaskPushNotificationConfig taskPushNotificationConfig = new TaskPushNotificationConfig(params.id(), pushNotificationConfig, params.tenant());
                 taskPushNotificationConfigList.add(taskPushNotificationConfig);
             }
         }

--- a/spec-grpc/src/main/java/io/a2a/grpc/mapper/DeleteTaskPushNotificationConfigParamsMapper.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/mapper/DeleteTaskPushNotificationConfigParamsMapper.java
@@ -23,6 +23,7 @@ public interface DeleteTaskPushNotificationConfigParamsMapper {
     @BeanMapping(builder = @Builder(buildMethod = "build"))
     @Mapping(target = "id", expression = "java(ResourceNameParser.parseTaskPushNotificationConfigName(proto.getName())[0])")
     @Mapping(target = "pushNotificationConfigId", expression = "java(ResourceNameParser.parseTaskPushNotificationConfigName(proto.getName())[1])")
+    @Mapping(target = "tenant", source = "tenant")
     DeleteTaskPushNotificationConfigParams fromProto(io.a2a.grpc.DeleteTaskPushNotificationConfigRequest proto);
 
     /**

--- a/spec-grpc/src/main/java/io/a2a/grpc/mapper/GetTaskPushNotificationConfigParamsMapper.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/mapper/GetTaskPushNotificationConfigParamsMapper.java
@@ -26,6 +26,7 @@ public interface GetTaskPushNotificationConfigParamsMapper {
     @BeanMapping(builder = @Builder(buildMethod = "build"))
     @Mapping(target = "id", expression = "java(ResourceNameParser.parseGetTaskPushNotificationConfigName(proto.getName())[0])")
     @Mapping(target = "pushNotificationConfigId", expression = "java(ResourceNameParser.parseGetTaskPushNotificationConfigName(proto.getName())[1])")
+    @Mapping(target = "tenant", source = "tenant")
     GetTaskPushNotificationConfigParams fromProto(io.a2a.grpc.GetTaskPushNotificationConfigRequest proto);
 
     /**

--- a/spec-grpc/src/main/java/io/a2a/grpc/mapper/ListTaskPushNotificationConfigParamsMapper.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/mapper/ListTaskPushNotificationConfigParamsMapper.java
@@ -22,6 +22,7 @@ public interface ListTaskPushNotificationConfigParamsMapper {
      */
     @BeanMapping(builder = @Builder(buildMethod = "build"))
     @Mapping(target = "id", expression = "java(ResourceNameParser.extractParentId(proto.getParent()))")
+    @Mapping(target = "tenant", source = "tenant")
     ListTaskPushNotificationConfigParams fromProto(io.a2a.grpc.ListTaskPushNotificationConfigRequest proto);
 
     /**

--- a/spec-grpc/src/main/java/io/a2a/grpc/mapper/TaskIdParamsMapper.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/mapper/TaskIdParamsMapper.java
@@ -39,6 +39,7 @@ public interface TaskIdParamsMapper {
      */
     @BeanMapping(builder = @Builder(buildMethod = "build"))
     @Mapping(target = "id", expression = "java(ResourceNameParser.extractTaskId(proto.getName()))")
+    @Mapping(target = "tenant", source = "tenant")
     TaskIdParams fromProtoSubscribeToTaskRequest(io.a2a.grpc.SubscribeToTaskRequest proto);
 
     /**

--- a/spec-grpc/src/main/java/io/a2a/grpc/mapper/TaskQueryParamsMapper.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/mapper/TaskQueryParamsMapper.java
@@ -28,5 +28,6 @@ public interface TaskQueryParamsMapper {
     @BeanMapping(builder = @Builder(buildMethod = "build"))
     @Mapping(target = "name", expression = "java(ResourceNameParser.defineTaskName(domain.id()))")
     @Mapping(target = "historyLength", source = "historyLength")
+    @Mapping(target = "tenant", source = "tenant")
     io.a2a.grpc.GetTaskRequest toProto(TaskQueryParams domain);
 }

--- a/spec/src/main/java/io/a2a/spec/TaskQueryParams.java
+++ b/spec/src/main/java/io/a2a/spec/TaskQueryParams.java
@@ -19,11 +19,11 @@ public record TaskQueryParams(String id, @Nullable Integer historyLength, String
             throw new IllegalArgumentException("Invalid history length");
         }
     }
-    public TaskQueryParams(String id, Integer historyLength) {
+    public TaskQueryParams(String id, @Nullable Integer historyLength) {
         this(id, historyLength, "");
     }
 
     public TaskQueryParams(String id) {
-        this(id, 0, "");
+        this(id, null, "");
     }
 }

--- a/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -676,13 +676,17 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
 
         TaskPushNotificationConfig taskPushConfig
                 = new TaskPushNotificationConfig(
-                        MINIMAL_TASK.getId(), PushNotificationConfig.builder().url("http://example.com")
-                        .id("c295ea44-7543-4f78-b524-7a38915ad6e4").build(), "tenant");
+                        MINIMAL_TASK.getId(), 
+                        PushNotificationConfig.builder().url("http://example.com")
+                                .id("c295ea44-7543-4f78-b524-7a38915ad6e4").build(), 
+                        "tenant");
         SetTaskPushNotificationConfigRequest request = new SetTaskPushNotificationConfigRequest("1", taskPushConfig);
         SetTaskPushNotificationConfigResponse response = handler.setPushNotificationConfig(request, callContext);
         TaskPushNotificationConfig taskPushConfigResult
-                = new TaskPushNotificationConfig(
-                        MINIMAL_TASK.getId(), PushNotificationConfig.builder().url("http://example.com").id("c295ea44-7543-4f78-b524-7a38915ad6e4").build(), null);
+                = new TaskPushNotificationConfig( MINIMAL_TASK.getId(), 
+                        PushNotificationConfig.builder().url("http://example.com")
+                                .id("c295ea44-7543-4f78-b524-7a38915ad6e4").build(),
+                        "tenant");
 
         Assertions.assertEquals(taskPushConfigResult, response.getResult());
     }
@@ -708,7 +712,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
         GetTaskPushNotificationConfigResponse getResponse = handler.getPushNotificationConfig(getRequest, callContext);
 
         TaskPushNotificationConfig expectedConfig = new TaskPushNotificationConfig(MINIMAL_TASK.getId(),
-                PushNotificationConfig.builder().id("c295ea44-7543-4f78-b524-7a38915ad6e4").url("http://example.com").build(), null);
+                PushNotificationConfig.builder().id("c295ea44-7543-4f78-b524-7a38915ad6e4").url("http://example.com").build(), "");
 
         assertEquals(expectedConfig, getResponse.getResult());
     }
@@ -1350,7 +1354,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
                         MINIMAL_TASK.getId(), PushNotificationConfig.builder()
                         .url("http://example.com")
                         .id(MINIMAL_TASK.getId())
-                        .build(), null);
+                        .build(), "");
         ListTaskPushNotificationConfigRequest listRequest
                 = new ListTaskPushNotificationConfigRequest("111", new ListTaskPushNotificationConfigParams(MINIMAL_TASK.getId()));
         ListTaskPushNotificationConfigResponse listResponse = handler.listPushNotificationConfig(listRequest, callContext);

--- a/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
+++ b/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
@@ -26,13 +26,13 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
         taskStore.save(MINIMAL_TASK);
 
-        RestHandler.HTTPRestResponse response = handler.getTask(MINIMAL_TASK.getId(), 0, callContext);
+        RestHandler.HTTPRestResponse response = handler.getTask(MINIMAL_TASK.getId(), 0, "", callContext);
 
         Assertions.assertEquals(200, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
         Assertions.assertTrue(response.getBody().contains(MINIMAL_TASK.getId()));
 
-        response = handler.getTask(MINIMAL_TASK.getId(),2 , callContext);
+        response = handler.getTask(MINIMAL_TASK.getId(),2 , "",callContext);
 
         Assertions.assertEquals(200, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
@@ -43,7 +43,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
     public void testGetTaskNotFound() {
         RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
 
-        RestHandler.HTTPRestResponse response = handler.getTask("nonexistent", 0, callContext);
+        RestHandler.HTTPRestResponse response = handler.getTask("nonexistent", 0, "",callContext);
 
         Assertions.assertEquals(404, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
@@ -75,7 +75,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
               }
             }""";
 
-        RestHandler.HTTPRestResponse response = handler.sendMessage(requestBody, callContext);
+        RestHandler.HTTPRestResponse response = handler.sendMessage(requestBody, "", callContext);
         Assertions.assertEquals(200, response.getStatusCode(), response.toString());
         Assertions.assertEquals("application/json", response.getContentType());
         Assertions.assertNotNull(response.getBody());
@@ -86,7 +86,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
 
         String invalidBody = "invalid json";
-        RestHandler.HTTPRestResponse response = handler.sendMessage(invalidBody, callContext);
+        RestHandler.HTTPRestResponse response = handler.sendMessage(invalidBody, "", callContext);
 
         Assertions.assertEquals(400, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
@@ -110,7 +110,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
                           }
                       }
                     }""";
-        RestHandler.HTTPRestResponse response = handler.sendMessage(requestBody, callContext);
+        RestHandler.HTTPRestResponse response = handler.sendMessage(requestBody, "", callContext);
 
         Assertions.assertEquals(422, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
@@ -121,7 +121,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
     public void testSendMessageEmptyBody() {
         RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
 
-        RestHandler.HTTPRestResponse response = handler.sendMessage("", callContext);
+        RestHandler.HTTPRestResponse response = handler.sendMessage("", "", callContext);
 
         Assertions.assertEquals(400, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
@@ -142,7 +142,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
             taskUpdater.cancel();
         };
 
-        RestHandler.HTTPRestResponse response = handler.cancelTask(MINIMAL_TASK.getId(), callContext);
+        RestHandler.HTTPRestResponse response = handler.cancelTask(MINIMAL_TASK.getId(), "", callContext);
 
         Assertions.assertEquals(200, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
@@ -153,7 +153,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
     public void testCancelTaskNotFound() {
         RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
 
-        RestHandler.HTTPRestResponse response = handler.cancelTask("nonexistent", callContext);
+        RestHandler.HTTPRestResponse response = handler.cancelTask("nonexistent", "", callContext);
 
         Assertions.assertEquals(404, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
@@ -183,7 +183,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
               }
             }""";
 
-        RestHandler.HTTPRestResponse response = handler.sendStreamingMessage(requestBody, callContext);
+        RestHandler.HTTPRestResponse response = handler.sendStreamingMessage(requestBody, "", callContext);
         Assertions.assertEquals(200, response.getStatusCode(), response.toString());
         Assertions.assertInstanceOf(RestHandler.HTTPRestStreamingResponse.class, response);
         RestHandler.HTTPRestStreamingResponse streamingResponse = (RestHandler.HTTPRestStreamingResponse) response;
@@ -206,7 +206,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
             }
             """;
 
-        RestHandler.HTTPRestResponse response = handler.sendStreamingMessage(requestBody, callContext);
+        RestHandler.HTTPRestResponse response = handler.sendStreamingMessage(requestBody, "", callContext);
 
         Assertions.assertEquals(400, response.getStatusCode());
         Assertions.assertTrue(response.getBody().contains("InvalidRequestError"));
@@ -232,7 +232,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
               }
             }""".formatted(MINIMAL_TASK.getId(), MINIMAL_TASK.getId());
 
-        RestHandler.HTTPRestResponse response = handler.setTaskPushNotificationConfiguration( MINIMAL_TASK.getId(), requestBody, callContext);
+        RestHandler.HTTPRestResponse response = handler.setTaskPushNotificationConfiguration( MINIMAL_TASK.getId(), requestBody, "", callContext);
 
         Assertions.assertEquals(201, response.getStatusCode(), response.toString());
         Assertions.assertEquals("application/json", response.getContentType());
@@ -253,7 +253,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
             }
             """.formatted(MINIMAL_TASK.getId());
 
-        RestHandler.HTTPRestResponse response = handler.setTaskPushNotificationConfiguration(MINIMAL_TASK.getId(), requestBody, callContext);
+        RestHandler.HTTPRestResponse response = handler.setTaskPushNotificationConfiguration(MINIMAL_TASK.getId(), requestBody, "", callContext);
 
         Assertions.assertEquals(501, response.getStatusCode());
         Assertions.assertTrue(response.getBody().contains("PushNotificationNotSupportedError"));
@@ -279,11 +279,11 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
                 }
               }
             }""".formatted(MINIMAL_TASK.getId(), MINIMAL_TASK.getId());
-        RestHandler.HTTPRestResponse response = handler.setTaskPushNotificationConfiguration(MINIMAL_TASK.getId(), createRequestBody, callContext);
+        RestHandler.HTTPRestResponse response = handler.setTaskPushNotificationConfiguration(MINIMAL_TASK.getId(), createRequestBody, "", callContext);
         Assertions.assertEquals(201, response.getStatusCode(), response.toString());
         Assertions.assertEquals("application/json", response.getContentType());
         // Now get it
-        response = handler.getTaskPushNotificationConfiguration(MINIMAL_TASK.getId(), "default-config-id", callContext);
+        response = handler.getTaskPushNotificationConfiguration(MINIMAL_TASK.getId(), "default-config-id", "", callContext);
         Assertions.assertEquals(200, response.getStatusCode(), response.toString());
         Assertions.assertEquals("application/json", response.getContentType());
     }
@@ -292,7 +292,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
     public void testDeletePushNotificationConfig() {
         RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
         taskStore.save(MINIMAL_TASK);
-        RestHandler.HTTPRestResponse response = handler.deleteTaskPushNotificationConfiguration(MINIMAL_TASK.getId(), "default-config-id", callContext);
+        RestHandler.HTTPRestResponse response = handler.deleteTaskPushNotificationConfiguration(MINIMAL_TASK.getId(), "default-config-id", "", callContext);
         Assertions.assertEquals(204, response.getStatusCode());
     }
 
@@ -301,7 +301,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
         taskStore.save(MINIMAL_TASK);
 
-        RestHandler.HTTPRestResponse response = handler.listTaskPushNotificationConfigurations(MINIMAL_TASK.getId(), callContext);
+        RestHandler.HTTPRestResponse response = handler.listTaskPushNotificationConfigurations(MINIMAL_TASK.getId(), "", callContext);
 
         Assertions.assertEquals(200, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
@@ -313,11 +313,11 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
 
         // Test 400 for invalid request
-        RestHandler.HTTPRestResponse response = handler.sendMessage("", callContext);
+        RestHandler.HTTPRestResponse response = handler.sendMessage("", "", callContext);
         Assertions.assertEquals(400, response.getStatusCode());
 
         // Test 404 for not found
-        response = handler.getTask("nonexistent", 0, callContext);
+        response = handler.getTask("nonexistent", 0, "", callContext);
         Assertions.assertEquals(404, response.getStatusCode());
     }
 
@@ -357,7 +357,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
             }""";
 
         // Start streaming
-        RestHandler.HTTPRestResponse response = handler.sendStreamingMessage(requestBody, callContext);
+        RestHandler.HTTPRestResponse response = handler.sendStreamingMessage(requestBody, "", callContext);
 
         Assertions.assertEquals(200, response.getStatusCode());
         Assertions.assertInstanceOf(RestHandler.HTTPRestStreamingResponse.class, response);


### PR DESCRIPTION
- Add tenant parameter to RestHandler.getTaskPushNotificationConfiguration to match other push notification methods
- Add route with trailing slash to distinguish GET (single config) from LIST in A2AServerRoutes
- Update RestTransport to use trailing slash when configId is null
- Update tests to use new method signatures
- Update REST routes to match the new teannt path element
    
    This ensures consistent tenant handling across all push notification endpoints and fixes routing ambiguity between GET and LIST operations.

- [X] Follow the [`CONTRIBUTING` Guide](../CONTRIBUTING.md).
- [C] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
    - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
        - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
        - `feat:` represents a new feature, and correlates to a SemVer minor.
        - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [X Ensure the tests pass
- [X] Appropriate READMEs were updated (if necessary)

Fixes #531 🦕