### PR TITLE
feat: Add metadata support to Part types

### DIFF
--- a/extras/queue-manager-replicated/tests-multi-instance/tests/pom.xml
+++ b/extras/queue-manager-replicated/tests-multi-instance/tests/pom.xml
@@ -84,8 +84,6 @@
                     <!-- Ensure tests run with proper module path for Testcontainers -->
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <!-- workaround for https://github.com/testcontainers/testcontainers-java/issues/11212 -->
-                        <api.version>1.44</api.version>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <rest-assured.version>5.5.1</rest-assured.version>
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.18</logback.version>
+        <version.testcontainers>1.21.4</version.testcontainers>
         <error-prone.version>2.47.0</error-prone.version>
         <nullaway.version>0.13.1</nullaway.version>
         <error-prone.flag>-XDaddTypeAnnotationsToSymbol=true</error-prone.flag>
@@ -223,6 +224,13 @@
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-bom</artifactId>
                 <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${version.testcontainers}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/server-common/src/main/java/io/a2a/server/util/ArtifactUtils.java
+++ b/server-common/src/main/java/io/a2a/server/util/ArtifactUtils.java
@@ -1,7 +1,6 @@
 package io.a2a.server.util;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import io.a2a.spec.Artifact;

--- a/spec/src/main/java/io/a2a/spec/DataPart.java
+++ b/spec/src/main/java/io/a2a/spec/DataPart.java
@@ -2,6 +2,7 @@ package io.a2a.spec;
 
 
 import io.a2a.util.Assert;
+import java.util.Map;
 import org.jspecify.annotations.Nullable;
 
 
@@ -37,11 +38,12 @@ import org.jspecify.annotations.Nullable;
  * }</pre>
  *
  * @param data the structured data (required, supports JSON objects, arrays, primitives, and null)
+ * @param metadata additional metadata for the part
  * @see Part
  * @see Message
  * @see Artifact
  */
