### PR TITLE
feat: Add pluggable A2AHttpClient with Vert.x implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,10 @@ nb-configuration.xml
 /.quarkus/cli/plugins/
 # TLS Certificates
 .certs/
+
+#Apache NetBeans
 nbproject/
+nbactions.xml
 
 # Private Claude config
 .claude/

--- a/boms/extras/pom.xml
+++ b/boms/extras/pom.xml
@@ -36,6 +36,11 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>a2a-java-sdk-http-client-vertx</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>a2a-java-extras-task-store-database-jpa</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/boms/extras/src/it/extras-usage-test/pom.xml
+++ b/boms/extras/src/it/extras-usage-test/pom.xml
@@ -46,6 +46,10 @@
         </dependency>
         <dependency>
             <groupId>io.github.a2asdk</groupId>
+            <artifactId>a2a-java-sdk-http-client-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.a2asdk</groupId>
             <artifactId>a2a-java-extras-task-store-database-jpa</artifactId>
         </dependency>
         <dependency>

--- a/client/base/pom.xml
+++ b/client/base/pom.xml
@@ -24,6 +24,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>a2a-java-sdk-http-client-vertx</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>a2a-java-sdk-client-transport-spi</artifactId>
         </dependency>
         <dependency>

--- a/client/base/src/main/java/io/a2a/A2A.java
+++ b/client/base/src/main/java/io/a2a/A2A.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import io.a2a.client.http.A2ACardResolver;
 import io.a2a.client.http.A2AHttpClient;
-import io.a2a.client.http.JdkA2AHttpClient;
+import io.a2a.client.http.A2AHttpClientFactory;
 import io.a2a.spec.A2AClientError;
 import io.a2a.spec.A2AClientJSONError;
 import io.a2a.spec.AgentCard;
