### PR TITLE
fix: Why not set tenant to "" in ListTasksParams$Builder?

### DIFF
--- a/spec/src/main/java/io/a2a/spec/DeleteTaskPushNotificationConfigParams.java
+++ b/spec/src/main/java/io/a2a/spec/DeleteTaskPushNotificationConfigParams.java
@@ -3,6 +3,7 @@ package io.a2a.spec;
 
 
 import io.a2a.util.Assert;
+import io.a2a.util.Utils;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -111,7 +112,7 @@ public record DeleteTaskPushNotificationConfigParams(String id, String pushNotif
             return new DeleteTaskPushNotificationConfigParams(
                     Assert.checkNotNullParam("id", id),
                     Assert.checkNotNullParam("pushNotificationConfigId", pushNotificationConfigId),
-                    Assert.checkNotNullParam("tenant", tenant));
+                    Utils.defaultIfNull(tenant,""));
         }
     }
 }

--- a/spec/src/main/java/io/a2a/spec/GetTaskPushNotificationConfigParams.java
+++ b/spec/src/main/java/io/a2a/spec/GetTaskPushNotificationConfigParams.java
@@ -3,6 +3,7 @@ package io.a2a.spec;
 
 
 import io.a2a.util.Assert;
+import io.a2a.util.Utils;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -108,7 +109,7 @@ public record GetTaskPushNotificationConfigParams(String id, String pushNotifica
             return new GetTaskPushNotificationConfigParams(
                     Assert.checkNotNullParam("id", id),
                     Assert.checkNotNullParam("pushNotificationConfigId", pushNotificationConfigId),
-                    Assert.checkNotNullParam("tenant", tenant));
+                    Utils.defaultIfNull(tenant,""));
         }
     }
 }

--- a/spec/src/main/java/io/a2a/spec/ListTaskPushNotificationConfigParams.java
+++ b/spec/src/main/java/io/a2a/spec/ListTaskPushNotificationConfigParams.java
@@ -1,6 +1,8 @@
 package io.a2a.spec;
 
 import io.a2a.util.Assert;
+import io.a2a.util.Utils;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Parameters for listing all push notification configurations for a task.
@@ -50,5 +52,89 @@ public record ListTaskPushNotificationConfigParams(String id, int pageSize, Stri
         return 100;
       }
       return pageSize;
+    }
+
+    /**
+     * Create a new Builder
+     *
+     * @return the builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for constructing instances.
+     */
+    public static class Builder {
+        private @Nullable String id;
+        private @Nullable Integer pageSize;
+        private @Nullable String pageToken;
+        private @Nullable String tenant;
+
+        /**
+         * Creates a new Builder with all fields unset.
+         */
+        private Builder() {
+        }
+
+        /**
+         * Sets the id.
+         *
+         * @param id the task identifier (required)
+         * @return this builder for method chaining
+         */
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        /**
+         * Sets the pageSize.
+         *
+         * @param pageSize the maximum number of items to return per page
+         * @return this builder for method chaining
+         */
+        public Builder pageSize(Integer pageSize) {
+            this.pageSize = pageSize;
+            return this;
+        }
+
+        /**
+         * Sets the pageToken.
+         *
+         * @param pageToken the pagination token for the next page
+         * @return this builder for method chaining
+         */
+        public Builder pageToken(String pageToken) {
+            this.pageToken = pageToken;
+            return this;
+        }
+
+        /**
+         * Sets the tenant.
+         *
+         * @param tenant the tenant identifier
+         * @return this builder for method chaining
+         */
+        public Builder tenant(String tenant) {
+            this.tenant = tenant;
+            return this;
+        }
+
+        /**
+         * Builds the ListTaskPushNotificationConfigParams.
+         *
+         * @return a new ListTaskPushNotificationConfigParams instance
+         * @throws IllegalArgumentException if id is null
+         */
+        public ListTaskPushNotificationConfigParams build() {
+            return new ListTaskPushNotificationConfigParams(
+                Assert.checkNotNullParam("id", id),
+                pageSize != null ? pageSize : 0,
+                pageToken != null ? pageToken : "",
+                Utils.defaultIfNull(tenant,"")
+            );
+        }
     }
 }

