### PR TITLE
chore: Upgrade Nullaway and error prone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
         <rest-assured.version>5.5.1</rest-assured.version>
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.18</logback.version>
-        <error-prone.version>2.45.0</error-prone.version>
-        <nullaway.version>0.12.14</nullaway.version>
+        <error-prone.version>2.47.0</error-prone.version>
+        <nullaway.version>0.13.1</nullaway.version>
         <error-prone.flag>-XDaddTypeAnnotationsToSymbol=true</error-prone.flag>
         <nullaway.args>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -Xep:RequireExplicitNullMarking:WARN -XepOpt:NullAway:ExhaustiveOverride=true -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true -XepExcludedPaths:.*/src/test/.* -XepDisableWarningsInGeneratedCode</nullaway.args>
 


### PR DESCRIPTION
Upgrading Nullaway fro 0.12.14 to 0.13.1:
https://github.com/uber/NullAway/compare/v0.12.14...v0.13.1
