### PR TITLE
chore: Fix TCK GitHub actions

### DIFF
--- a/.github/workflows/run-tck-1.0-wip.yml
+++ b/.github/workflows/run-tck-1.0-wip.yml
@@ -105,6 +105,7 @@ jobs:
         id: run-tck
         timeout-minutes: 5
         run: |
+          set -o pipefail
           ./run_tck.py --sut-url ${{ env.SUT_JSONRPC_URL }} --category all --transports jsonrpc --compliance-report report.json 2>&1 | tee tck-output.log
         working-directory: tck/a2a-tck
       - name: Capture Diagnostics on Failure

--- a/.github/workflows/run-tck.yml
+++ b/.github/workflows/run-tck.yml
@@ -107,6 +107,7 @@ jobs:
         id: run-tck
         timeout-minutes: 5
         run: |
+          set -o pipefail
           ./run_tck.py --sut-url ${{ env.SUT_JSONRPC_URL }} --category all --transports jsonrpc,grpc,rest --compliance-report report.json 2>&1 | tee tck-output.log
         working-directory: tck/a2a-tck
       - name: Capture Diagnostics on Failure


### PR DESCRIPTION
Make the pipeline fail when the TCK has failure (otherwise, the exit code that is reported is for `tee`).