@@ -286,7 +286,7 @@ public class A2A {
      * @see AgentCard
      */
     public static AgentCard getAgentCard(String agentUrl) throws A2AClientError, A2AClientJSONError {
-        return getAgentCard(new JdkA2AHttpClient(), agentUrl);
+        return getAgentCard(A2AHttpClientFactory.create(), agentUrl);
     }
 
     /**
@@ -357,7 +357,7 @@ public class A2A {
      * @throws io.a2a.spec.A2AClientJSONError if the response body cannot be decoded as JSON or validated against the AgentCard schema
      */
     public static AgentCard getAgentCard(String agentUrl, String relativeCardPath, Map<String, String> authHeaders) throws A2AClientError, A2AClientJSONError {
-        return getAgentCard(new JdkA2AHttpClient(), agentUrl, relativeCardPath, authHeaders);
+        return getAgentCard(A2AHttpClientFactory.create(), agentUrl, relativeCardPath, authHeaders);
     }
 
     /**

--- a/client/base/src/test/java/io/a2a/client/ClientBuilderTest.java
+++ b/client/base/src/test/java/io/a2a/client/ClientBuilderTest.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.List;
 
 import io.a2a.client.config.ClientConfig;
-import io.a2a.client.http.JdkA2AHttpClient;
+import io.a2a.client.http.A2AHttpClientFactory;
 import io.a2a.client.transport.grpc.GrpcTransport;
 import io.a2a.client.transport.grpc.GrpcTransportConfigBuilder;
 import io.a2a.client.transport.jsonrpc.JSONRPCTransport;
@@ -89,7 +89,7 @@ public class ClientBuilderTest {
         Client client = Client
                 .builder(card)
                 .withTransport(JSONRPCTransport.class, new JSONRPCTransportConfigBuilder())
-                .withTransport(JSONRPCTransport.class, new JSONRPCTransportConfig(new JdkA2AHttpClient()))
+                .withTransport(JSONRPCTransport.class, new JSONRPCTransportConfig(A2AHttpClientFactory.create()))
                 .build();
 
         Assertions.assertNotNull(client);

--- a/client/transport/jsonrpc/src/main/java/io/a2a/client/transport/jsonrpc/JSONRPCTransport.java
+++ b/client/transport/jsonrpc/src/main/java/io/a2a/client/transport/jsonrpc/JSONRPCTransport.java
@@ -23,8 +23,8 @@ import java.util.function.Consumer;
 import com.google.protobuf.MessageOrBuilder;
 import io.a2a.client.http.A2ACardResolver;
 import io.a2a.client.http.A2AHttpClient;
+import io.a2a.client.http.A2AHttpClientFactory;
 import io.a2a.client.http.A2AHttpResponse;
-import io.a2a.client.http.JdkA2AHttpClient;
 import io.a2a.client.transport.jsonrpc.sse.SSEEventListener;
 import io.a2a.client.transport.spi.ClientTransport;
 import io.a2a.client.transport.spi.interceptors.ClientCallContext;
@@ -84,7 +84,7 @@ public class JSONRPCTransport implements ClientTransport {
 
     public JSONRPCTransport(@Nullable A2AHttpClient httpClient, @Nullable AgentCard agentCard,
                             AgentInterface agentInterface, @Nullable List<ClientCallInterceptor> interceptors) {
-        this.httpClient = httpClient == null ? new JdkA2AHttpClient() : httpClient;
+        this.httpClient = httpClient == null ? A2AHttpClientFactory.create() : httpClient;
         this.agentCard = agentCard;
         this.agentInterface = agentInterface;
         this.interceptors = interceptors;

--- a/client/transport/jsonrpc/src/main/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportConfigBuilder.java
+++ b/client/transport/jsonrpc/src/main/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportConfigBuilder.java
@@ -1,7 +1,7 @@
 package io.a2a.client.transport.jsonrpc;
 
 import io.a2a.client.http.A2AHttpClient;
-import io.a2a.client.http.JdkA2AHttpClient;
+import io.a2a.client.http.A2AHttpClientFactory;
 import io.a2a.client.transport.spi.ClientTransportConfigBuilder;
 import org.jspecify.annotations.Nullable;
 
@@ -11,7 +11,7 @@ import org.jspecify.annotations.Nullable;
  * This builder provides a fluent API for configuring the JSON-RPC transport protocol.
  * All configuration options are optional - if not specified, sensible defaults are used:
  * <ul>
- *   <li><b>HTTP client:</b> {@link JdkA2AHttpClient} (JDK's built-in HTTP client)</li>
+ *   <li><b>HTTP client:</b> Auto-selected via {@link A2AHttpClientFactory} (prefers Vert.x, falls back to JDK)</li>
  *   <li><b>Interceptors:</b> None</li>
  * </ul>
  * <p>
@@ -78,7 +78,7 @@ public class JSONRPCTransportConfigBuilder extends ClientTransportConfigBuilder<
      *   <li>Custom header handling</li>
      * </ul>
      * <p>
-     * If not specified, the default {@link JdkA2AHttpClient} is used.
+     * If not specified, a client is auto-selected via {@link A2AHttpClientFactory}.
      * <p>
      * Example:
      * <pre>{@code
@@ -101,16 +101,16 @@ public class JSONRPCTransportConfigBuilder extends ClientTransportConfigBuilder<
     /**
      * Build the JSON-RPC transport configuration.
      * <p>
-     * If no HTTP client was configured, the default {@link JdkA2AHttpClient} is used.
+     * If no HTTP client was configured, one is auto-selected via {@link A2AHttpClientFactory}.
      * Any configured interceptors are transferred to the configuration.
      *
      * @return the configured JSON-RPC transport configuration
      */
     @Override
     public JSONRPCTransportConfig build() {
-        // No HTTP client provided, fallback to the default one (JDK-based implementation)
+        // No HTTP client provided, use factory to get best available implementation
         if (httpClient == null) {
-            httpClient = new JdkA2AHttpClient();
+            httpClient = A2AHttpClientFactory.create();
         }
 
         JSONRPCTransportConfig config = new JSONRPCTransportConfig(httpClient);

--- a/client/transport/jsonrpc/src/main/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportProvider.java
+++ b/client/transport/jsonrpc/src/main/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportProvider.java
@@ -1,6 +1,6 @@
 package io.a2a.client.transport.jsonrpc;
 
-import io.a2a.client.http.JdkA2AHttpClient;
+import io.a2a.client.http.A2AHttpClientFactory;
 import io.a2a.client.transport.spi.ClientTransportProvider;
 import io.a2a.spec.A2AClientException;
 import io.a2a.spec.AgentCard;
@@ -14,7 +14,7 @@ public class JSONRPCTransportProvider implements ClientTransportProvider<JSONRPC
     public JSONRPCTransport create(@Nullable JSONRPCTransportConfig clientTransportConfig, AgentCard agentCard, AgentInterface agentInterface) throws A2AClientException {
         JSONRPCTransportConfig currentClientTransportConfig = clientTransportConfig;
         if (currentClientTransportConfig == null) {
-            currentClientTransportConfig = new JSONRPCTransportConfig(new JdkA2AHttpClient());
+            currentClientTransportConfig = new JSONRPCTransportConfig(A2AHttpClientFactory.create());
         }
         return new JSONRPCTransport(currentClientTransportConfig.getHttpClient(), agentCard, agentInterface, currentClientTransportConfig.getInterceptors());
     }

--- a/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestTransport.java
+++ b/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestTransport.java
@@ -29,8 +29,8 @@ import com.google.protobuf.MessageOrBuilder;
 import com.google.protobuf.util.JsonFormat;
 import io.a2a.client.http.A2ACardResolver;
 import io.a2a.client.http.A2AHttpClient;
+import io.a2a.client.http.A2AHttpClientFactory;
 import io.a2a.client.http.A2AHttpResponse;
-import io.a2a.client.http.JdkA2AHttpClient;
 import io.a2a.client.transport.rest.sse.RestSSEEventListener;
 import io.a2a.client.transport.spi.ClientTransport;
 import io.a2a.client.transport.spi.interceptors.ClientCallContext;
@@ -74,7 +74,7 @@ public class RestTransport implements ClientTransport {
 
     public RestTransport(@Nullable A2AHttpClient httpClient, AgentCard agentCard,
             AgentInterface agentInterface, @Nullable List<ClientCallInterceptor> interceptors) {
-        this.httpClient = httpClient == null ? new JdkA2AHttpClient() : httpClient;
+        this.httpClient = httpClient == null ? A2AHttpClientFactory.create() : httpClient;
         this.agentCard = agentCard;
         this.agentInterface = agentInterface;
         this.interceptors = interceptors;

--- a/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestTransportConfigBuilder.java
+++ b/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestTransportConfigBuilder.java
@@ -1,7 +1,7 @@
 package io.a2a.client.transport.rest;
 
 import io.a2a.client.http.A2AHttpClient;
-import io.a2a.client.http.JdkA2AHttpClient;
+import io.a2a.client.http.A2AHttpClientFactory;
 import io.a2a.client.transport.spi.ClientTransportConfigBuilder;
 import org.jspecify.annotations.Nullable;
 
@@ -11,7 +11,7 @@ import org.jspecify.annotations.Nullable;
  * This builder provides a fluent API for configuring the REST transport protocol.
  * All configuration options are optional - if not specified, sensible defaults are used:
  * <ul>
- *   <li><b>HTTP client:</b> {@link JdkA2AHttpClient} (JDK's built-in HTTP client)</li>
+ *   <li><b>HTTP client:</b> Auto-selected via {@link A2AHttpClientFactory} (prefers Vert.x, falls back to JDK)</li>
  *   <li><b>Interceptors:</b> None</li>
  * </ul>
  * <p>
@@ -78,7 +78,7 @@ public class RestTransportConfigBuilder extends ClientTransportConfigBuilder<Res
      *   <li>Custom header handling</li>
      * </ul>
      * <p>
-     * If not specified, the default {@link JdkA2AHttpClient} is used.
+     * If not specified, a client is auto-selected via {@link A2AHttpClientFactory}.
      * <p>
      * Example:
      * <pre>{@code
@@ -101,16 +101,16 @@ public class RestTransportConfigBuilder extends ClientTransportConfigBuilder<Res
     /**
      * Build the REST transport configuration.
      * <p>
-     * If no HTTP client was configured, the default {@link JdkA2AHttpClient} is used.
+     * If no HTTP client was configured, one is auto-selected via {@link A2AHttpClientFactory}.
      * Any configured interceptors are transferred to the configuration.
      *
      * @return the configured REST transport configuration
      */
     @Override
     public RestTransportConfig build() {
-        // No HTTP client provided, fallback to the default one (JDK-based implementation)
+        // No HTTP client provided, use factory to get best available implementation
         if (httpClient == null) {
-            httpClient = new JdkA2AHttpClient();
+            httpClient = A2AHttpClientFactory.create();
         }
 
         RestTransportConfig config = new RestTransportConfig(httpClient);

--- a/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestTransportProvider.java
+++ b/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestTransportProvider.java
@@ -1,6 +1,6 @@
 package io.a2a.client.transport.rest;
 
-import io.a2a.client.http.JdkA2AHttpClient;
+import io.a2a.client.http.A2AHttpClientFactory;
 import io.a2a.client.transport.spi.ClientTransportProvider;
 import io.a2a.spec.A2AClientException;
 import io.a2a.spec.AgentCard;
@@ -18,9 +18,9 @@ public class RestTransportProvider implements ClientTransportProvider<RestTransp
     public RestTransport create(RestTransportConfig clientTransportConfig, AgentCard agentCard, AgentInterface agentInterface) throws A2AClientException {
         RestTransportConfig transportConfig = clientTransportConfig;
          if (transportConfig == null) {
-            transportConfig = new RestTransportConfig(new JdkA2AHttpClient());
+            transportConfig = new RestTransportConfig(A2AHttpClientFactory.create());
         }
-        return new RestTransport(clientTransportConfig.getHttpClient(), agentCard, agentInterface, transportConfig.getInterceptors());
+        return new RestTransport(transportConfig.getHttpClient(), agentCard, agentInterface, transportConfig.getInterceptors());
     }
 
     @Override

--- a/extras/README.md
+++ b/extras/README.md
@@ -4,6 +4,16 @@ This directory contains additions to what is provided by the default SDK impleme
 
 Please see the README's of each child directory for more details.
 
-[`task-store-database-jpa`](./task-store-database-jpa/README.md) - Replaces the default `InMemoryTaskStore` with a `TaskStore` backed by a RDBMS. It uses JPA to interact with the RDBMS.
-[`push-notification-config-store-database-jpa`](./push-notification-config-store-database-jpa/README.md) - Replaces the default `InMemoryPushNotificationConfigStore` with a `PushNotificationConfigStore` backed by a RDBMS. It uses JPA to interact with the RDBMS.
-[`queue-manager-replicated`](./queue-manager-replicated/README.md) - Replaces the default `InMemoryQueueManager` with a `QueueManager` supporting replication to other A2A servers implementing the same agent. You can write your own `ReplicationStrategy`, or use the provided `MicroProfile Reactive Messaging implementation`.
+## HTTP Client
+
+[`http-client-vertx`](./http-client-vertx/README.md) - Vert.x WebClient-based implementation of `A2AHttpClient` for reactive, high-performance HTTP communication. Replaces the default JDK HttpClient with a non-blocking, event-loop based client. Uses SPI for automatic discovery - simply add this library as a dependency to use it. Recommended for reactive applications, Quarkus, and high-throughput scenarios.
+
+## Storage & Persistence
+
+[`task-store-database-jpa`](./task-store-database-jpa/README.md) - Replaces the default `InMemoryTaskStore` with a `TaskStore` backed by a RDBMS. It uses JPA to interact with the RDBMS, providing persistence across application restarts and shared state in multi-instance deployments.
+
+[`push-notification-config-store-database-jpa`](./push-notification-config-store-database-jpa/README.md) - Replaces the default `InMemoryPushNotificationConfigStore` with a `PushNotificationConfigStore` backed by a RDBMS. It uses JPA to interact with the RDBMS, ensuring push notification subscriptions survive restarts.
+
+## Distributed Systems
+
+[`queue-manager-replicated`](./queue-manager-replicated/README.md) - Replaces the default `InMemoryQueueManager` with a `QueueManager` supporting replication to other A2A servers implementing the same agent. Required for multi-instance deployments. You can write your own `ReplicationStrategy`, or use the provided MicroProfile Reactive Messaging implementation with Apache Kafka, Pulsar, or AMQP.

--- a/extras/http-client-vertx/README.md
+++ b/extras/http-client-vertx/README.md
@@ -1,0 +1,398 @@
+# A2A Java SDK - Vert.x HTTP Client
+
+This module provides a Vert.x WebClient-based implementation of the `A2AHttpClient` interface for reactive, high-performance HTTP communication in the A2A Java SDK.
+
+## Overview
+
+The A2A SDK uses an `A2AHttpClient` abstraction for all HTTP communication, including fetching agent cards and making REST transport calls. By default, the SDK uses a JDK 11+ HttpClient implementation. This module provides a drop-in replacement using **Vert.x WebClient**, offering:
+
+- **Reactive/Async Architecture**: Built on Vert.x's event loop for non-blocking I/O
+- **Better Performance**: Lower resource usage and higher throughput than blocking JDK HttpClient
+- **HTTP/2 Support**: Automatic HTTP/2 negotiation via ALPN
+- **Seamless Integration**: Automatic discovery via Java SPI - no code changes required
+
+## What It Does
+
+Replaces the default `JdkA2AHttpClient` with `VertxA2AHttpClient`, which uses Vert.x WebClient for all HTTP operations:
+
+- GET requests (synchronous and async SSE streaming)
+- POST requests (synchronous and async SSE streaming)
+- DELETE requests
+- Agent card fetching
+- REST transport communication
+
+The implementation maintains the same API as the JDK client but uses Vert.x's reactive architecture under the hood.
+
+## Problem It Solves
+
+### Performance & Scalability
+- **JDK HttpClient**: Uses platform threads for blocking I/O operations
+- **Vert.x WebClient**: Uses event loop threads with non-blocking I/O
+- **Result**: Lower memory footprint, higher concurrency, better throughput
+
+### Reactive Integration
+- Applications already using Vert.x can share the same event loop
+- Avoids mixing blocking and non-blocking I/O patterns
+- Better integration with reactive frameworks (Quarkus, Vert.x, etc.)
+
+### Resource Efficiency
+- Fewer threads needed for high-concurrency scenarios
+- Better connection pooling and keep-alive management
+- Lower latency for streaming operations (SSE)
+
+## When to Use
+
+✅ **Recommended for:**
+- Quarkus applications (Vert.x is already included)
+- Reactive applications using Vert.x or reactive frameworks
+- High-throughput scenarios with many concurrent requests
+- Applications requiring efficient SSE streaming
+- Cloud-native deployments optimizing for resource usage
+
+❌ **Not needed for:**
+- Simple, low-volume applications
+- Applications without existing Vert.x dependency
+- Environments where JDK HttpClient performs adequately
+
+## Quick Start
+
+### 1. Add Dependency
+
+Add this module to your project's `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>io.github.a2asdk</groupId>
+    <artifactId>a2a-java-sdk-http-client-vertx</artifactId>
+    <version>${a2a.version}</version>
+</dependency>
+```
+
+You also need the Vert.x WebClient dependency (if not already present):
+
+```xml
+<dependency>
+    <groupId>io.vertx</groupId>
+    <artifactId>vertx-web-client</artifactId>
+</dependency>
+```
+
+**For Quarkus**: Vert.x is already included, so you only need to add the `a2a-java-sdk-http-client-vertx` dependency.
+
+### 2. Automatic Discovery (No Code Changes)
+
+The Vert.x HTTP client is automatically discovered via **Java SPI (Service Provider Interface)**:
+
+```java
+// No changes needed - A2A SDK automatically uses VertxA2AHttpClient
+A2ACardResolver resolver = new A2ACardResolver("http://localhost:9999");
+AgentCard card = resolver.getAgentCard(); // Uses Vert.x under the hood
+
+// Client creation also uses Vert.x automatically
+Client client = Client.builder(card)
+    .withTransport(JSONRPCTransport.class, new JSONRPCTransportConfig())
+    .build();
+```
+
+The `VertxA2AHttpClientProvider` has **priority 100**, which is higher than the JDK implementation's priority (50). The SDK's `A2AHttpClientFactory` uses `ServiceLoader` to discover and select the highest-priority provider available.
+
+### 3. No Configuration Required
+
+The module works out-of-the-box with sensible defaults:
+- HTTP keep-alive enabled
+- Automatic redirect following
+- Automatic HTTP/2 negotiation
+
+## Usage Examples
+
+### Basic Usage (Automatic Discovery)
+
+```java
+// The A2A SDK internally uses A2AHttpClient for all HTTP operations
+// With vertx-http-client on the classpath, it automatically uses VertxA2AHttpClient
+
+// Example 1: Fetching agent card
+A2ACardResolver resolver = new A2ACardResolver("http://localhost:9999");
+AgentCard card = resolver.getAgentCard();
+
+// Example 2: Using REST transport (uses HTTP client internally)
+Client client = Client.builder(card)
+    .withTransport(RESTTransport.class, new RESTTransportConfig())
+    .build();
+
+Message message = A2A.toUserMessage("Hello!");
+client.sendMessage(message);
+```
+
+### Direct Usage (Advanced)
+
+If you need direct access to the HTTP client (rare):
+
+```java
+import io.a2a.client.http.A2AHttpClient;
+import io.a2a.client.http.A2AHttpClientFactory;
+import io.a2a.client.http.A2AHttpResponse;
+
+// Get the client via factory (returns VertxA2AHttpClient if available)
+try (A2AHttpClient client = A2AHttpClientFactory.create()) {
+    // Simple GET request
+    A2AHttpResponse response = client.createGet()
+        .url("https://api.example.com/data")
+        .addHeader("Authorization", "Bearer token")
+        .get();
+
+    if (response.success()) {
+        System.out.println(response.body());
+    }
+}
+```
+
+### POST Request with JSON Body
+
+```java
+try (A2AHttpClient client = A2AHttpClientFactory.create()) {
+    A2AHttpResponse response = client.createPost()
+        .url("https://api.example.com/submit")
+        .addHeader("Content-Type", "application/json")
+        .body("{\"key\":\"value\"}")
+        .post();
+
+    System.out.println("Status: " + response.status());
+}
+```
+
+### Server-Sent Events (SSE) Streaming
+
+```java
+try (A2AHttpClient client = A2AHttpClientFactory.create()) {
+    CompletableFuture<Void> future = client.createGet()
+        .url("https://api.example.com/stream")
+        .getAsyncSSE(
+            message -> System.out.println("Received: " + message),
+            error -> error.printStackTrace(),
+            () -> System.out.println("Stream complete")
+        );
+
+    // Do other work while streaming...
+    future.join(); // Wait for completion if needed
+}
+```
+
+## Advanced Configuration
+
+### Using an External Vert.x Instance
+
+In Quarkus or other CDI environments, you can inject an existing Vert.x instance:
+
+#### Quarkus Example
+
+```java
+import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class MyService {
+
+    @Inject
+    Vertx vertx;
+
+    public void doSomething() {
+        // VertxA2AHttpClient will automatically discover and use the CDI-managed Vertx
+        try (A2AHttpClient client = A2AHttpClientFactory.create()) {
+            // The client internally reuses the injected Vertx instance
+            A2AHttpResponse response = client.createGet()
+                .url("https://example.com")
+                .get();
+        }
+    }
+}
+```
+
+The `VertxA2AHttpClient` constructor automatically checks for a CDI-managed `Vertx` instance and reuses it if available. This ensures that your entire application shares the same Vert.x event loop.
+
+#### Manual Vertx Instance (Non-CDI)
+
+If you're not using CDI but want to share a Vert.x instance:
+
+```java
+import io.a2a.client.http.VertxA2AHttpClient;
+import io.vertx.core.Vertx;
+
+// Create Vertx instance once
+Vertx vertx = Vertx.vertx();
+
+try {
+    // Create client with shared Vertx instance
+    try (VertxA2AHttpClient client = new VertxA2AHttpClient(vertx)) {
+        A2AHttpResponse response = client.createGet()
+            .url("https://example.com")
+            .get();
+    }
+    // Client is closed, but Vertx instance remains open
+} finally {
+    // Close Vertx when application shuts down
+    vertx.close();
+}
+```
+
+### Custom WebClient Configuration
+
+For advanced use cases requiring custom Vert.x WebClient configuration, you can create your own provider:
+
+```java
+import io.a2a.client.http.A2AHttpClient;
+import io.a2a.client.http.VertxA2AHttpClient;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+// Create custom Vertx instance with specific options
+Vertx vertx = Vertx.vertx();
+
+// Note: VertxA2AHttpClient doesn't expose WebClient customization directly
+// For custom WebClient options, you would need to extend VertxA2AHttpClient
+// or configure Vert.x-level options
+```
+
+## How It Works
+
+### Service Provider Interface (SPI)
+
+The module uses Java's `ServiceLoader` mechanism for automatic discovery:
+
+1. **Provider Registration**: `META-INF/services/io.a2a.client.http.A2AHttpClientProvider` contains:
+   ```
+   io.a2a.client.http.VertxA2AHttpClientProvider
+   ```
+
+2. **Priority System**: Each provider has a priority:
+   - `VertxA2AHttpClientProvider`: **100** (when Vert.x is available)
+   - `JdkA2AHttpClientProvider`: **50** (always available)
+
+3. **Automatic Selection**: `A2AHttpClientFactory.create()` uses the highest-priority available provider
+
+4. **Graceful Fallback**: If Vert.x classes are not on the classpath, the provider returns priority `-1` and the SDK falls back to JDK HttpClient
+
+### Lifecycle Management
+
+#### Standalone Usage
+```java
+// Client owns Vertx instance
+try (VertxA2AHttpClient client = new VertxA2AHttpClient()) {
+    // Use client
+} // Both WebClient and Vertx are closed
+```
+
+#### CDI/Quarkus Usage
+```java
+// Client uses externally-managed Vertx
+try (VertxA2AHttpClient client = new VertxA2AHttpClient(injectedVertx)) {
+    // Use client
+} // Only WebClient is closed, Vertx remains open
+```
+
+### Thread Safety
+
+- **Client Instance**: Thread-safe - multiple threads can use the same client
+- **Builder Instances**: NOT thread-safe - create separate builders per thread
+- **Vertx Event Loop**: All I/O operations execute on Vert.x event loop threads
+
+## Performance Characteristics
+
+### Synchronous Methods (`.get()`, `.post()`, `.delete()`)
+
+Despite using Vert.x's async API internally, these methods block the calling thread:
+
+```java
+A2AHttpResponse response = client.createGet()
+    .url("https://example.com")
+    .get(); // ← Blocks until response received
+```
+
+**Why block?** The `A2AHttpClient` interface is designed for synchronous operations to simplify SDK usage. Vert.x's async execution still provides benefits:
+- Non-blocking I/O at the network layer
+- Efficient connection pooling
+- Lower thread usage overall
+
+### Async Methods (`.getAsyncSSE()`, `.postAsyncSSE()`)
+
+True async operation - returns immediately with a `CompletableFuture`:
+
+```java
+CompletableFuture<Void> future = client.createGet()
+    .url("https://example.com/stream")
+    .getAsyncSSE(
+        message -> handleMessage(message),
+        error -> handleError(error),
+        () -> handleComplete()
+    ); // ← Returns immediately
+
+// Do other work
+future.join(); // Optional: wait for completion
+```
+
+## Troubleshooting
+
+### Client Not Being Used
+
+**Symptom**: Logs show `JdkA2AHttpClient` instead of `VertxA2AHttpClient`
+
+**Cause**: Vert.x WebClient not on classpath or version incompatibility
+
+**Solution**:
+1. Verify dependency is present:
+   ```bash
+   mvn dependency:tree | grep vertx-web-client
+   ```
+
+2. For Quarkus, ensure Vert.x version matches:
+   ```xml
+   <dependency>
+       <groupId>io.quarkus</groupId>
+       <artifactId>quarkus-vertx</artifactId>
+   </dependency>
+   ```
+
+### ClassNotFoundException for Vert.x
+
+**Symptom**: `ClassNotFoundException: io.vertx.core.Vertx`
+
+**Solution**: Add Vert.x WebClient dependency:
+```xml
+<dependency>
+    <groupId>io.vertx</groupId>
+    <artifactId>vertx-web-client</artifactId>
+    <version>4.x.x</version> <!-- Use version compatible with your framework -->
+</dependency>
+```
+
+### Memory Leaks
+
+**Symptom**: `Vertx` instances not being closed
+
+**Cause**: Not closing `VertxA2AHttpClient` when created with no-args constructor
+
+**Solution**: Always use try-with-resources:
+```java
+try (VertxA2AHttpClient client = new VertxA2AHttpClient()) {
+    // Use client
+} // Automatically closed
+```
+
+## Version Compatibility
+
+- **Java**: 17+ (same as A2A SDK)
+- **Vert.x**: 4.x (tested with 4.5.0+)
+- **Quarkus**: Any version using Vert.x 4.x
+- **Jakarta EE**: 9.0+ (for CDI discovery)
+
+## Additional Resources
+
+- [Vert.x WebClient Documentation](https://vertx.io/docs/vertx-web-client/java/)
+- [A2A Protocol Specification](https://a2a-protocol.org/)
+- [Quarkus Vert.x Guide](https://quarkus.io/guides/vertx)
+
+---
+
+*This module is part of the A2A Java SDK extras and provides production-ready reactive HTTP support for high-performance A2A applications.*

--- a/extras/http-client-vertx/pom.xml
+++ b/extras/http-client-vertx/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.a2asdk</groupId>
+        <artifactId>a2a-java-sdk-parent</artifactId>
+        <version>1.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>a2a-java-sdk-http-client-vertx</artifactId>
+
+    <packaging>jar</packaging>
+
+    <name>Java SDK A2A HTTP Client - Vert.x Implementation</name>
+    <description>Vert.x implementation for A2A HTTP Client</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>a2a-java-sdk-http-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/extras/http-client-vertx/src/main/java/io/a2a/client/http/VertxA2AHttpClient.java
+++ b/extras/http-client-vertx/src/main/java/io/a2a/client/http/VertxA2AHttpClient.java
@@ -1,0 +1,554 @@
+package io.a2a.client.http;
+
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_MULT_CHOICE;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.jspecify.annotations.Nullable;
+
+import io.a2a.common.A2AErrorMessages;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.ext.web.codec.BodyCodec;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.CDI;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Vert.x WebClient-based implementation of {@link A2AHttpClient}.
+ *
+ * <p>
+ * This implementation uses Vert.x's reactive HTTP client to execute requests.
+ * For synchronous methods ({@link GetBuilder#get()}, {@link PostBuilder#post()}, {@link DeleteBuilder#delete()}),
+ * the implementation blocks the calling thread until the asynchronous operation completes.
+ * For SSE streaming methods, the implementation returns immediately with a
+ * {@link CompletableFuture} and streams events asynchronously via callbacks.
+ *
+ * <h2>Lifecycle Management</h2>
+ * <p>
+ * This client implements {@link AutoCloseable} and should be closed when no longer needed:
+ * <pre>{@code
+ * try (VertxA2AHttpClient client = new VertxA2AHttpClient()) {
+ *     A2AHttpResponse response = client.createGet()
+ *         .url("https://example.com/api")
+ *         .get();
+ *     // Use response
+ * }
+ * }</pre>
+ *
+ * <p>
+ * If constructed with the no-args constructor, the client creates and owns a
+ * {@link Vertx} instance which will be closed when {@link #close()} is called.
+ * If constructed with an external {@link Vertx} instance, only the WebClient is
+ * closed, leaving the Vertx instance management to the caller.
+ *
+ * <h2>Thread Safety</h2>
+ * <p>
+ * This client is thread-safe. Multiple threads can create and execute requests
+ * concurrently. However, individual builder instances are NOT thread-safe and should
+ * not be shared across threads.
+ *
+ * <h2>HTTP/2 Support</h2>
+ * <p>
+ * Vert.x WebClient automatically negotiates HTTP/2 when supported by the server
+ * via ALPN. No explicit configuration is required.
+ *
+ * <h2>Usage Examples</h2>
+ *
+ * <h3>Simple GET Request</h3>
+ * <pre>{@code
+ * try (VertxA2AHttpClient client = new VertxA2AHttpClient()) {
+ *     A2AHttpResponse response = client.createGet()
+ *         .url("https://api.example.com/data")
+ *         .addHeader("Authorization", "Bearer token")
+ *         .get();
+ *
+ *     if (response.success()) {
+ *         System.out.println(response.body());
+ *     }
+ * }
+ * }</pre>
+ *
+ * <h3>POST Request with JSON Body</h3>
+ * <pre>{@code
+ * try (VertxA2AHttpClient client = new VertxA2AHttpClient()) {
+ *     A2AHttpResponse response = client.createPost()
+ *         .url("https://api.example.com/submit")
+ *         .addHeader("Content-Type", "application/json")
+ *         .body("{\"key\":\"value\"}")
+ *         .post();
+ *
+ *     System.out.println("Status: " + response.status());
+ * }
+ * }</pre>
+ *
+ * <h3>Async SSE Streaming</h3>
+ * <pre>{@code
+ * try (VertxA2AHttpClient client = new VertxA2AHttpClient()) {
+ *     CompletableFuture<Void> future = client.createGet()
+ *         .url("https://api.example.com/stream")
+ *         .getAsyncSSE(
+ *             message -> System.out.println("Received: " + message),
+ *             error -> error.printStackTrace(),
+ *             () -> System.out.println("Stream complete")
+ *         );
+ *
+ *     // Do other work while streaming...
+ *     future.join(); // Wait for completion if needed
+ * }
+ * }</pre>
+ */
+public class VertxA2AHttpClient implements A2AHttpClient, AutoCloseable {
+
+    private final Vertx vertx;
+    private final WebClient webClient;
+    private boolean ownsVertx;
+    private static final Logger log = Logger.getLogger(VertxA2AHttpClient.class.getName());
+
+    /**
+     * Creates a new VertxA2AHttpClient with an internally managed Vert.x instance.
+     *
+     * <p>
+     * The client creates a new {@link Vertx} instance and {@link WebClient} configured
+     * with HTTP keep-alive and automatic redirect following. When {@link #close()} is called,
+     * both the WebClient and Vertx instance are closed.
+     *
+     * <p>
+     * <strong>Important:</strong> Always call {@link #close()} when done with this client
+     * to prevent resource leaks.
+     *
+     * @see #VertxA2AHttpClient(Vertx) for using an externally managed Vertx instance
+     */
+    public VertxA2AHttpClient() {
+        this.vertx = createVertx();
+        WebClientOptions options = new WebClientOptions()
+                .setFollowRedirects(true)
+                .setKeepAlive(true);
+        this.webClient = WebClient.create(vertx, options);
+       log.fine("Vert.x client is ready.");
+    }
+
+    private Vertx createVertx() {
+        try {
+            BeanManager beanManager = CDI.current().getBeanManager();
+            Set<Bean<?>> beans = beanManager.getBeans(Vertx.class);
+            if (beans != null && !beans.isEmpty()) {
+                this.ownsVertx = false;
+                Bean<?> bean = beans.iterator().next();
+                CreationalContext<?> context = beanManager.createCreationalContext(bean);
+                return (Vertx) beanManager.getReference(bean, Vertx.class, context);
+            }
+        } catch (Exception ex) {
+            log.log(Level.FINE, "Error loading vertx from CDI error details", ex);
+        }
+        this.ownsVertx = true;
+        return Vertx.vertx();
+    }
+
+    /**
+     * Creates a new VertxA2AHttpClient using an externally managed Vert.x instance.
+     *
+     * <p>
+     * The client creates a {@link WebClient} using the provided {@link Vertx} instance.
+     * When {@link #close()} is called, only the WebClient is closed; the Vertx instance
+     * remains open and must be managed by the caller.
+     *
+     * <p>
+     * This constructor is useful in environments where Vert.x is already managed,
+     * such as Quarkus applications.
+     *
+     * @param vertx the Vert.x instance to use; must not be null
+     * @throws NullPointerException if vertx is null
+     */
+    public VertxA2AHttpClient(Vertx vertx) {
+        if (vertx == null) {
+            throw new NullPointerException("vertx must not be null");
+        }
+        this.vertx = vertx;
+        this.ownsVertx = false;
+        WebClientOptions options = new WebClientOptions()
+                .setFollowRedirects(true)
+                .setKeepAlive(true);
+        this.webClient = WebClient.create(vertx, options);
+        log.fine("Vert.x client is ready.");
+    }
+
+    /**
+     * Closes this HTTP client and releases associated resources.
+     *
+     * <p>
+     * This method always closes the WebClient. If the client was created with the
+     * no-args constructor (and thus owns the Vert.x instance), the Vertx instance is
+     * also closed. Otherwise, the Vertx instance is left open for the caller to manage.
+     */
+    @Override
+    public void close() {
+        webClient.close();
+        if (ownsVertx) {
+            vertx.close();
+        }
+    }
+
+    @Override
+    public GetBuilder createGet() {
+        return new VertxGetBuilder();
+    }
+
+    @Override
+    public PostBuilder createPost() {
+        return new VertxPostBuilder();
+    }
+
+    @Override
+    public DeleteBuilder createDelete() {
+        return new VertxDeleteBuilder();
+    }
+
+    private abstract class VertxBuilder<T extends Builder<T>> implements Builder<T> {
+
+        protected String url = "";
+        protected Map<String, String> headers = new HashMap<>();
+
+        @Override
+        public T url(String url) {
+            this.url = url;
+            return self();
+        }
+
+        @Override
+        public T addHeader(String name, String value) {
+            headers.put(name, value);
+            return self();
+        }
+
+        @Override
+        public T addHeaders(Map<String, String> headers) {
+            if (headers != null && !headers.isEmpty()) {
+                for (Map.Entry<String, String> entry : headers.entrySet()) {
+                    addHeader(entry.getKey(), entry.getValue());
+                }
+            }
+            return self();
+        }
+
+        @SuppressWarnings("unchecked")
+        T self() {
+            return (T) this;
+        }
+    }
+
+    /**
+     * Common method to execute synchronous HTTP requests (GET, POST, DELETE).
+     *
+     * @param request the HTTP request configured with method and URL
+     * @param headers custom headers to add to the request
+     * @param bodyBuffer optional body buffer for POST requests (null for GET/DELETE)
+     * @return the HTTP response
+     * @throws IOException if the request fails or returns 401/403
+     * @throws InterruptedException if the thread is interrupted while waiting
+     */
+    private A2AHttpResponse executeSyncRequest(
+            HttpRequest<Buffer> request,
+            Map<String, String> headers,
+            @Nullable Buffer bodyBuffer) throws IOException, InterruptedException {
+
+        // Add headers
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            request.putHeader(entry.getKey(), entry.getValue());
+        }
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<A2AHttpResponse> responseRef = new AtomicReference<>();
+        AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+        // Send with or without body
+        if (bodyBuffer != null) {
+            request.sendBuffer(bodyBuffer, ar -> handleResponse(ar, responseRef, errorRef, latch));
+        } else {
+            request.send(ar -> handleResponse(ar, responseRef, errorRef, latch));
+        }
+
+        latch.await();
+
+        if (errorRef.get() != null) {
+            Throwable error = errorRef.get();
+            if (error instanceof IOException) {
+                throw (IOException) error;
+            } 
+            if (error instanceof InterruptedException) {
+                throw (InterruptedException) error;
+            }
+            throw new IOException("Request failed", error);
+        }
+        A2AHttpResponse finalResponse = responseRef.get();
+        if(finalResponse == null) {
+            throw new IllegalStateException("No response from http request");
+        }
+        return finalResponse;
+    }
+
+    /**
+     * Handles the HTTP response callback, checking for auth errors and populating response/error refs.
+     */
+    private void handleResponse(
+            io.vertx.core.AsyncResult<HttpResponse<Buffer>> ar,
+            AtomicReference<A2AHttpResponse> responseRef,
+            AtomicReference<Throwable> errorRef,
+            CountDownLatch latch) {
+
+        if (ar.succeeded()) {
+            HttpResponse<Buffer> response = ar.result();
+            int status = response.statusCode();
+
+            // Check for authentication/authorization errors
+            switch (status) {
+                case HTTP_UNAUTHORIZED -> errorRef.set(new IOException(A2AErrorMessages.AUTHENTICATION_FAILED));
+                case HTTP_FORBIDDEN -> errorRef.set(new IOException(A2AErrorMessages.AUTHORIZATION_FAILED));
+                default -> {
+                    String body = response.bodyAsString();
+                    responseRef.set(new VertxHttpResponse(status, body != null ? body : ""));
+                }
+            }
+        } else {
+            errorRef.set(ar.cause());
+        }
+        latch.countDown();
+    }
+
+    /**
+     * Common method to execute async SSE requests (GET or POST).
+     *
+     * @param baseRequest the base HTTP request (HttpRequest&lt;Buffer&gt;) configured with method and URL
+     * @param headers custom headers to add to the request
+     * @param bodyBuffer optional body buffer for POST requests (null for GET)
+     * @param messageConsumer callback for each SSE message received
+     * @param errorConsumer callback for errors
+     * @param completeRunnable callback when stream completes successfully
+     * @return CompletableFuture that completes when the stream ends
+     */
+    private CompletableFuture<Void> executeAsyncSSE(
+            HttpRequest<Buffer> baseRequest,
+            Map<String, String> headers,
+            @Nullable Buffer bodyBuffer,
+            Consumer<String> messageConsumer,
+            Consumer<Throwable> errorConsumer,
+            Runnable completeRunnable) {
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        AtomicBoolean successOccurred = new AtomicBoolean(false);
+        AtomicBoolean streamEnded = new AtomicBoolean(false);
+        AtomicBoolean futureCompleted = new AtomicBoolean(false);
+
+        HttpRequest<Void> request = baseRequest
+                .putHeader(ACCEPT, EVENT_STREAM)
+                .as(BodyCodec.sseStream(stream -> {
+                    stream.handler(event -> {
+                        String data = event.data();
+                        if (data != null) {
+                            data = data.trim();
+                            if (!data.isEmpty()) {
+                                messageConsumer.accept(data);
+                            }
+                        }
+                    });
+
+                    stream.endHandler(v -> {
+                        streamEnded.set(true);
+                        // Only complete if we've validated success and haven't completed yet
+                        if (successOccurred.get() && futureCompleted.compareAndSet(false, true)) {
+                            completeRunnable.run();
+                            future.complete(null);
+                        }
+                    });
+
+                    stream.exceptionHandler(error -> {
+                        if (futureCompleted.compareAndSet(false, true)) {
+                            errorConsumer.accept(error);
+                            future.complete(null);
+                        }
+                    });
+                }));
+
+        // Add custom headers
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            request.putHeader(entry.getKey(), entry.getValue());
+        }
+
+        // Send with or without body
+        var sendFuture = (bodyBuffer != null) ? request.sendBuffer(bodyBuffer) : request.send();
+
+        sendFuture
+                .onSuccess(response -> {
+                    // Validate status code manually since .expecting() doesn't work with SSE streams
+                    int statusCode = response.statusCode();
+                    if (statusCode < 200 || statusCode >= 300) {
+                        // Error - don't set successOccurred, just report error
+                        if (futureCompleted.compareAndSet(false, true)) {
+                            // Use same error messages as sync requests for consistency
+                            IOException error = switch (statusCode) {
+                                case HTTP_UNAUTHORIZED -> new IOException(A2AErrorMessages.AUTHENTICATION_FAILED);
+                                case HTTP_FORBIDDEN -> new IOException(A2AErrorMessages.AUTHORIZATION_FAILED);
+                                default -> new IOException("HTTP " + statusCode + ": " + response.bodyAsString());
+                            };
+                            errorConsumer.accept(error);
+                            future.complete(null);
+                        }
+                    } else {
+                        // Success - mark as successful
+                        successOccurred.set(true);
+                        // If stream already ended, complete now
+                        if (streamEnded.get() && futureCompleted.compareAndSet(false, true)) {
+                            completeRunnable.run();
+                            future.complete(null);
+                        }
+                    }
+                })
+                .onFailure(cause -> {
+                    if (futureCompleted.compareAndSet(false, true)) {
+                        errorConsumer.accept(cause);
+                        future.complete(null);
+                    }
+                });
+
+        return future;
+    }
+
+    private class VertxGetBuilder extends VertxBuilder<GetBuilder> implements A2AHttpClient.GetBuilder {
+
+        /**
+         * {@inheritDoc}
+         *
+         * <p>
+         * <strong>Implementation Note:</strong> This method blocks the calling thread until
+         * the asynchronous HTTP request completes. The underlying Vert.x operation executes
+         * asynchronously on the Vert.x event loop.
+         *
+         * @throws IOException if the request fails, including:
+         * <ul>
+         * <li>Network errors (connection refused, timeout, etc.)</li>
+         * <li>HTTP 401 Unauthorized - with message from {@link A2AErrorMessages#AUTHENTICATION_FAILED}</li>
+         * <li>HTTP 403 Forbidden - with message from {@link A2AErrorMessages#AUTHORIZATION_FAILED}</li>
+         * </ul>
+         * @throws InterruptedException if the thread is interrupted while waiting
+         */
+        @Override
+        public A2AHttpResponse get() throws IOException, InterruptedException {
+            return executeSyncRequest(webClient.getAbs(url), headers, null);
+        }
+
+        @Override
+        public CompletableFuture<Void> getAsyncSSE(
+                Consumer<String> messageConsumer,
+                Consumer<Throwable> errorConsumer,
+                Runnable completeRunnable) throws IOException, InterruptedException {
+
+            HttpRequest<Buffer> request = webClient.getAbs(url);
+            return executeAsyncSSE(request, headers, null, messageConsumer, errorConsumer, completeRunnable);
+        }
+    }
+
+    private class VertxPostBuilder extends VertxBuilder<PostBuilder> implements A2AHttpClient.PostBuilder {
+
+        private String body = "";
+
+        @Override
+        public PostBuilder body(String body) {
+            this.body = body;
+            return self();
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * <p>
+         * <strong>Implementation Note:</strong> This method blocks the calling thread until
+         * the asynchronous HTTP request completes. The underlying Vert.x operation executes
+         * asynchronously on the Vert.x event loop.
+         *
+         * @throws IOException if the request fails, including:
+         * <ul>
+         * <li>Network errors (connection refused, timeout, etc.)</li>
+         * <li>HTTP 401 Unauthorized - with message from {@link A2AErrorMessages#AUTHENTICATION_FAILED}</li>
+         * <li>HTTP 403 Forbidden - with message from {@link A2AErrorMessages#AUTHORIZATION_FAILED}</li>
+         * </ul>
+         * @throws InterruptedException if the thread is interrupted while waiting
+         */
+        @Override
+        public A2AHttpResponse post() throws IOException, InterruptedException {
+            Buffer bodyBuffer = Buffer.buffer(body, StandardCharsets.UTF_8.name());
+            return executeSyncRequest(webClient.postAbs(url), headers, bodyBuffer);
+        }
+
+        @Override
+        public CompletableFuture<Void> postAsyncSSE(
+                Consumer<String> messageConsumer,
+                Consumer<Throwable> errorConsumer,
+                Runnable completeRunnable) throws IOException, InterruptedException {
+
+            HttpRequest<Buffer> request = webClient.postAbs(url);
+            Buffer bodyBuffer = Buffer.buffer(body, StandardCharsets.UTF_8.name());
+            return executeAsyncSSE(request, headers, bodyBuffer, messageConsumer, errorConsumer, completeRunnable);
+        }
+    }
+
+    private class VertxDeleteBuilder extends VertxBuilder<DeleteBuilder> implements A2AHttpClient.DeleteBuilder {
+
+        /**
+         * {@inheritDoc}
+         *
+         * <p>
+         * <strong>Implementation Note:</strong> This method blocks the calling thread until
+         * the asynchronous HTTP request completes. The underlying Vert.x operation executes
+         * asynchronously on the Vert.x event loop.
+         *
+         * @throws IOException if the request fails, including:
+         * <ul>
+         * <li>Network errors (connection refused, timeout, etc.)</li>
+         * <li>HTTP 401 Unauthorized - with message from {@link A2AErrorMessages#AUTHENTICATION_FAILED}</li>
+         * <li>HTTP 403 Forbidden - with message from {@link A2AErrorMessages#AUTHORIZATION_FAILED}</li>
+         * </ul>
+         * @throws InterruptedException if the thread is interrupted while waiting
+         */
+        @Override
+        public A2AHttpResponse delete() throws IOException, InterruptedException {
+            return executeSyncRequest(webClient.deleteAbs(url), headers, null);
+        }
+    }
+
+    private record VertxHttpResponse(int status, String body) implements A2AHttpResponse {
+
+        @Override
+        public int status() {
+            return status;
+        }
+
+        @Override
+        public boolean success() {
+            return status >= HTTP_OK && status < HTTP_MULT_CHOICE;
+        }
+
+        @Override
+        public String body() {
+            return body;
+        }
+    }
+}

--- a/extras/http-client-vertx/src/main/java/io/a2a/client/http/VertxA2AHttpClientProvider.java
+++ b/extras/http-client-vertx/src/main/java/io/a2a/client/http/VertxA2AHttpClientProvider.java
@@ -1,0 +1,59 @@
+package io.a2a.client.http;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Service provider for {@link VertxA2AHttpClient}.
+ *
+ * <p>
+ * This provider has a higher priority (100) than the JDK implementation and will be
+ * preferred when the Vert.x dependencies are available on the classpath.
+ *
+ * <p>
+ * If Vert.x classes are not available at runtime, this provider will check for their
+ * presence and throw an {@link IllegalStateException} when attempting to create a client.
+ * The ServiceLoader mechanism will skip this provider and fall back to the JDK implementation.
+ */
+public final class VertxA2AHttpClientProvider implements A2AHttpClientProvider {
+
+    private static final boolean VERTX_AVAILABLE = isVertxAvailable();
+    private static final Logger log = Logger.getLogger(VertxA2AHttpClientProvider.class.getName());
+
+    private static boolean isVertxAvailable() {
+        try {
+            Class.forName("io.vertx.core.Vertx");
+            Class.forName("io.vertx.ext.web.client.WebClient");
+            return true;
+        } catch (ClassNotFoundException ex) {
+            Logger.getLogger(VertxA2AHttpClientProvider.class.getName()).log(Level.FINE, "Vert.x classes are not available on the classpath. Falling back to other providers.", ex);
+            return false;
+        }
+    }
+
+    @Override
+    public A2AHttpClient create() {
+        if (!VERTX_AVAILABLE) {
+            throw new IllegalStateException(
+                    "Vert.x classes are not available on the classpath. "
+                    + "Add io.vertx:vertx-web-client dependency or use the JDK HTTP client implementation.");
+        }
+
+        try {
+            Class<?> clientClass = Class.forName("io.a2a.client.http.VertxA2AHttpClient");
+            return (A2AHttpClient) clientClass.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to create VertxA2AHttpClient instance", e);
+        }
+    }
+
+    @Override
+    public int priority() {
+        return VERTX_AVAILABLE ? 100 : -1; // Higher priority when available, negative when not
+    }
+
+    @Override
+    public String name() {
+        return "vertx";
+    }
+}

--- a/extras/http-client-vertx/src/main/resources/META-INF/services/io.a2a.client.http.A2AHttpClientProvider
+++ b/extras/http-client-vertx/src/main/resources/META-INF/services/io.a2a.client.http.A2AHttpClientProvider
@@ -1,0 +1,1 @@
+io.a2a.client.http.VertxA2AHttpClientProvider

--- a/extras/http-client-vertx/src/test/java/io/a2a/client/http/VertxA2AHttpClientFactoryTest.java
+++ b/extras/http-client-vertx/src/test/java/io/a2a/client/http/VertxA2AHttpClientFactoryTest.java
@@ -1,0 +1,66 @@
+package io.a2a.client.http;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class VertxA2AHttpClientFactoryTest {
+
+    @Test
+    public void testCreateReturnsVertxClient() {
+        // When both JDK and Vertx are on classpath, Vertx should be preferred due to higher priority
+        A2AHttpClient client = A2AHttpClientFactory.create();
+        assertNotNull(client);
+        assertInstanceOf(VertxA2AHttpClient.class, client,
+            "Factory should return VertxA2AHttpClient when Vertx is available");
+        // Clean up
+        if (client instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) client).close();
+            } catch (Exception e) {
+                fail("Failed to close client: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testCreateWithVertxProviderName() {
+        A2AHttpClient client = A2AHttpClientFactory.create("vertx");
+        assertNotNull(client);
+        assertInstanceOf(VertxA2AHttpClient.class, client,
+            "Factory should return VertxA2AHttpClient when 'vertx' provider is requested");
+        // Clean up
+        if (client instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) client).close();
+            } catch (Exception e) {
+                fail("Failed to close client: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testVertxClientIsUsable() {
+        A2AHttpClient client = A2AHttpClientFactory.create("vertx");
+        assertNotNull(client);
+
+        // Verify we can create builders
+        A2AHttpClient.GetBuilder getBuilder = client.createGet();
+        assertNotNull(getBuilder, "Should be able to create GET builder");
+
+        A2AHttpClient.PostBuilder postBuilder = client.createPost();
+        assertNotNull(postBuilder, "Should be able to create POST builder");
+
+        A2AHttpClient.DeleteBuilder deleteBuilder = client.createDelete();
+        assertNotNull(deleteBuilder, "Should be able to create DELETE builder");
+
+        // Clean up
+        if (client instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) client).close();
+            } catch (Exception e) {
+                fail("Failed to close client: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/extras/http-client-vertx/src/test/java/io/a2a/client/http/VertxA2AHttpClientIntegrationTest.java
+++ b/extras/http-client-vertx/src/test/java/io/a2a/client/http/VertxA2AHttpClientIntegrationTest.java
@@ -1,0 +1,212 @@
+package io.a2a.client.http;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import io.a2a.common.A2AErrorMessages;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockserver.integration.ClientAndServer;
+
+public class VertxA2AHttpClientIntegrationTest {
+
+    private ClientAndServer mockServer;
+    private VertxA2AHttpClient client;
+
+    @BeforeEach
+    public void setup() {
+        mockServer = ClientAndServer.startClientAndServer(0);  // Use random port
+        client = new VertxA2AHttpClient();
+    }
+
+    @AfterEach
+    public void teardown() {
+        if (client != null) {
+            client.close();
+        }
+        if (mockServer != null) {
+            mockServer.stop();
+        }
+    }
+
+    private String getBaseUrl() {
+        return "http://localhost:" + mockServer.getPort();
+    }
+
+    @Test
+    public void testGetRequestSuccess() throws Exception {
+        mockServer
+                .when(request().withMethod("GET").withPath("/test"))
+                .respond(response().withStatusCode(200).withBody("success"));
+
+        A2AHttpResponse response = client.createGet()
+                .url(getBaseUrl() + "/test")
+                .get();
+
+        assertEquals(200, response.status());
+        assertTrue(response.success());
+        assertEquals("success", response.body());
+    }
+
+    @Test
+    public void testPostRequestSuccess() throws Exception {
+        mockServer
+                .when(request()
+                        .withMethod("POST")
+                        .withPath("/test")
+                        .withBody("{\"key\":\"value\"}"))
+                .respond(response().withStatusCode(201).withBody("created"));
+
+        A2AHttpResponse response = client.createPost()
+                .url(getBaseUrl() + "/test")
+                .body("{\"key\":\"value\"}")
+                .post();
+
+        assertEquals(201, response.status());
+        assertTrue(response.success());
+        assertEquals("created", response.body());
+    }
+
+    @Test
+    public void testDeleteRequestSuccess() throws Exception {
+        mockServer
+                .when(request().withMethod("DELETE").withPath("/test"))
+                .respond(response().withStatusCode(204));
+
+        A2AHttpResponse response = client.createDelete()
+                .url(getBaseUrl() + "/test")
+                .delete();
+
+        assertEquals(204, response.status());
+        assertTrue(response.success());
+    }
+
+    @Test
+    public void test401AuthenticationErrorOnGet() throws Exception {
+        mockServer
+                .when(request().withMethod("GET").withPath("/test"))
+                .respond(response().withStatusCode(401));
+
+        Exception exception = assertThrows(java.io.IOException.class, () -> {
+            client.createGet()
+                    .url(getBaseUrl() + "/test")
+                    .get();
+        });
+
+        assertEquals(A2AErrorMessages.AUTHENTICATION_FAILED, exception.getMessage());
+    }
+
+    @Test
+    public void test403AuthorizationErrorOnGet() throws Exception {
+        mockServer
+                .when(request().withMethod("GET").withPath("/test"))
+                .respond(response().withStatusCode(403));
+
+        Exception exception = assertThrows(java.io.IOException.class, () -> {
+            client.createGet()
+                    .url(getBaseUrl() + "/test")
+                    .get();
+        });
+
+        assertEquals(A2AErrorMessages.AUTHORIZATION_FAILED, exception.getMessage());
+    }
+
+    @Test
+    public void test401AuthenticationErrorOnPost() throws Exception {
+        mockServer
+                .when(request().withMethod("POST").withPath("/test"))
+                .respond(response().withStatusCode(401));
+
+        Exception exception = assertThrows(java.io.IOException.class, () -> {
+            client.createPost()
+                    .url(getBaseUrl() + "/test")
+                    .body("{}")
+                    .post();
+        });
+
+        assertEquals(A2AErrorMessages.AUTHENTICATION_FAILED, exception.getMessage());
+    }
+
+    @Test
+    public void test403AuthorizationErrorOnPost() throws Exception {
+        mockServer
+                .when(request().withMethod("POST").withPath("/test"))
+                .respond(response().withStatusCode(403));
+
+        Exception exception = assertThrows(java.io.IOException.class, () -> {
+            client.createPost()
+                    .url(getBaseUrl() + "/test")
+                    .body("{}")
+                    .post();
+        });
+
+        assertEquals(A2AErrorMessages.AUTHORIZATION_FAILED, exception.getMessage());
+    }
+
+    @Test
+    public void test401AuthenticationErrorOnDelete() throws Exception {
+        mockServer
+                .when(request().withMethod("DELETE").withPath("/test"))
+                .respond(response().withStatusCode(401));
+
+        Exception exception = assertThrows(java.io.IOException.class, () -> {
+            client.createDelete()
+                    .url(getBaseUrl() + "/test")
+                    .delete();
+        });
+
+        assertEquals(A2AErrorMessages.AUTHENTICATION_FAILED, exception.getMessage());
+    }
+
+    @Test
+    public void testHeaderPropagation() throws Exception {
+        mockServer
+                .when(request()
+                        .withMethod("GET")
+                        .withPath("/test")
+                        .withHeader("Authorization", "Bearer token")
+                        .withHeader("X-Custom-Header", "custom-value"))
+                .respond(response().withStatusCode(200).withBody("ok"));
+
+        A2AHttpResponse response = client.createGet()
+                .url(getBaseUrl() + "/test")
+                .addHeader("Authorization", "Bearer token")
+                .addHeader("X-Custom-Header", "custom-value")
+                .get();
+
+        assertEquals(200, response.status());
+        assertEquals("ok", response.body());
+    }
+
+    @Test
+    public void testNonSuccessStatusCode() throws Exception {
+        mockServer
+                .when(request().withMethod("GET").withPath("/test"))
+                .respond(response().withStatusCode(500).withBody("Internal Server Error"));
+
+        A2AHttpResponse response = client.createGet()
+                .url(getBaseUrl() + "/test")
+                .get();
+
+        assertEquals(500, response.status());
+        assertFalse(response.success());
+        assertEquals("Internal Server Error", response.body());
+    }
+
+    @Test
+    public void test404NotFound() throws Exception {
+        mockServer
+                .when(request().withMethod("GET").withPath("/test"))
+                .respond(response().withStatusCode(404).withBody("Not Found"));
+
+        A2AHttpResponse response = client.createGet()
+                .url(getBaseUrl() + "/test")
+                .get();
+
+        assertEquals(404, response.status());
+        assertFalse(response.success());
+        assertEquals("Not Found", response.body());
+    }
+}

--- a/extras/http-client-vertx/src/test/java/io/a2a/client/http/VertxA2AHttpClientSSETest.java
+++ b/extras/http-client-vertx/src/test/java/io/a2a/client/http/VertxA2AHttpClientSSETest.java
@@ -1,0 +1,253 @@
+package io.a2a.client.http;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import io.a2a.common.A2AErrorMessages;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockserver.integration.ClientAndServer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class VertxA2AHttpClientSSETest {
+
+    private ClientAndServer mockServer;
+    private VertxA2AHttpClient client;
+
+    @BeforeEach
+    public void setup() {
+        mockServer = ClientAndServer.startClientAndServer(0);  // Use random port
+        client = new VertxA2AHttpClient();
+    }
+
+    @AfterEach
+    public void teardown() {
+        if (client != null) {
+            client.close();
+        }
+        if (mockServer != null) {
+            mockServer.stop();
+        }
+    }
+
+    private String getBaseUrl() {
+        return "http://localhost:" + mockServer.getPort();
+    }
+
+    @Test
+    public void testGetAsyncSSE() throws Exception {
+        mockServer
+                .when(request().withMethod("GET").withPath("/sse"))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withHeader("Content-Type", "text/event-stream")
+                        .withBody("data: event1\n\ndata: event2\n\ndata: event3\n\n"));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        List<String> events = new ArrayList<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        CompletableFuture<Void> future = client.createGet()
+                .url(getBaseUrl() + "/sse")
+                .getAsyncSSE(
+                        events::add,
+                        error::set,
+                        latch::countDown
+                );
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "Expected completion handler to be called");
+        assertNull(error.get(), "Expected no errors");
+        assertFalse(events.isEmpty(), "Expected to receive events");
+        assertTrue(events.contains("event1"), "Expected event1");
+        assertTrue(events.contains("event2"), "Expected event2");
+        assertTrue(events.contains("event3"), "Expected event3");
+    }
+
+    @Test
+    public void testPostAsyncSSE() throws Exception {
+        mockServer
+                .when(request()
+                        .withMethod("POST")
+                        .withPath("/sse")
+                        .withBody("{\"subscribe\":true}"))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withHeader("Content-Type", "text/event-stream")
+                        .withBody("data: message1\n\ndata: message2\n\n"));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        List<String> events = new ArrayList<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        CompletableFuture<Void> future = client.createPost()
+                .url(getBaseUrl() + "/sse")
+                .body("{\"subscribe\":true}")
+                .postAsyncSSE(
+                        events::add,
+                        error::set,
+                        latch::countDown
+                );
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "Expected completion handler to be called");
+        assertNull(error.get(), "Expected no errors");
+        assertFalse(events.isEmpty(), "Expected to receive events");
+        assertTrue(events.contains("message1"), "Expected message1");
+        assertTrue(events.contains("message2"), "Expected message2");
+    }
+
+    @Test
+    public void testSSEDataPrefixStripping() throws Exception {
+        mockServer
+                .when(request().withMethod("GET").withPath("/sse"))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withHeader("Content-Type", "text/event-stream")
+                        .withBody("data: content here\n\ndata:no space\n\ndata:  extra spaces  \n\n"));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        List<String> events = new ArrayList<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        CompletableFuture<Void> future = client.createGet()
+                .url(getBaseUrl() + "/sse")
+                .getAsyncSSE(
+                        events::add,
+                        error::set,
+                        latch::countDown
+                );
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertTrue(events.contains("content here"), "Should have stripped 'data: ' prefix");
+        assertTrue(events.contains("no space"), "Should handle 'data:' without space");
+        assertTrue(events.contains("extra spaces"), "Should trim whitespace");
+    }
+
+    @Test
+    public void testSSEAuthenticationError() throws Exception {
+        mockServer
+                .when(request().withMethod("GET").withPath("/sse"))
+                .respond(response().withStatusCode(401));
+
+        CountDownLatch errorLatch = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        AtomicBoolean completed = new AtomicBoolean(false);
+
+        CompletableFuture<Void> future = client.createGet()
+                .url(getBaseUrl() + "/sse")
+                .getAsyncSSE(
+                        msg -> {},
+                        e -> {
+                            error.set(e);
+                            errorLatch.countDown();
+                        },
+                        () -> completed.set(true)
+                );
+
+        assertTrue(errorLatch.await(5, TimeUnit.SECONDS), "Expected error handler to be called");
+        assertNotNull(error.get(), "Expected an error");
+        assertTrue(error.get() instanceof IOException, "Expected IOException");
+        assertTrue(error.get().getMessage().contains("Authentication failed"),
+            "Expected authentication error message but got: " + error.get().getMessage());
+        assertFalse(completed.get(), "Should not call completion handler on error");
+    }
+
+    @Test
+    public void testSSEAuthorizationError() throws Exception {
+        mockServer
+                .when(request().withMethod("GET").withPath("/sse"))
+                .respond(response().withStatusCode(403));
+
+        CountDownLatch errorLatch = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        AtomicBoolean completed = new AtomicBoolean(false);
+
+        CompletableFuture<Void> future = client.createGet()
+                .url(getBaseUrl() + "/sse")
+                .getAsyncSSE(
+                        msg -> {},
+                        e -> {
+                            error.set(e);
+                            errorLatch.countDown();
+                        },
+                        () -> completed.set(true)
+                );
+
+        assertTrue(errorLatch.await(5, TimeUnit.SECONDS), "Expected error handler to be called");
+        assertNotNull(error.get(), "Expected an error");
+        assertTrue(error.get() instanceof IOException, "Expected IOException");
+        assertTrue(error.get().getMessage().contains("Authorization failed"),
+            "Expected authorization error message but got: " + error.get().getMessage());
+        assertFalse(completed.get(), "Should not call completion handler on error");
+    }
+
+    @Test
+    public void testSSEEmptyLinesIgnored() throws Exception {
+        mockServer
+                .when(request().withMethod("GET").withPath("/sse"))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withHeader("Content-Type", "text/event-stream")
+                        .withBody("data: first\n\n\n\ndata: second\n\ndata: \n\ndata: third\n\n"));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        List<String> events = new ArrayList<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        CompletableFuture<Void> future = client.createGet()
+                .url(getBaseUrl() + "/sse")
+                .getAsyncSSE(
+                        events::add,
+                        error::set,
+                        latch::countDown
+                );
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(3, events.size(), "Should have received 3 non-empty events");
+        assertTrue(events.contains("first"));
+        assertTrue(events.contains("second"));
+        assertTrue(events.contains("third"));
+    }
+
+    @Test
+    public void testSSEHeaderPropagation() throws Exception {
+        mockServer
+                .when(request()
+                        .withMethod("GET")
+                        .withPath("/sse")
+                        .withHeader("Accept", "text/event-stream")
+                        .withHeader("Authorization", "Bearer token"))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withHeader("Content-Type", "text/event-stream")
+                        .withBody("data: authenticated\n\n"));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        List<String> events = new ArrayList<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        CompletableFuture<Void> future = client.createGet()
+                .url(getBaseUrl() + "/sse")
+                .addHeader("Authorization", "Bearer token")
+                .getAsyncSSE(
+                        events::add,
+                        error::set,
+                        latch::countDown
+                );
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertTrue(events.contains("authenticated"));
+    }
+}

--- a/extras/http-client-vertx/src/test/java/io/a2a/client/http/VertxA2AHttpClientTest.java
+++ b/extras/http-client-vertx/src/test/java/io/a2a/client/http/VertxA2AHttpClientTest.java
@@ -1,0 +1,94 @@
+package io.a2a.client.http;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.Test;
+
+public class VertxA2AHttpClientTest {
+
+    @Test
+    public void testNoArgsConstructor() {
+        VertxA2AHttpClient client = new VertxA2AHttpClient();
+        assertNotNull(client);
+        client.close();
+    }
+
+    @Test
+    public void testVertxParameterConstructor() {
+        Vertx vertx = Vertx.vertx();
+        VertxA2AHttpClient client = new VertxA2AHttpClient(vertx);
+        assertNotNull(client);
+        client.close();
+        vertx.close();
+    }
+
+    @Test
+    public void testVertxParameterConstructorNullThrows() {
+        assertThrows(NullPointerException.class, () -> {
+            new VertxA2AHttpClient(null);
+        });
+    }
+
+    @Test
+    public void testCreateGet() {
+        try (VertxA2AHttpClient client = new VertxA2AHttpClient()) {
+            A2AHttpClient.GetBuilder builder = client.createGet();
+            assertNotNull(builder);
+        }
+    }
+
+    @Test
+    public void testCreatePost() {
+        try (VertxA2AHttpClient client = new VertxA2AHttpClient()) {
+            A2AHttpClient.PostBuilder builder = client.createPost();
+            assertNotNull(builder);
+        }
+    }
+
+    @Test
+    public void testCreateDelete() {
+        try (VertxA2AHttpClient client = new VertxA2AHttpClient()) {
+            A2AHttpClient.DeleteBuilder builder = client.createDelete();
+            assertNotNull(builder);
+        }
+    }
+
+    @Test
+    public void testBuilderUrlSetting() {
+        try (VertxA2AHttpClient client = new VertxA2AHttpClient()) {
+            A2AHttpClient.GetBuilder builder = client.createGet();
+            A2AHttpClient.GetBuilder result = builder.url("https://example.com");
+            assertSame(builder, result, "Builder should return itself for method chaining");
+        }
+    }
+
+    @Test
+    public void testBuilderHeaderSetting() {
+        try (VertxA2AHttpClient client = new VertxA2AHttpClient()) {
+            A2AHttpClient.GetBuilder builder = client.createGet();
+            A2AHttpClient.GetBuilder result = builder.addHeader("Accept", "application/json");
+            assertSame(builder, result, "Builder should return itself for method chaining");
+        }
+    }
+
+    @Test
+    public void testBuilderMethodChaining() {
+        try (VertxA2AHttpClient client = new VertxA2AHttpClient()) {
+            A2AHttpClient.GetBuilder builder = client.createGet()
+                    .url("https://example.com")
+                    .addHeader("Accept", "application/json")
+                    .addHeader("Authorization", "Bearer token");
+            assertNotNull(builder);
+        }
+    }
+
+    @Test
+    public void testPostBuilderBody() {
+        try (VertxA2AHttpClient client = new VertxA2AHttpClient()) {
+            A2AHttpClient.PostBuilder builder = client.createPost();
+            A2AHttpClient.PostBuilder result = builder.body("{\"key\":\"value\"}");
+            assertSame(builder, result, "Builder should return itself for method chaining");
+        }
+    }
+}

--- a/http-client/src/main/java/io/a2a/client/http/A2ACardResolver.java
+++ b/http-client/src/main/java/io/a2a/client/http/A2ACardResolver.java
@@ -27,18 +27,18 @@ public class A2ACardResolver {
     private static final String DEFAULT_AGENT_CARD_PATH = "/.well-known/agent-card.json";
 
     /**
-     * Get the agent card for an A2A agent. The {@code JdkA2AHttpClient} will be used to fetch the agent card.
+     * Get the agent card for an A2A agent. An HTTP client will be auto-selected via {@link A2AHttpClientFactory}.
      *
      * @param baseUrl the base URL for the agent whose agent card we want to retrieve, must not be null
      * @throws A2AClientError if the URL for the agent is invalid
      * @throws IllegalArgumentException if baseUrl is null
      */
     public A2ACardResolver(String baseUrl) throws A2AClientError {
-        this(new JdkA2AHttpClient(), baseUrl, null, null);
+        this(A2AHttpClientFactory.create(), baseUrl, null, null);
     }
 
     /**
-     * Get the agent card for an A2A agent. The {@code JdkA2AHttpClient} will be used to fetch the agent card.
+     * Get the agent card for an A2A agent. An HTTP client will be auto-selected via {@link A2AHttpClientFactory}.
      *
      * @param baseUrl the base URL for the agent whose agent card we want to retrieve, must not be null
      * @param tenant the tenant path to use when fetching the agent card, may be null for no tenant
@@ -46,7 +46,7 @@ public class A2ACardResolver {
      * @throws IllegalArgumentException if baseUrl is null
      */
     public A2ACardResolver(String baseUrl, @Nullable String tenant) throws A2AClientError {
-        this(new JdkA2AHttpClient(), baseUrl, tenant, null);
+        this(A2AHttpClientFactory.create(), baseUrl, tenant, null);
     }
 
     /**

--- a/http-client/src/main/java/io/a2a/client/http/A2AHttpClient.java
+++ b/http-client/src/main/java/io/a2a/client/http/A2AHttpClient.java
@@ -9,6 +9,8 @@ public interface A2AHttpClient {
 
     String CONTENT_TYPE= "Content-Type";
     String APPLICATION_JSON= "application/json";
+    String ACCEPT = "Accept";
+    String EVENT_STREAM = "text/event-stream";
 
     GetBuilder createGet();
 

--- a/http-client/src/main/java/io/a2a/client/http/A2AHttpClientFactory.java
+++ b/http-client/src/main/java/io/a2a/client/http/A2AHttpClientFactory.java
@@ -1,0 +1,89 @@
+package io.a2a.client.http;
+
+import java.util.Comparator;
+import java.util.ServiceLoader;
+import java.util.stream.StreamSupport;
+
+/**
+ * Factory for creating {@link A2AHttpClient} instances using the ServiceLoader mechanism.
+ *
+ * <p>
+ * This factory discovers available {@link A2AHttpClientProvider} implementations at runtime
+ * and selects the one with the highest priority. If no providers are found, it falls back
+ * to creating a {@link JdkA2AHttpClient}.
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * // Get the default client (highest priority provider)
+ * A2AHttpClient client = A2AHttpClientFactory.create();
+ *
+ * // Use with try-with-resources if the client implements AutoCloseable
+ * try (A2AHttpClient client = A2AHttpClientFactory.create()) {
+ *     A2AHttpResponse response = client.createGet()
+ *         .url("https://example.com")
+ *         .get();
+ * }
+ * }</pre>
+ *
+ * <h2>Priority System</h2>
+ * <p>
+ * Providers are selected based on their priority value (higher is better):
+ * <ul>
+ * <li>JdkA2AHttpClient: priority 0 (fallback)</li>
+ * <li>VertxA2AHttpClient: priority 100 (preferred when available)</li>
+ * </ul>
+ *
+ * <h2>Custom Providers</h2>
+ * <p>
+ * To add a custom provider, implement {@link A2AHttpClientProvider} and register it
+ * in {@code META-INF/services/io.a2a.client.http.A2AHttpClientProvider}.
+ */
+public final class A2AHttpClientFactory {
+
+    private A2AHttpClientFactory() {
+        // Utility class
+    }
+
+    /**
+     * Creates a new A2AHttpClient instance using the highest priority provider available.
+     *
+     * <p>
+     * This method uses the ServiceLoader mechanism to discover providers at runtime.
+     * If no providers are found, it falls back to creating a {@link JdkA2AHttpClient}.
+     *
+     * @return a new A2AHttpClient instance
+     */
+    public static A2AHttpClient create() {
+        ServiceLoader<A2AHttpClientProvider> loader = ServiceLoader.load(A2AHttpClientProvider.class);
+
+        return StreamSupport.stream(loader.spliterator(), false)
+                .max(Comparator.comparingInt(A2AHttpClientProvider::priority))
+                .map(A2AHttpClientProvider::create)
+                .orElseGet(JdkA2AHttpClient::new);
+    }
+
+    /**
+     * Creates a new A2AHttpClient instance using a specific provider by name.
+     *
+     * <p>
+     * This method is useful for testing or when you need to force a specific implementation.
+     *
+     * @param providerName the name of the provider to use
+     * @return a new A2AHttpClient instance from the specified provider
+     * @throws IllegalArgumentException if no provider with the given name is found
+     */
+    public static A2AHttpClient create(String providerName) {
+        if (providerName == null || providerName.isEmpty()) {
+            throw new IllegalArgumentException("Provider name must not be null or empty");
+        }
+
+        ServiceLoader<A2AHttpClientProvider> loader = ServiceLoader.load(A2AHttpClientProvider.class);
+
+        return StreamSupport.stream(loader.spliterator(), false)
+                .filter(provider -> providerName.equals(provider.name()))
+                .findFirst()
+                .map(A2AHttpClientProvider::create)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "No A2AHttpClientProvider found with name: " + providerName));
+    }
+}

--- a/http-client/src/main/java/io/a2a/client/http/A2AHttpClientProvider.java
+++ b/http-client/src/main/java/io/a2a/client/http/A2AHttpClientProvider.java
@@ -1,0 +1,48 @@
+package io.a2a.client.http;
+
+/**
+ * Service provider interface for creating {@link A2AHttpClient} instances.
+ *
+ * <p>
+ * Implementations of this interface can be registered via the Java ServiceLoader
+ * mechanism. The {@link A2AHttpClientFactory} will discover and use the highest
+ * priority provider available.
+ *
+ * <p>
+ * To register a provider, create a file named
+ * {@code META-INF/services/io.a2a.client.http.A2AHttpClientProvider} containing
+ * the fully qualified class name of your provider implementation.
+ */
+public interface A2AHttpClientProvider {
+
+    /**
+     * Creates a new instance of an A2AHttpClient.
+     *
+     * @return a new A2AHttpClient instance
+     */
+    A2AHttpClient create();
+
+    /**
+     * Returns the priority of this provider. Higher priority providers are
+     * preferred over lower priority ones.
+     *
+     * <p>
+     * Default priorities:
+     * <ul>
+     * <li>JdkA2AHttpClient: 0 (fallback)</li>
+     * <li>VertxA2AHttpClient: 100 (preferred when available)</li>
+     * </ul>
+     *
+     * @return the priority value (higher is better)
+     */
+    default int priority() {
+        return 0;
+    }
+
+    /**
+     * Returns the name of this provider for logging and debugging purposes.
+     *
+     * @return the provider name
+     */
+    String name();
+}

--- a/http-client/src/main/java/io/a2a/client/http/JdkA2AHttpClient.java
+++ b/http-client/src/main/java/io/a2a/client/http/JdkA2AHttpClient.java
@@ -199,7 +199,7 @@ public class JdkA2AHttpClient implements A2AHttpClient {
         private HttpRequest.Builder createRequestBuilder(boolean SSE) throws IOException {
             HttpRequest.Builder builder = super.createRequestBuilder().GET();
             if (SSE) {
-                builder.header("Accept", "text/event-stream");
+                builder.header(ACCEPT, EVENT_STREAM);
             }
             return builder;
         }
@@ -250,7 +250,7 @@ public class JdkA2AHttpClient implements A2AHttpClient {
             HttpRequest.Builder builder = super.createRequestBuilder()
                     .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8));
             if (SSE) {
-                builder.header("Accept", "text/event-stream");
+                builder.header(ACCEPT, EVENT_STREAM);
             }
             return builder;
         }

--- a/http-client/src/main/java/io/a2a/client/http/JdkA2AHttpClientProvider.java
+++ b/http-client/src/main/java/io/a2a/client/http/JdkA2AHttpClientProvider.java
@@ -1,0 +1,27 @@
+package io.a2a.client.http;
+
+/**
+ * Service provider for {@link JdkA2AHttpClient}.
+ *
+ * <p>
+ * This provider has the lowest priority (0) and serves as the fallback implementation
+ * when no other providers are available. The JDK HTTP client is always available as it
+ * uses only standard Java libraries.
+ */
+public final class JdkA2AHttpClientProvider implements A2AHttpClientProvider {
+
+    @Override
+    public A2AHttpClient create() {
+        return new JdkA2AHttpClient();
+    }
+
+    @Override
+    public int priority() {
+        return 0; // Lowest priority - fallback
+    }
+
+    @Override
+    public String name() {
+        return "jdk";
+    }
+}

--- a/http-client/src/main/resources/META-INF/services/io.a2a.client.http.A2AHttpClientProvider
+++ b/http-client/src/main/resources/META-INF/services/io.a2a.client.http.A2AHttpClientProvider
@@ -1,0 +1,1 @@
+io.a2a.client.http.JdkA2AHttpClientProvider

--- a/http-client/src/test/java/io/a2a/client/http/A2AHttpClientFactoryTest.java
+++ b/http-client/src/test/java/io/a2a/client/http/A2AHttpClientFactoryTest.java
@@ -1,0 +1,88 @@
+package io.a2a.client.http;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class A2AHttpClientFactoryTest {
+
+    @Test
+    public void testCreateReturnsNonNull() {
+        A2AHttpClient client = A2AHttpClientFactory.create();
+        assertNotNull(client, "Factory should return a non-null client");
+    }
+
+    @Test
+    public void testCreateReturnsJdkClient() {
+        // When Vertx is not on classpath, JDK client should be used
+        A2AHttpClient client = A2AHttpClientFactory.create();
+        assertNotNull(client);
+        assertInstanceOf(JdkA2AHttpClient.class, client,
+            "Factory should return JdkA2AHttpClient when Vertx is not available");
+    }
+
+    @Test
+    public void testCreateWithJdkProviderName() {
+        A2AHttpClient client = A2AHttpClientFactory.create("jdk");
+        assertNotNull(client);
+        assertInstanceOf(JdkA2AHttpClient.class, client,
+            "Factory should return JdkA2AHttpClient when 'jdk' provider is requested");
+    }
+
+    @Test
+    public void testCreateWithVertxProviderNameThrows() {
+        // Vertx provider is not available in the core module
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> A2AHttpClientFactory.create("vertx"),
+            "Factory should throw IllegalArgumentException when vertx provider is not found"
+        );
+        assertTrue(exception.getMessage().contains("vertx"),
+            "Exception message should mention the provider name");
+    }
+
+    @Test
+    public void testCreateWithInvalidProviderNameThrows() {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> A2AHttpClientFactory.create("nonexistent"),
+            "Factory should throw IllegalArgumentException for unknown provider"
+        );
+        assertTrue(exception.getMessage().contains("nonexistent"),
+            "Exception message should mention the provider name");
+    }
+
+    @Test
+    public void testCreateWithNullProviderNameThrows() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> A2AHttpClientFactory.create(null),
+            "Factory should throw IllegalArgumentException for null provider name"
+        );
+    }
+
+    @Test
+    public void testCreateWithEmptyProviderNameThrows() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> A2AHttpClientFactory.create(""),
+            "Factory should throw IllegalArgumentException for empty provider name"
+        );
+    }
+
+    @Test
+    public void testCreatedClientIsUsable() {
+        A2AHttpClient client = A2AHttpClientFactory.create();
+        assertNotNull(client);
+
+        // Verify we can create builders
+        A2AHttpClient.GetBuilder getBuilder = client.createGet();
+        assertNotNull(getBuilder, "Should be able to create GET builder");
+
+        A2AHttpClient.PostBuilder postBuilder = client.createPost();
+        assertNotNull(postBuilder, "Should be able to create POST builder");
+
+        A2AHttpClient.DeleteBuilder deleteBuilder = client.createDelete();
+        assertNotNull(deleteBuilder, "Should be able to create DELETE builder");
+    }
+}

--- a/http-client/src/test/java/io/a2a/client/http/A2AHttpClientFactoryUsageExample.java
+++ b/http-client/src/test/java/io/a2a/client/http/A2AHttpClientFactoryUsageExample.java
@@ -1,0 +1,122 @@
+package io.a2a.client.http;
+
+import java.io.IOException;
+
+/**
+ * Example demonstrating how to use {@link A2AHttpClientFactory} to obtain HTTP client instances.
+ *
+ * <p>
+ * This class shows various usage patterns for the factory-based approach to creating
+ * A2AHttpClient instances.
+ */
+public class A2AHttpClientFactoryUsageExample {
+
+    /**
+     * Example 1: Basic usage with automatic selection of best available client.
+     */
+    public void basicUsage() throws IOException, InterruptedException {
+        // The factory automatically selects the best available implementation:
+        // - VertxA2AHttpClient (priority 100) if Vert.x is on the classpath
+        // - JdkA2AHttpClient (priority 0) as fallback
+        A2AHttpClient client = A2AHttpClientFactory.create();
+
+        try {
+            A2AHttpResponse response = client.createGet()
+                .url("https://api.example.com/data")
+                .addHeader("Accept", "application/json")
+                .get();
+
+            if (response.success()) {
+                System.out.println("Response: " + response.body());
+            }
+        } finally {
+            // Close if the client supports AutoCloseable (Vertx does, JDK doesn't)
+            if (client instanceof AutoCloseable) {
+                try {
+                    ((AutoCloseable) client).close();
+                } catch (Exception e) {
+                    // Handle close exception
+                }
+            }
+        }
+    }
+
+    /**
+     * Example 2: Try-with-resources pattern (recommended for AutoCloseable clients).
+     */
+    public void tryWithResourcesUsage() throws Exception {
+        A2AHttpClient client = A2AHttpClientFactory.create();
+
+        // Only use try-with-resources if the client is AutoCloseable
+        if (client instanceof AutoCloseable) {
+            try (AutoCloseable closeableClient = (AutoCloseable) client) {
+                A2AHttpResponse response = client.createPost()
+                    .url("https://api.example.com/submit")
+                    .addHeader("Content-Type", "application/json")
+                    .body("{\"key\":\"value\"}")
+                    .post();
+
+                System.out.println("Status: " + response.status());
+            }
+        } else {
+            // Non-closeable client, use normally
+            A2AHttpResponse response = client.createPost()
+                .url("https://api.example.com/submit")
+                .addHeader("Content-Type", "application/json")
+                .body("{\"key\":\"value\"}")
+                .post();
+
+            System.out.println("Status: " + response.status());
+        }
+    }
+
+    /**
+     * Example 3: Explicitly selecting a specific implementation.
+     */
+    public void specificProviderUsage() throws IOException, InterruptedException {
+        // Force the use of JDK client even if Vert.x is available
+        A2AHttpClient jdkClient = A2AHttpClientFactory.create("jdk");
+        A2AHttpResponse response = jdkClient.createGet()
+            .url("https://api.example.com/data")
+            .get();
+
+        System.out.println("Using JDK client: " + response.status());
+
+        // Or explicitly use Vert.x client
+        try (AutoCloseable vertxClient = (AutoCloseable) A2AHttpClientFactory.create("vertx")) {
+            A2AHttpResponse vertxResponse = ((A2AHttpClient) vertxClient).createGet()
+                .url("https://api.example.com/data")
+                .get();
+
+            System.out.println("Using Vert.x client: " + vertxResponse.status());
+        } catch (Exception e) {
+            // Handle exceptions
+        }
+    }
+
+    /**
+     * Example 4: Defensive programming - handling unknown implementations.
+     */
+    public void defensiveUsage() throws IOException, InterruptedException {
+        A2AHttpClient client = null;
+        try {
+            client = A2AHttpClientFactory.create();
+
+            A2AHttpResponse response = client.createGet()
+                .url("https://api.example.com/data")
+                .get();
+
+            System.out.println("Response: " + response.body());
+
+        } finally {
+            // Safely close if possible
+            if (client instanceof AutoCloseable) {
+                try {
+                    ((AutoCloseable) client).close();
+                } catch (Exception e) {
+                    System.err.println("Warning: Failed to close client: " + e.getMessage());
+                }
+            }
+        }
+    }
+}

--- a/http-client/src/test/java/io/a2a/client/http/A2AHttpClientProviderTest.java
+++ b/http-client/src/test/java/io/a2a/client/http/A2AHttpClientProviderTest.java
@@ -1,0 +1,28 @@
+package io.a2a.client.http;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class A2AHttpClientProviderTest {
+
+    @Test
+    public void testJdkProviderCreatesClient() {
+        JdkA2AHttpClientProvider provider = new JdkA2AHttpClientProvider();
+        A2AHttpClient client = provider.create();
+        assertNotNull(client);
+        assertInstanceOf(JdkA2AHttpClient.class, client);
+    }
+
+    @Test
+    public void testJdkProviderPriority() {
+        JdkA2AHttpClientProvider provider = new JdkA2AHttpClientProvider();
+        assertEquals(0, provider.priority(), "JDK provider should have priority 0");
+    }
+
+    @Test
+    public void testJdkProviderName() {
+        JdkA2AHttpClientProvider provider = new JdkA2AHttpClientProvider();
+        assertEquals("jdk", provider.name(), "JDK provider name should be 'jdk'");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
         <protobuf-java.version>4.33.1</protobuf-java.version>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
-        <quarkus.platform.version>3.30.1</quarkus.platform.version>
+        <quarkus.platform.version>3.30.6</quarkus.platform.version>
         <rest-assured.version>5.5.1</rest-assured.version>
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.18</logback.version>
@@ -117,6 +117,11 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>a2a-java-sdk-http-client</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>a2a-java-sdk-http-client-vertx</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -510,6 +515,7 @@
         <module>extras/task-store-database-jpa</module>
         <module>extras/push-notification-config-store-database-jpa</module>
         <module>extras/queue-manager-replicated</module>
+        <module>extras/http-client-vertx</module>
         <module>http-client</module>
         <module>jsonrpc-common</module>
         <module>integrations/microprofile-config</module>

--- a/reference/jsonrpc/pom.xml
+++ b/reference/jsonrpc/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>a2a-java-sdk-http-client-vertx</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>a2a-java-sdk-tests-server-common</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/QuarkusA2AJSONRPCJdkTest.java
+++ b/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/QuarkusA2AJSONRPCJdkTest.java
@@ -1,0 +1,16 @@
+package io.a2a.server.apps.quarkus;
+
+import io.a2a.client.ClientBuilder;
+import io.a2a.client.http.JdkA2AHttpClient;
+import io.a2a.client.transport.jsonrpc.JSONRPCTransport;
+import io.a2a.client.transport.jsonrpc.JSONRPCTransportConfigBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class QuarkusA2AJSONRPCJdkTest extends QuarkusA2AJSONRPCTest {
+
+    @Override
+    protected void configureTransport(ClientBuilder builder) {
+        builder.withTransport(JSONRPCTransport.class, new JSONRPCTransportConfigBuilder().httpClient(new JdkA2AHttpClient()));
+    }
+}

--- a/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/QuarkusA2AJSONRPCTest.java
+++ b/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/QuarkusA2AJSONRPCTest.java
@@ -1,14 +1,10 @@
 package io.a2a.server.apps.quarkus;
 
 import io.a2a.client.ClientBuilder;
-import io.a2a.client.transport.jsonrpc.JSONRPCTransport;
-import io.a2a.client.transport.jsonrpc.JSONRPCTransportConfigBuilder;
 import io.a2a.server.apps.common.AbstractA2AServerTest;
 import io.a2a.spec.TransportProtocol;
-import io.quarkus.test.junit.QuarkusTest;
 
-@QuarkusTest
-public class QuarkusA2AJSONRPCTest extends AbstractA2AServerTest {
+public abstract class QuarkusA2AJSONRPCTest extends AbstractA2AServerTest {
 
     public QuarkusA2AJSONRPCTest() {
         super(8081);
@@ -25,7 +21,5 @@ public class QuarkusA2AJSONRPCTest extends AbstractA2AServerTest {
     }
 
     @Override
-    protected void configureTransport(ClientBuilder builder) {
-        builder.withTransport(JSONRPCTransport.class, new JSONRPCTransportConfigBuilder());
-    }
+    protected abstract void configureTransport(ClientBuilder builder);
 }

--- a/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/QuarkusA2AJSONRPCVertxTest.java
+++ b/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/QuarkusA2AJSONRPCVertxTest.java
@@ -1,0 +1,21 @@
+package io.a2a.server.apps.quarkus;
+
+import io.a2a.client.ClientBuilder;
+import io.a2a.client.http.VertxA2AHttpClient;
+import io.a2a.client.transport.jsonrpc.JSONRPCTransport;
+import io.a2a.client.transport.jsonrpc.JSONRPCTransportConfigBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.Vertx;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+public class QuarkusA2AJSONRPCVertxTest extends QuarkusA2AJSONRPCTest {
+
+    @Inject
+    Vertx vertx;
+
+    @Override
+    protected void configureTransport(ClientBuilder builder) {
+        builder.withTransport(JSONRPCTransport.class, new JSONRPCTransportConfigBuilder().httpClient(new VertxA2AHttpClient(vertx)));
+    }
+}

--- a/reference/rest/pom.xml
+++ b/reference/rest/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>a2a-java-sdk-http-client-vertx</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>a2a-java-sdk-client-transport-rest</artifactId>
             <scope>test</scope>
         </dependency>
@@ -107,7 +112,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>3.5.4</version>
                 <configuration>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager> 

--- a/reference/rest/src/test/java/io/a2a/server/rest/quarkus/QuarkusA2ARestJdkTest.java
+++ b/reference/rest/src/test/java/io/a2a/server/rest/quarkus/QuarkusA2ARestJdkTest.java
@@ -1,0 +1,16 @@
+package io.a2a.server.rest.quarkus;
+
+import io.a2a.client.ClientBuilder;
+import io.a2a.client.http.JdkA2AHttpClient;
+import io.a2a.client.transport.rest.RestTransport;
+import io.a2a.client.transport.rest.RestTransportConfigBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class QuarkusA2ARestJdkTest extends QuarkusA2ARestTest {
+
+    @Override
+    protected void configureTransport(ClientBuilder builder) {
+        builder.withTransport(RestTransport.class, new RestTransportConfigBuilder().httpClient(new JdkA2AHttpClient()));
+    }
+}

--- a/reference/rest/src/test/java/io/a2a/server/rest/quarkus/QuarkusA2ARestTest.java
+++ b/reference/rest/src/test/java/io/a2a/server/rest/quarkus/QuarkusA2ARestTest.java
@@ -6,16 +6,12 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
 import io.a2a.client.ClientBuilder;
-import io.a2a.client.transport.rest.RestTransport;
-import io.a2a.client.transport.rest.RestTransportConfigBuilder;
 import io.a2a.server.apps.common.AbstractA2AServerTest;
 import io.a2a.spec.TransportProtocol;
-import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-@QuarkusTest
-public class QuarkusA2ARestTest extends AbstractA2AServerTest {
+public abstract class QuarkusA2ARestTest extends AbstractA2AServerTest {
 
     public QuarkusA2ARestTest() {
         super(8081);
@@ -32,9 +28,7 @@ public class QuarkusA2ARestTest extends AbstractA2AServerTest {
     }
 
     @Override
-    protected void configureTransport(ClientBuilder builder) {
-        builder.withTransport(RestTransport.class, new RestTransportConfigBuilder());
-    }
+    protected abstract void configureTransport(ClientBuilder builder);
 
     @Test
     public void testMethodNotFound() throws Exception {

--- a/reference/rest/src/test/java/io/a2a/server/rest/quarkus/QuarkusA2ARestVertxTest.java
+++ b/reference/rest/src/test/java/io/a2a/server/rest/quarkus/QuarkusA2ARestVertxTest.java
@@ -1,0 +1,21 @@
+package io.a2a.server.rest.quarkus;
+
+import io.a2a.client.ClientBuilder;
+import io.a2a.client.http.VertxA2AHttpClient;
+import io.a2a.client.transport.rest.RestTransport;
+import io.a2a.client.transport.rest.RestTransportConfigBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.Vertx;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+public class QuarkusA2ARestVertxTest extends QuarkusA2ARestTest {
+
+    @Inject
+    Vertx vertx;
+
+    @Override
+    protected void configureTransport(ClientBuilder builder) {
+        builder.withTransport(RestTransport.class, new RestTransportConfigBuilder().httpClient(new VertxA2AHttpClient(vertx)));
+    }
+}

--- a/server-common/pom.xml
+++ b/server-common/pom.xml
@@ -36,6 +36,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>a2a-java-sdk-http-client-vertx</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>a2a-java-sdk-client-transport-jsonrpc</artifactId>
         </dependency>
         <dependency>

--- a/server-common/src/main/java/io/a2a/server/tasks/BasePushNotificationSender.java
+++ b/server-common/src/main/java/io/a2a/server/tasks/BasePushNotificationSender.java
@@ -16,7 +16,7 @@ import java.util.concurrent.ExecutionException;
 
 
 import io.a2a.client.http.A2AHttpClient;
-import io.a2a.client.http.JdkA2AHttpClient;
+import io.a2a.client.http.A2AHttpClientFactory;
 import io.a2a.jsonrpc.common.json.JsonUtil;
 import io.a2a.spec.ListTaskPushNotificationConfigParams;
 import io.a2a.spec.ListTaskPushNotificationConfigResult;
@@ -52,7 +52,7 @@ public class BasePushNotificationSender implements PushNotificationSender {
 
     @Inject
     public BasePushNotificationSender(PushNotificationConfigStore configStore) {
-        this.httpClient = new JdkA2AHttpClient();
+        this.httpClient = A2AHttpClientFactory.create();
         this.configStore = configStore;
     }
 


### PR DESCRIPTION
Introduce ServiceLoader-based A2AHttpClient client architecture with two implementations:
- JDK HttpClient (core, always available)
- Vert.x WebClient (optional, high-performance)

Changes:
- Create http-client-vertx module for Vert.x implementation
- Add ServiceLoader infrastructure (A2AHttpClientFactory, providers)
- Update dependent modules to use Vert.x client by default
- Add comprehensive tests and usage examples

Users can choose implementation via Maven dependencies. Priority-based selection: Vert.x (100) > JDK (0).


Fixes #583 🦕