-public record DataPart(Object data) implements Part<Object> {
+public record DataPart(Object data, @Nullable Map<String, Object> metadata) implements Part<Object> {
 
     /**
      * The JSON member name discriminator for data parts: "data".
@@ -60,50 +62,19 @@ public record DataPart(Object data) implements Part<Object> {
      * @param data the structured data (supports JSON objects, arrays, primitives, and null)
      * @throws IllegalArgumentException if data is null
      */
-    public DataPart {
+    public DataPart (Object data, @Nullable Map<String, Object> metadata) {
         Assert.checkNotNullParam("data", data);
+        this.metadata = metadata == null ? null : Map.copyOf(metadata);
+        this.data = data;
     }
 
     /**
-     * Create a new Builder
+     * Constructor.
      *
-     * @return the builder
+     * @param data the structured data (supports JSON objects, arrays, primitives, and not null)
+     * @throws IllegalArgumentException if data is null
      */
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    /**
-     * Builder for constructing {@link DataPart} instances.
-     */
-    public static class Builder {
-        private @Nullable Object data;
-
-        /**
-         * Creates a new Builder with all fields unset.
-         */
-        private Builder() {
-        }
-
-        /**
-         * Sets the structured data.
-         *
-         * @param data the structured data (required, supports JSON objects, arrays, primitives, and null)
-         * @return this builder for method chaining
-         */
-        public Builder data(Object data) {
-            this.data = data;
-            return this;
-        }
-
-        /**
-         * Builds a new {@link DataPart} from the current builder state.
-         *
-         * @return a new DataPart instance
-         * @throws IllegalArgumentException if data is null
-         */
-        public DataPart build() {
-            return new DataPart(Assert.checkNotNullParam("data", data));
-        }
+    public DataPart(Object data) {
+        this(data, null);
     }
 }

--- a/spec/src/main/java/io/a2a/spec/FilePart.java
+++ b/spec/src/main/java/io/a2a/spec/FilePart.java
@@ -2,6 +2,8 @@ package io.a2a.spec;
 
 
 import io.a2a.util.Assert;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 
 /**
@@ -31,12 +33,13 @@ import io.a2a.util.Assert;
  * }</pre>
  *
  * @param file the file content (required, either FileWithBytes or FileWithUri)
+ * @param metadata additional metadata for the part
  * @see Part
  * @see FileContent
  * @see FileWithBytes
  * @see FileWithUri
  */
-public record FilePart(FileContent file) implements Part<FileContent> {
+public record FilePart(FileContent file, @Nullable Map<String, Object> metadata) implements Part<FileContent> {
 
     /**
      * The JSON member name discriminator for file parts: "file".
@@ -52,7 +55,19 @@ public record FilePart(FileContent file) implements Part<FileContent> {
      * @param file the file content (required, either FileWithBytes or FileWithUri)
      * @throws IllegalArgumentException if file is null
      */
-    public FilePart {
+    public FilePart (FileContent file, @Nullable Map<String, Object> metadata) {
         Assert.checkNotNullParam("file", file);
+        this.metadata = metadata == null ? null : Map.copyOf(metadata);
+        this.file = file;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param file the file content (required, either FileWithBytes or FileWithUri)
+     * @throws IllegalArgumentException if file is null
+     */
+    public FilePart (FileContent file) {
+        this(file, null);
     }
 }

--- a/spec/src/main/java/io/a2a/spec/Message.java
+++ b/spec/src/main/java/io/a2a/spec/Message.java
@@ -35,14 +35,12 @@ import org.jspecify.annotations.Nullable;
  * @see <a href="https://a2a-protocol.org/latest/">A2A Protocol Specification</a>
  */
 public record Message(Role role, List<Part<?>> parts,
-        String messageId, @Nullable
-        String contextId,
-        @Nullable
-        String taskId, @Nullable
-        List<String> referenceTaskIds,
-        @Nullable
-        Map<String, Object> metadata, @Nullable
-        List<String> extensions
+        String messageId,
+        @Nullable String contextId,
+        @Nullable String taskId,
+        @Nullable List<String> referenceTaskIds,
+        @Nullable Map<String, Object> metadata,
+        @Nullable List<String> extensions
         ) implements EventKind, StreamingEventKind {
 
     /**

--- a/spec/src/main/java/io/a2a/spec/TextPart.java
+++ b/spec/src/main/java/io/a2a/spec/TextPart.java
@@ -2,6 +2,8 @@ package io.a2a.spec;
 
 
 import io.a2a.util.Assert;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 
 /**
@@ -20,11 +22,12 @@ import io.a2a.util.Assert;
  * }</pre>
  *
  * @param text the text content (required, must not be null)
+ * @param metadata additional metadata for the part
  * @see Part
  * @see Message
  * @see Artifact
  */
-public record TextPart(String text) implements Part<String> {
+public record TextPart(String text, @Nullable Map<String, Object> metadata) implements Part<String> {
 
     /**
      * The JSON member name discriminator for text parts: "text".
@@ -40,7 +43,19 @@ public record TextPart(String text) implements Part<String> {
      * @param text the text content (required, must not be null)
      * @throws IllegalArgumentException if text is null
      */
-    public TextPart {
+    public TextPart (String text, @Nullable Map<String, Object> metadata) {
         Assert.checkNotNullParam("text", text);
+        this.metadata = metadata == null ? null : Map.copyOf(metadata);
+        this.text = text;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param text the text content (required, must not be null)
+     * @throws IllegalArgumentException if data is null
+     */
+    public TextPart (String text){
+        this(text, null);
     }
 }

--- a/transport/grpc/src/test/java/io/a2a/transport/grpc/handler/GrpcHandlerTest.java
+++ b/transport/grpc/src/test/java/io/a2a/transport/grpc/handler/GrpcHandlerTest.java
@@ -54,7 +54,10 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
             .setContextId(AbstractA2ARequestHandlerTest.MINIMAL_TASK.contextId())
             .setMessageId(AbstractA2ARequestHandlerTest.MESSAGE.messageId())
             .setRole(Role.ROLE_AGENT)
-            .addParts(Part.newBuilder().setText(((TextPart) AbstractA2ARequestHandlerTest.MESSAGE.parts().get(0)).text()).build())
+            .addParts(Part.newBuilder()
+                    .setText(((TextPart) AbstractA2ARequestHandlerTest.MESSAGE.parts().get(0)).text())
+                    .setMetadata(Struct.newBuilder().build())
+                    .build())
             .setMetadata(Struct.newBuilder().build())
             .build();
 


### PR DESCRIPTION
Add optional metadata field to TextPart, FilePart, and DataPart records to support additional contextual information for message and artifact content parts as specified in the A2A protocol v1.0.

Changes:
  - Add metadata parameter to Part constructors (TextPart, FilePart, DataPart)
  - Update PartMapper to convert metadata between domain and gRPC proto
  - Update JsonUtil PartTypeAdapter to serialize/deserialize metadata

Fixes #649 🦕