### PR TITLE
fix: Race condition in testNonBlockingWithMultipleMessages

### DIFF
--- a/reference/grpc/src/test/java/io/a2a/server/grpc/quarkus/A2ATestResource.java
+++ b/reference/grpc/src/test/java/io/a2a/server/grpc/quarkus/A2ATestResource.java
@@ -137,4 +137,40 @@ public class A2ATestResource {
         testUtilsBean.saveTaskPushNotificationConfig(taskId, notificationConfig);
         return Response.ok().build();
     }
+
+    /**
+     * REST endpoint to wait for queue poller to start.
+     * Waits for the EventConsumer polling loop to start for the specified task's queue,
+     * ensuring the queue is ready to receive and process events.
+     *
+     * @param taskId the task ID whose queue poller to wait for
+     * @return HTTP 200 response when poller has started
+     * @throws InterruptedException if interrupted while waiting
+     */
+    @POST
+    @Path("/queue/awaitPollerStart/{taskId}")
+    public Response awaitQueuePollerStart(@PathParam("taskId") String taskId) throws InterruptedException {
+        testUtilsBean.awaitQueuePollerStart(taskId);
+        return Response.ok().build();
+    }
+
+    /**
+     * REST endpoint to wait for child queue count to stabilize.
+     * Waits for the specified task's child queue count to match expectedCount for 3 consecutive
+     * checks (150ms total), ensuring EventConsumer polling loops have started.
+     *
+     * @param taskId the task ID whose child queues to monitor
+     * @param expectedCount the expected number of active child queues
+     * @param timeoutMs maximum time to wait in milliseconds
+     * @return HTTP 200 response with "true" if count stabilized, "false" if timeout occurred
+     * @throws InterruptedException if interrupted while waiting
+     */
+    @POST
+    @Path("/queue/awaitChildCountStable/{taskId}/{expectedCount}/{timeoutMs}")
+    public Response awaitChildQueueCountStable(@PathParam("taskId") String taskId,
+                                               @PathParam("expectedCount") int expectedCount,
+                                               @PathParam("timeoutMs") long timeoutMs) throws InterruptedException {
+        boolean stable = testUtilsBean.awaitChildQueueCountStable(taskId, expectedCount, timeoutMs);
+        return Response.ok(String.valueOf(stable), TEXT_PLAIN).build();
+    }
 }

--- a/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/A2ATestRoutes.java
+++ b/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/A2ATestRoutes.java
@@ -185,6 +185,30 @@ public class A2ATestRoutes {
         }
     }
 
+    /**
+     * REST endpoint to wait for child queue count to stabilize.
+     * Waits for the specified task's child queue count to match expectedCount for 3 consecutive
+     * checks (150ms total), ensuring EventConsumer polling loops have started.
+     *
+     * @param taskId the task ID whose child queues to monitor
+     * @param expectedCountStr the expected number of active child queues (as string)
+     * @param timeoutMsStr maximum time to wait in milliseconds (as string)
+     * @param rc the Vert.x routing context
+     */
+    @Route(path = "/test/queue/awaitChildCountStable/:taskId/:expectedCount/:timeoutMs", methods = {Route.HttpMethod.POST}, type = Route.HandlerType.BLOCKING)
+    public void awaitChildQueueCountStable(@Param("taskId") String taskId, @Param("expectedCount") String expectedCountStr, @Param("timeoutMs") String timeoutMsStr, RoutingContext rc) {
+        try {
+            int expectedCount = Integer.parseInt(expectedCountStr);
+            long timeoutMs = Long.parseLong(timeoutMsStr);
+            boolean stable = testUtilsBean.awaitChildQueueCountStable(taskId, expectedCount, timeoutMs);
+            rc.response()
+                    .setStatusCode(200)
+                    .end(String.valueOf(stable));
+        } catch (Throwable t) {
+            errorResponse(t, rc);
+        }
+    }
+
     private void errorResponse(Throwable t, RoutingContext rc) {
         t.printStackTrace();
         rc.response()

--- a/reference/rest/src/test/java/io/a2a/server/rest/quarkus/A2ATestRoutes.java
+++ b/reference/rest/src/test/java/io/a2a/server/rest/quarkus/A2ATestRoutes.java
@@ -185,6 +185,30 @@ public class A2ATestRoutes {
         }
     }
 
