### PR TITLE
chore: fixing flaky test

### DIFF
--- a/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
@@ -1426,8 +1426,17 @@ public abstract class AbstractA2AServerTest {
             }
         };
 
+        // Wait for streaming subscription to be established before sending message
+        CountDownLatch streamSubscriptionLatch = new CountDownLatch(1);
+        awaitStreamingSubscription()
+                .whenComplete((unused, throwable) -> streamSubscriptionLatch.countDown());
+
         // Streaming message adds artifact-2 and completes task
         getClient().sendMessage(message2, List.of(streamConsumer), null);
+
+        // Ensure subscription is established before agent sends events
+        assertTrue(streamSubscriptionLatch.await(15, TimeUnit.SECONDS),
+                "Stream subscription should be established");
 
         // 4. Verify both consumers received artifact-2 and completion
         assertTrue(resubEventLatch.await(10, TimeUnit.SECONDS));


### PR DESCRIPTION
The Problem
  The second sendMessage call doesn't wait for its streaming subscription to be established. This creates a race condition:
  - The agent receives message2 and immediately sends events (artifact-2 + completion)
  - But the streamConsumer subscription might not be fully wired up yet
  - The events get delivered to the resubConsumer (which is already established) but missed by the streamConsumer

The Fix
Add the awaitStreamingSubscription() pattern before the second sendMessage call:

Fixes #627 🦕