--- a/spec/src/main/java/io/a2a/spec/ListTasksParams.java
+++ b/spec/src/main/java/io/a2a/spec/ListTasksParams.java
@@ -227,7 +227,7 @@ public record ListTasksParams(
          */
         public ListTasksParams build() {
             return new ListTasksParams(contextId, status, pageSize, pageToken, historyLength,
-                    statusTimestampAfter, includeArtifacts, Assert.checkNotNullParam("tenant", tenant));
+                    statusTimestampAfter, includeArtifacts, tenant == null ? "" : tenant);
         }
     }
 }

--- a/spec/src/main/java/io/a2a/spec/TaskIdParams.java
+++ b/spec/src/main/java/io/a2a/spec/TaskIdParams.java
@@ -1,6 +1,8 @@
 package io.a2a.spec;
 
 import io.a2a.util.Assert;
+import io.a2a.util.Utils;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Parameters containing a task identifier for task-related operations.
@@ -33,5 +35,63 @@ public record TaskIdParams(String id, String tenant) {
      */
     public TaskIdParams(String id) {
         this(id, "");
+    }
+
+    /**
+     * Create a new Builder
+     *
+     * @return the builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for constructing instances.
+     */
+    public static class Builder {
+        private @Nullable String id;
+        private @Nullable String tenant;
+
+        /**
+         * Creates a new Builder with all fields unset.
+         */
+        private Builder() {
+        }
+
+        /**
+         * Sets the id.
+         *
+         * @param id the task identifier (required)
+         * @return this builder for method chaining
+         */
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        /**
+         * Sets the tenant.
+         *
+         * @param tenant the tenant identifier
+         * @return this builder for method chaining
+         */
+        public Builder tenant(String tenant) {
+            this.tenant = tenant;
+            return this;
+        }
+
+        /**
+         * Builds the TaskIdParams.
+         *
+         * @return a new TaskIdParams instance
+         * @throws IllegalArgumentException if id is null
+         */
+        public TaskIdParams build() {
+            return new TaskIdParams(
+                Assert.checkNotNullParam("id", id),
+                Utils.defaultIfNull(tenant,"")
+            );
+        }
     }
 }

--- a/spec/src/main/java/io/a2a/spec/TaskQueryParams.java
+++ b/spec/src/main/java/io/a2a/spec/TaskQueryParams.java
@@ -1,6 +1,7 @@
 package io.a2a.spec;
 
 import io.a2a.util.Assert;
+import io.a2a.util.Utils;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -46,5 +47,76 @@ public record TaskQueryParams(String id, @Nullable Integer historyLength, String
      */
     public TaskQueryParams(String id) {
         this(id, null, "");
+    }
+
+    /**
+     * Create a new Builder
+     *
+     * @return the builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for constructing instances.
+     */
+    public static class Builder {
+        private @Nullable String id;
+        private @Nullable Integer historyLength;
+        private @Nullable String tenant;
+
+        /**
+         * Creates a new Builder with all fields unset.
+         */
+        private Builder() {
+        }
+
+        /**
+         * Sets the id.
+         *
+         * @param id the task identifier (required)
+         * @return this builder for method chaining
+         */
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        /**
+         * Sets the historyLength.
+         *
+         * @param historyLength the maximum number of history items to include
+         * @return this builder for method chaining
+         */
+        public Builder historyLength(Integer historyLength) {
+            this.historyLength = historyLength;
+            return this;
+        }
+
+        /**
+         * Sets the tenant.
+         *
+         * @param tenant the tenant identifier
+         * @return this builder for method chaining
+         */
+        public Builder tenant(String tenant) {
+            this.tenant = tenant;
+            return this;
+        }
+
+        /**
+         * Builds the TaskQueryParams.
+         *
+         * @return a new TaskQueryParams instance
+         * @throws IllegalArgumentException if id is null or historyLength is negative
+         */
+        public TaskQueryParams build() {
+            return new TaskQueryParams(
+                Assert.checkNotNullParam("id", id),
+                historyLength,
+                Utils.defaultIfNull(tenant,"")
+            );
+        }
     }
 }


### PR DESCRIPTION
ListTasksParams.Builder should set the tenant to "" when it is not defined.

Fixes #653 🦕