+    /**
+     * REST endpoint to wait for child queue count to stabilize.
+     * Waits for the specified task's child queue count to match expectedCount for 3 consecutive
+     * checks (150ms total), ensuring EventConsumer polling loops have started.
+     *
+     * @param taskId the task ID whose child queues to monitor
+     * @param expectedCountStr the expected number of active child queues (as string)
+     * @param timeoutMsStr maximum time to wait in milliseconds (as string)
+     * @param rc the Vert.x routing context
+     */
+    @Route(path = "/test/queue/awaitChildCountStable/:taskId/:expectedCount/:timeoutMs", methods = {Route.HttpMethod.POST}, type = Route.HandlerType.BLOCKING)
+    public void awaitChildQueueCountStable(@Param("taskId") String taskId, @Param("expectedCount") String expectedCountStr, @Param("timeoutMs") String timeoutMsStr, RoutingContext rc) {
+        try {
+            int expectedCount = Integer.parseInt(expectedCountStr);
+            long timeoutMs = Long.parseLong(timeoutMsStr);
+            boolean stable = testUtilsBean.awaitChildQueueCountStable(taskId, expectedCount, timeoutMs);
+            rc.response()
+                    .setStatusCode(200)
+                    .end(String.valueOf(stable));
+        } catch (Throwable t) {
+            errorResponse(t, rc);
+        }
+    }
+
     private void errorResponse(Throwable t, RoutingContext rc) {
         t.printStackTrace();
         rc.response()

--- a/tests/server-common/src/test/java/io/a2a/server/apps/common/TestUtilsBean.java
+++ b/tests/server-common/src/test/java/io/a2a/server/apps/common/TestUtilsBean.java
@@ -61,4 +61,53 @@ public class TestUtilsBean {
     public void saveTaskPushNotificationConfig(String taskId, PushNotificationConfig notificationConfig) {
         pushNotificationConfigStore.setInfo(taskId, notificationConfig);
     }
+
+    /**
+     * Waits for the EventConsumer polling loop to start for the specified task's queue.
+     * This ensures the queue is ready to receive and process events.
+     *
+     * @param taskId the task ID whose queue poller to wait for
+     * @throws InterruptedException if interrupted while waiting
+     */
+    public void awaitQueuePollerStart(String taskId) throws InterruptedException {
+        queueManager.awaitQueuePollerStart(queueManager.get(taskId));
+    }
+
+    /**
+     * Waits for the child queue count to stabilize at the expected value.
+     * <p>
+     * This method addresses a race condition where EventConsumer polling loops may not have started
+     * yet when events are emitted. It waits for the child queue count to match the expected value
+     * for 3 consecutive checks (150ms total), ensuring EventConsumers are actively polling and
+     * won't miss events.
+     * <p>
+     * Use this after operations that create child queues (e.g., subscribeToTask, sendMessage) to
+     * ensure their EventConsumer polling loops have started before the agent emits events.
+     *
+     * @param taskId the task ID whose child queues to monitor
+     * @param expectedCount the expected number of active child queues
+     * @param timeoutMs maximum time to wait in milliseconds
+     * @return true if the count stabilized at the expected value, false if timeout occurred
+     * @throws InterruptedException if interrupted while waiting
+     */
+    public boolean awaitChildQueueCountStable(String taskId, int expectedCount, long timeoutMs) throws InterruptedException {
+        long endTime = System.currentTimeMillis() + timeoutMs;
+        int consecutiveMatches = 0;
+        final int requiredMatches = 3; // Count must match 3 times in a row (150ms) to be considered stable
+
+        while (System.currentTimeMillis() < endTime) {
+            int count = queueManager.getActiveChildQueueCount(taskId);
+            if (count == expectedCount) {
+                consecutiveMatches++;
+                if (consecutiveMatches >= requiredMatches) {
+                    // Count is stable - all child queues exist and haven't closed
+                    return true;
+                }
+            } else {
+                consecutiveMatches = 0; // Reset if count changes
+            }
+            Thread.sleep(50);
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Addresses intermittent test failure where subscribeToTask created child queues
but EventConsumer polling loops hadn't started yet when the agent executed,
causing emitted events to be lost.

Root Cause:
- awaitStreamingSubscription() only guarantees transport-level subscription
  (Flow.Subscriber.onSubscribe() called)
- EventConsumer polling starts asynchronously on eventConsumerExecutor thread
- Agent execution could begin before EventConsumer was actively polling
- Events emitted before polling started were lost in the queue

Solution:
- Added awaitChildQueueCountStable() to TestUtilsBean
- Waits for child queue count to match expected value for 3 consecutive
  checks (150ms total), ensuring EventConsumer is actively polling
- Follows pattern from commit 18d2abff which fixed similar race condition
- Exposed REST endpoints in all transports (JSON-RPC, gRPC, REST)
- Added client helper in AbstractA2AServerTest
- Applied stability check after subscribeToTask() in tests
- Increased timeouts from 10s to 15s for CI stability

Files Modified:
- TestUtilsBean.java: Core synchronization logic with comprehensive Javadoc
- A2ATestRoutes.java (JSON-RPC, REST): REST endpoints for stability checks
- A2ATestResource.java (gRPC): REST endpoints for stability checks
- AbstractA2AServerTest.java: Client helper and extensive inline comments
