### PR TITLE
chore: Disable TCK runs for PRs while updating to 1.0.0

### DIFF
--- a/.github/workflows/run-tck-1.0-wip.yml
+++ b/.github/workflows/run-tck-1.0-wip.yml
@@ -5,9 +5,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+  #pull_request:
+  #  branches:
+  #     - main
   workflow_dispatch:
 
 env:

--- a/.github/workflows/run-tck.yml
+++ b/.github/workflows/run-tck.yml
@@ -8,7 +8,8 @@ on:
       - 0.3.x
   pull_request:
     branches:
-      - main
+# Disable TCK runs on main PRs for now, since we are making spec and TCK updates for 1.0.0
+#      - main
       - 0.3.x
   workflow_dispatch:
 


### PR DESCRIPTION
We will still get runs when pushes happen to the main branch