### PR TITLE
fix: add missing META-INF/beans.xml to microprofile-config integration

### DIFF
--- a/integrations/microprofile-config/src/main/resources/META-INF/beans.xml
+++ b/integrations/microprofile-config/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+                           https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
+</beans>


### PR DESCRIPTION
The microprofile-config integration was missing the beans.xml marker file, which prevented the configuration from being loaded as an alternative bean in Quarkus applications. This file is required for CDI bean discovery.

Fixes #587