### PR TITLE
chore: Managing tenant in JSONRPC.

### DIFF
--- a/reference/jsonrpc/src/main/java/io/a2a/server/apps/quarkus/A2AServerRoutes.java
+++ b/reference/jsonrpc/src/main/java/io/a2a/server/apps/quarkus/A2AServerRoutes.java
@@ -2,6 +2,7 @@ package io.a2a.server.apps.quarkus;
 
 import static io.a2a.transport.jsonrpc.context.JSONRPCContextKeys.HEADERS_KEY;
 import static io.a2a.transport.jsonrpc.context.JSONRPCContextKeys.METHOD_NAME_KEY;
+import static io.a2a.transport.jsonrpc.context.JSONRPCContextKeys.TENANT_KEY;
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static jakarta.ws.rs.core.MediaType.SERVER_SENT_EVENTS;
@@ -101,7 +102,7 @@ public class A2AServerRoutes {
         Multi<? extends A2AResponse<?>> streamingResponse = null;
         A2AErrorResponse error = null;
         try {
-            A2ARequest<?> request = JSONRPCUtils.parseRequestBody(body);
+            A2ARequest<?> request = JSONRPCUtils.parseRequestBody(body, extractTenant(rc));
             context.getState().put(METHOD_NAME_KEY, request.getMethod());
             if (request instanceof NonStreamingJSONRPCRequest nonStreamingRequest) {
                 nonStreamingResponse = processNonStreamingRequest(nonStreamingRequest, context);
@@ -213,7 +214,6 @@ public class A2AServerRoutes {
     }
 
     private ServerCallContext createCallContext(RoutingContext rc) {
-
         if (callContextFactory.isUnsatisfied()) {
             User user;
             if (rc.user() == null) {
@@ -240,6 +240,7 @@ public class A2AServerRoutes {
             Set<String> headerNames = rc.request().headers().names();
             headerNames.forEach(name -> headers.put(name, rc.request().getHeader(name)));
             state.put(HEADERS_KEY, headers);
+            state.put(TENANT_KEY, extractTenant(rc));
 
             // Extract requested protocol version from X-A2A-Version header
             String requestedVersion = rc.request().getHeader(A2AHeaders.X_A2A_VERSION);
@@ -253,6 +254,20 @@ public class A2AServerRoutes {
             CallContextFactory builder = callContextFactory.get();
             return builder.build(rc);
         }
+    }
+
+    private String extractTenant(RoutingContext rc) {
+        String tenantPath = rc.normalizedPath();
+        if (tenantPath == null || tenantPath.isBlank()) {
+            return "";
+        }
+        if (tenantPath.startsWith("/")) {
+            tenantPath = tenantPath.substring(1);
+        }
+        if(tenantPath.endsWith("/")) {
+            tenantPath = tenantPath.substring(0, tenantPath.length() -1);
+        }
+        return tenantPath;
     }
 
     private static String serializeResponse(A2AResponse<?> response) {

--- a/reference/rest/src/main/java/io/a2a/server/rest/quarkus/A2AServerRoutes.java
+++ b/reference/rest/src/main/java/io/a2a/server/rest/quarkus/A2AServerRoutes.java
@@ -58,6 +58,8 @@ import static io.a2a.spec.A2AMethods.SEND_MESSAGE_METHOD;
 import static io.a2a.spec.A2AMethods.SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
 import static io.a2a.spec.A2AMethods.SUBSCRIBE_TO_TASK_METHOD;
 
+import static io.a2a.transport.rest.context.RestContextKeys.TENANT_KEY;
+
 @Singleton
 @Authenticated
 public class A2AServerRoutes {
@@ -435,6 +437,7 @@ public class A2AServerRoutes {
             headerNames.forEach(name -> headers.put(name, rc.request().getHeader(name)));
             state.put(HEADERS_KEY, headers);
             state.put(METHOD_NAME_KEY, jsonRpcMethodName);
+            state.put(TENANT_KEY, extractTenant(rc));
 
             // Extract requested protocol version from X-A2A-Version header
             String requestedVersion = rc.request().getHeader(A2AHeaders.X_A2A_VERSION);

--- a/spec-grpc/src/main/java/io/a2a/grpc/utils/JSONRPCUtils.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/utils/JSONRPCUtils.java
@@ -183,7 +183,7 @@ public class JSONRPCUtils {
     private static final Pattern EXTRACT_WRONG_TYPE = Pattern.compile("Expected (.*) but found \".*\"");
     static final String ERROR_MESSAGE = "Invalid request content: %s. Please verify the request matches the expected schema for this method.";
 
-    public static A2ARequest<?> parseRequestBody(String body) throws JsonMappingException, JsonProcessingException {
+    public static A2ARequest<?> parseRequestBody(String body, @Nullable String tenant) throws JsonMappingException, JsonProcessingException {
         JsonElement jelement = JsonParser.parseString(body);
         JsonObject jsonRpc = jelement.getAsJsonObject();
         if (!jsonRpc.has("method")) {
@@ -196,52 +196,76 @@ public class JSONRPCUtils {
         String method = jsonRpc.get("method").getAsString();
         JsonElement paramsNode = jsonRpc.get("params");
         try {
-            return parseMethodRequest(version, id, method, paramsNode);
+            return parseMethodRequest(version, id, method, paramsNode, tenant);
         } catch (InvalidParamsError e) {
             throw new InvalidParamsJsonMappingException(Utils.defaultIfNull(e.getMessage(), "Invalid parameters"), id);
         }
     }
 
-    private static A2ARequest<?> parseMethodRequest(String version, Object id, String method, JsonElement paramsNode) throws InvalidParamsError, MethodNotFoundJsonMappingException, JsonProcessingException {
+    private static A2ARequest<?> parseMethodRequest(String version, Object id, String method, JsonElement paramsNode, @Nullable String tenant) throws InvalidParamsError, MethodNotFoundJsonMappingException, JsonProcessingException {
         switch (method) {
             case GET_TASK_METHOD -> {
                 io.a2a.grpc.GetTaskRequest.Builder builder = io.a2a.grpc.GetTaskRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
+                if (tenant != null && !tenant.isBlank() && (builder.getTenant() == null || builder.getTenant().isBlank())) {
+                    builder.setTenant(tenant);
+                }
                 return new GetTaskRequest(version, id, ProtoUtils.FromProto.taskQueryParams(builder));
             }
             case CANCEL_TASK_METHOD -> {
                 io.a2a.grpc.CancelTaskRequest.Builder builder = io.a2a.grpc.CancelTaskRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
+                if (tenant != null && !tenant.isBlank() && (builder.getTenant() == null || builder.getTenant().isBlank())) {
+                    builder.setTenant(tenant);
+                }
                 return new CancelTaskRequest(version, id, ProtoUtils.FromProto.taskIdParams(builder));
             }
             case LIST_TASK_METHOD -> {
                 io.a2a.grpc.ListTasksRequest.Builder builder = io.a2a.grpc.ListTasksRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
+                if (tenant != null && !tenant.isBlank() && (builder.getTenant() == null || builder.getTenant().isBlank())) {
+                    builder.setTenant(tenant);
+                }
                 return new ListTasksRequest(version, id, ProtoUtils.FromProto.listTasksParams(builder));
             }
             case SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 io.a2a.grpc.SetTaskPushNotificationConfigRequest.Builder builder = io.a2a.grpc.SetTaskPushNotificationConfigRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
+                if (tenant != null && !tenant.isBlank() && (builder.getTenant() == null || builder.getTenant().isBlank())) {
+                    builder.setTenant(tenant);
+                }
                 return new SetTaskPushNotificationConfigRequest(version, id, ProtoUtils.FromProto.setTaskPushNotificationConfig(builder));
             }
             case GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 io.a2a.grpc.GetTaskPushNotificationConfigRequest.Builder builder = io.a2a.grpc.GetTaskPushNotificationConfigRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
+                if (tenant != null && !tenant.isBlank() && (builder.getTenant() == null || builder.getTenant().isBlank())) {
+                    builder.setTenant(tenant);
+                }
                 return new GetTaskPushNotificationConfigRequest(version, id, ProtoUtils.FromProto.getTaskPushNotificationConfigParams(builder));
             }
             case SEND_MESSAGE_METHOD -> {
                 io.a2a.grpc.SendMessageRequest.Builder builder = io.a2a.grpc.SendMessageRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
+                if (tenant != null && !tenant.isBlank() && (builder.getTenant() == null || builder.getTenant().isBlank())) {
+                    builder.setTenant(tenant);
+                }
                 return new SendMessageRequest(version, id, ProtoUtils.FromProto.messageSendParams(builder));
             }
             case LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 io.a2a.grpc.ListTaskPushNotificationConfigRequest.Builder builder = io.a2a.grpc.ListTaskPushNotificationConfigRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
+                if (tenant != null && !tenant.isBlank() && (builder.getTenant() == null || builder.getTenant().isBlank())) {
+                    builder.setTenant(tenant);
+                }
                 return new ListTaskPushNotificationConfigRequest(version, id, ProtoUtils.FromProto.listTaskPushNotificationConfigParams(builder));
             }
             case DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 io.a2a.grpc.DeleteTaskPushNotificationConfigRequest.Builder builder = io.a2a.grpc.DeleteTaskPushNotificationConfigRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
+                if (tenant != null && !tenant.isBlank() && (builder.getTenant() == null || builder.getTenant().isBlank())) {
+                    builder.setTenant(tenant);
+                }
                 return new DeleteTaskPushNotificationConfigRequest(version, id, ProtoUtils.FromProto.deleteTaskPushNotificationConfigParams(builder));
             }
             case GET_EXTENDED_AGENT_CARD_METHOD -> {
@@ -250,11 +274,17 @@ public class JSONRPCUtils {
             case SEND_STREAMING_MESSAGE_METHOD -> {
                 io.a2a.grpc.SendMessageRequest.Builder builder = io.a2a.grpc.SendMessageRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
+                if (tenant != null && !tenant.isBlank() && (builder.getTenant() == null || builder.getTenant().isBlank())) {
+                    builder.setTenant(tenant);
+                }
                 return new SendStreamingMessageRequest(version, id, ProtoUtils.FromProto.messageSendParams(builder));
             }
             case SUBSCRIBE_TO_TASK_METHOD -> {
                 io.a2a.grpc.SubscribeToTaskRequest.Builder builder = io.a2a.grpc.SubscribeToTaskRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
+                if (tenant != null && !tenant.isBlank() && (builder.getTenant() == null || builder.getTenant().isBlank())) {
+                    builder.setTenant(tenant);
+                }
                 return new SubscribeToTaskRequest(version, id, ProtoUtils.FromProto.taskIdParams(builder));
             }
             default ->

--- a/spec-grpc/src/test/java/io/a2a/grpc/utils/JSONRPCUtilsTest.java
+++ b/spec-grpc/src/test/java/io/a2a/grpc/utils/JSONRPCUtilsTest.java
@@ -49,7 +49,7 @@ public class JSONRPCUtilsTest {
             }
             """;
 
-        A2ARequest<?> request = JSONRPCUtils.parseRequestBody(validRequest);
+        A2ARequest<?> request = JSONRPCUtils.parseRequestBody(validRequest, null);
 
         assertNotNull(request);
         assertInstanceOf(SetTaskPushNotificationConfigRequest.class, request);
@@ -78,7 +78,7 @@ public class JSONRPCUtilsTest {
             }
             """;
 
-        A2ARequest<?> request = JSONRPCUtils.parseRequestBody(validRequest);
+        A2ARequest<?> request = JSONRPCUtils.parseRequestBody(validRequest, null);
 
         assertNotNull(request);
         assertInstanceOf(GetTaskPushNotificationConfigRequest.class, request);
@@ -101,7 +101,7 @@ public class JSONRPCUtilsTest {
             """; // Missing closing braces
 
         JsonSyntaxException exception = assertThrows(JsonSyntaxException.class, () -> {
-            JSONRPCUtils.parseRequestBody(malformedRequest);
+            JSONRPCUtils.parseRequestBody(malformedRequest, null);
         });
         assertEquals("java.io.EOFException: End of input at line 6 column 1 path $.params.parent", exception.getMessage());
     }
@@ -119,7 +119,7 @@ public class JSONRPCUtilsTest {
 
         InvalidParamsJsonMappingException exception = assertThrows(
             InvalidParamsJsonMappingException.class,
-            () -> JSONRPCUtils.parseRequestBody(invalidParamsRequest)
+            () -> JSONRPCUtils.parseRequestBody(invalidParamsRequest, null)
         );
         assertEquals(3, exception.getId());
     }
@@ -139,7 +139,7 @@ public class JSONRPCUtilsTest {
 
         InvalidParamsJsonMappingException exception = assertThrows(
             InvalidParamsJsonMappingException.class,
-            () -> JSONRPCUtils.parseRequestBody(invalidStructure)
+            () -> JSONRPCUtils.parseRequestBody(invalidStructure, null)
         );
         assertEquals(4, exception.getId());
         assertEquals(ERROR_MESSAGE.formatted("invalid_field in message a2a.v1.SetTaskPushNotificationConfigRequest"), exception.getMessage());
@@ -169,7 +169,7 @@ public class JSONRPCUtilsTest {
             }""";
         InvalidParamsJsonMappingException exception = assertThrows(
             InvalidParamsJsonMappingException.class,
-            () -> JSONRPCUtils.parseRequestBody(missingRoleMessage)
+            () -> JSONRPCUtils.parseRequestBody(missingRoleMessage, null)
         );
         assertEquals(18, exception.getId());
     }
@@ -199,7 +199,7 @@ public class JSONRPCUtilsTest {
             }""";
         JsonMappingException exception = assertThrows(
             JsonMappingException.class,
-            () -> JSONRPCUtils.parseRequestBody(unkownFieldMessage)
+            () -> JSONRPCUtils.parseRequestBody(unkownFieldMessage, null)
         );
         assertEquals(ERROR_MESSAGE.formatted("unknown in message a2a.v1.Message"), exception.getMessage());
     }

--- a/transport/jsonrpc/src/main/java/io/a2a/transport/jsonrpc/context/JSONRPCContextKeys.java
+++ b/transport/jsonrpc/src/main/java/io/a2a/transport/jsonrpc/context/JSONRPCContextKeys.java
@@ -18,6 +18,11 @@ public final class JSONRPCContextKeys {
      */
     public static final String METHOD_NAME_KEY = "method";
 
+    /**
+     * Context key for storing the tenant identifier extracted from the normalized path.
+     */
+    public static final String TENANT_KEY = "tenant";
+
     private JSONRPCContextKeys() {
         // Utility class
     }

--- a/transport/rest/src/main/java/io/a2a/transport/rest/context/RestContextKeys.java
+++ b/transport/rest/src/main/java/io/a2a/transport/rest/context/RestContextKeys.java
@@ -17,6 +17,10 @@ public final class RestContextKeys {
      * Context key for storing the method name being called.
      */
     public static final String METHOD_NAME_KEY = "method";
+    /**
+     * Context key for storing the tenant identifier extracted from the request path.
+     */
+    public static final String TENANT_KEY = "tenant";
 
     private RestContextKeys() {
         // Utility class


### PR DESCRIPTION
If the tenant is not defined in the JSONRPC payload, we use the one from the request path.

Fixes #612 🦕