### PR TITLE
feat!: Update TaskState enums

### DIFF
--- a/client/base/src/main/java/io/a2a/client/ClientTaskManager.java
+++ b/client/base/src/main/java/io/a2a/client/ClientTaskManager.java
@@ -60,7 +60,7 @@ public class ClientTaskManager {
         Task task = currentTask;
         if (task == null) {
             task = Task.builder()
-                    .status(new TaskStatus(TaskState.UNKNOWN))
+                    .status(new TaskStatus(TaskState.UNRECOGNIZED))
                     .id(taskId)
                     .contextId(contextId == null ? "" : contextId)
                     .build();
@@ -96,7 +96,7 @@ public class ClientTaskManager {
         Task task = currentTask;
         if (task == null) {
             task = Task.builder()
-                    .status(new TaskStatus(TaskState.UNKNOWN))
+                    .status(new TaskStatus(TaskState.UNRECOGNIZED))
                     .id(taskId)
                     .contextId(contextId == null ? "" : contextId)
                     .build();

--- a/client/base/src/test/java/io/a2a/client/ClientTaskManagerTest.java
+++ b/client/base/src/test/java/io/a2a/client/ClientTaskManagerTest.java
@@ -37,7 +37,7 @@ public class ClientTaskManagerTest {
         sampleTask = Task.builder()
                 .id("task123")
                 .contextId("context456")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
         
         sampleMessage = Message.builder()
@@ -82,12 +82,12 @@ public class ClientTaskManagerTest {
         TaskStatusUpdateEvent statusUpdate = TaskStatusUpdateEvent.builder()
                 .taskId(sampleTask.id())
                 .contextId(sampleTask.contextId())
-                .status(new TaskStatus(TaskState.COMPLETED, sampleMessage, null))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED, sampleMessage, null))
                 .build();
         
         Task updatedTask = taskManager.saveTaskEvent(statusUpdate);
         
-        assertEquals(TaskState.COMPLETED, updatedTask.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, updatedTask.status().state());
         assertNotNull(updatedTask.history());
         assertEquals(1, updatedTask.history().size());
         assertEquals(sampleMessage, updatedTask.history().get(0));
@@ -104,7 +104,7 @@ public class ClientTaskManagerTest {
         TaskStatusUpdateEvent statusUpdate = TaskStatusUpdateEvent.builder()
                 .taskId(sampleTask.id())
                 .contextId(sampleTask.contextId())
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .metadata(metadata)
                 .build();
         
@@ -143,7 +143,7 @@ public class ClientTaskManagerTest {
         TaskStatusUpdateEvent statusUpdate = TaskStatusUpdateEvent.builder()
                 .taskId("new_task")
                 .contextId("new_context")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
         
         Task updatedTask = taskManager.saveTaskEvent(statusUpdate);
@@ -151,7 +151,7 @@ public class ClientTaskManagerTest {
         assertNotNull(updatedTask);
         assertEquals("new_task", updatedTask.id());
         assertEquals("new_context", updatedTask.contextId());
-        assertEquals(TaskState.WORKING, updatedTask.status().state());
+        assertEquals(TaskState.TASK_STATE_WORKING, updatedTask.status().state());
     }
 
     @Test
@@ -182,7 +182,7 @@ public class ClientTaskManagerTest {
         Task taskWithHistory = Task.builder()
                 .id("task123")
                 .contextId("context456")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
         
         Task updatedTask = taskManager.updateWithMessage(sampleMessage, taskWithHistory);
@@ -203,7 +203,7 @@ public class ClientTaskManagerTest {
         Task taskWithStatusMessage = Task.builder()
                 .id("task123")
                 .contextId("context456")
-                .status(new TaskStatus(TaskState.WORKING, statusMessage, null))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING, statusMessage, null))
                 .build();
         
         Task updatedTask = taskManager.updateWithMessage(sampleMessage, taskWithStatusMessage);
@@ -226,7 +226,7 @@ public class ClientTaskManagerTest {
         Task taskWithHistory = Task.builder()
                 .id("task123")
                 .contextId("context456")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .history(List.of(existingMessage))
                 .build();
         
@@ -246,11 +246,11 @@ public class ClientTaskManagerTest {
         TaskStatusUpdateEvent statusUpdate1 = TaskStatusUpdateEvent.builder()
                 .taskId(sampleTask.id())
                 .contextId(sampleTask.contextId())
-                .status(new TaskStatus(TaskState.WORKING, sampleMessage, null))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING, sampleMessage, null))
                 .build();
         
         Task updatedTask1 = taskManager.saveTaskEvent(statusUpdate1);
-        assertEquals(TaskState.WORKING, updatedTask1.status().state());
+        assertEquals(TaskState.TASK_STATE_WORKING, updatedTask1.status().state());
         assertEquals(1, updatedTask1.history().size());
         
         // Second status update
@@ -263,11 +263,11 @@ public class ClientTaskManagerTest {
         TaskStatusUpdateEvent statusUpdate2 = TaskStatusUpdateEvent.builder()
                 .taskId(sampleTask.id())
                 .contextId(sampleTask.contextId())
-                .status(new TaskStatus(TaskState.COMPLETED, secondMessage, null))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED, secondMessage, null))
                 .build();
         
         Task updatedTask2 = taskManager.saveTaskEvent(statusUpdate2);
-        assertEquals(TaskState.COMPLETED, updatedTask2.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, updatedTask2.status().state());
         assertEquals(2, updatedTask2.history().size());
     }
 
@@ -311,7 +311,7 @@ public class ClientTaskManagerTest {
         TaskStatusUpdateEvent statusUpdate = TaskStatusUpdateEvent.builder()
                 .taskId("task_with_empty_context")
                 .contextId("")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
         
         Task updatedTask = taskManager.saveTaskEvent(statusUpdate);

--- a/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportStreamingTest.java
+++ b/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportStreamingTest.java
@@ -158,7 +158,7 @@ public class JSONRPCTransportStreamingTest {
         Task task = (Task) eventKind;
         assertEquals("2", task.id());
         assertEquals("context-1234", task.contextId());
-        assertEquals(TaskState.COMPLETED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, task.status().state());
         List<Artifact> artifacts = task.artifacts();
         assertEquals(1, artifacts.size());
         Artifact artifact = artifacts.get(0);

--- a/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportTest.java
+++ b/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportTest.java
@@ -122,7 +122,7 @@ public class JSONRPCTransportTest {
         Task task = (Task) result;
         assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
         assertNotNull(task.contextId());
-        assertEquals(TaskState.COMPLETED,task.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED,task.status().state());
         assertEquals(1, task.artifacts().size());
         Artifact artifact = task.artifacts().get(0);
         assertEquals("artifact-1", artifact.artifactId());
@@ -235,7 +235,7 @@ public class JSONRPCTransportTest {
                 10), null);
         assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
         assertEquals("c295ea44-7543-4f78-b524-7a38915ad6e4", task.contextId());
-        assertEquals(TaskState.COMPLETED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, task.status().state());
         assertEquals(1, task.artifacts().size());
         Artifact artifact = task.artifacts().get(0);
         assertEquals(1, artifact.parts().size());
@@ -287,7 +287,7 @@ public class JSONRPCTransportTest {
         Task task = client.cancelTask(new TaskIdParams("de38c76d-d54c-436c-8b9f-4c2703648d64"), null);
         assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
         assertEquals("c295ea44-7543-4f78-b524-7a38915ad6e4", task.contextId());
-        assertEquals(TaskState.CANCELED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_CANCELED, task.status().state());
         assertTrue(task.metadata().isEmpty());
     }
 
@@ -457,7 +457,7 @@ public class JSONRPCTransportTest {
         Task task = (Task) result;
         assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
         assertNotNull(task.contextId());
-        assertEquals(TaskState.COMPLETED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, task.status().state());
         assertEquals(1, task.artifacts().size());
         Artifact artifact = task.artifacts().get(0);
         assertEquals("artifact-1", artifact.artifactId());
@@ -517,7 +517,7 @@ public class JSONRPCTransportTest {
         Task task = (Task) result;
         assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
         assertNotNull(task.contextId());
-        assertEquals(TaskState.COMPLETED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, task.status().state());
         assertEquals(1, task.artifacts().size());
         Artifact artifact = task.artifacts().get(0);
         assertEquals("artifact-1", artifact.artifactId());
@@ -575,7 +575,7 @@ public class JSONRPCTransportTest {
         Task task = (Task) result;
         assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
         assertNotNull(task.contextId());
-        assertEquals(TaskState.COMPLETED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, task.status().state());
         assertEquals(1, task.artifacts().size());
         Artifact artifact = task.artifacts().get(0);
         assertEquals("artifact-1", artifact.artifactId());

--- a/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/sse/SSEEventListenerTest.java
+++ b/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/sse/SSEEventListenerTest.java
@@ -50,7 +50,7 @@ public class SSEEventListenerTest {
         Task task = (Task) receivedEvent.get();
         assertEquals("task-123", task.id());
         assertEquals("context-456", task.contextId());
-        assertEquals(TaskState.WORKING, task.status().state());
+        assertEquals(TaskState.TASK_STATE_WORKING, task.status().state());
     }
 
     @Test
@@ -104,7 +104,7 @@ public class SSEEventListenerTest {
         assertEquals("1", taskStatusUpdateEvent.taskId());
         assertEquals("2", taskStatusUpdateEvent.contextId());
         assertFalse(taskStatusUpdateEvent.isFinal());
-        assertEquals(TaskState.SUBMITTED, taskStatusUpdateEvent.status().state());
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, taskStatusUpdateEvent.status().state());
     }
 
     @Test
@@ -184,7 +184,7 @@ public class SSEEventListenerTest {
 
     @Test
     public void testFinalTaskStatusUpdateEventCancels() {
-        TaskStatus completedStatus = new TaskStatus(TaskState.COMPLETED);
+        TaskStatus completedStatus = new TaskStatus(TaskState.TASK_STATE_COMPLETED);
         // Use constructor since Builder doesn't have isFinal method
         TaskStatusUpdateEvent tsue = new TaskStatusUpdateEvent(
                 "1234",
@@ -243,7 +243,7 @@ public class SSEEventListenerTest {
         assertEquals("1", taskStatusUpdateEvent.taskId());
         assertEquals("2", taskStatusUpdateEvent.contextId());
         assertTrue(taskStatusUpdateEvent.isFinal());
-        assertEquals(TaskState.COMPLETED, taskStatusUpdateEvent.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, taskStatusUpdateEvent.status().state());
 
         assertTrue(future.cancelHandlerCalled);
     }

--- a/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestTransport.java
+++ b/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestTransport.java
@@ -250,7 +250,7 @@ public class RestTransport implements ClientTransport {
             queryParts.add("contextId=" + URLEncoder.encode(request.contextId(), StandardCharsets.UTF_8));
         }
         if (request.status() != null) {
-            queryParts.add("status=" + request.status().asString());
+            queryParts.add("status=" + request.status());
         }
         if (request.pageSize() != null) {
             queryParts.add("pageSize=" + request.pageSize());

--- a/client/transport/rest/src/test/java/io/a2a/client/transport/rest/RestTransportTest.java
+++ b/client/transport/rest/src/test/java/io/a2a/client/transport/rest/RestTransportTest.java
@@ -136,7 +136,7 @@ public class RestTransportTest {
         Task task = (Task) result;
         assertEquals("9b511af4-b27c-47fa-aecf-2a93c08a44f8", task.id());
         assertEquals("context-1234", task.contextId());
-        assertEquals(TaskState.SUBMITTED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, task.status().state());
         assertNull(task.status().message());
         assertNull(task.metadata());
         assertEquals(true, task.artifacts().isEmpty());
@@ -174,7 +174,7 @@ public class RestTransportTest {
         RestTransport instance = new RestTransport(CARD);
         Task task = instance.cancelTask(new TaskIdParams("de38c76d-d54c-436c-8b9f-4c2703648d64"), context);
         assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
-        assertEquals(TaskState.CANCELED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_CANCELED, task.status().state());
         assertNull(task.status().message());
         assertNotNull(task.metadata());
         assertTrue(task.metadata().isEmpty());
@@ -200,7 +200,7 @@ public class RestTransportTest {
         RestTransport instance = new RestTransport(CARD);
         Task task = instance.getTask(request, context);
         assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
-        assertEquals(TaskState.COMPLETED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, task.status().state());
         assertNull(task.status().message());
         assertNotNull(task.metadata());
         assertTrue(task.metadata().isEmpty());
@@ -438,7 +438,7 @@ public class RestTransportTest {
         Task task = (Task) eventKind;
         assertEquals("2", task.id());
         assertEquals("context-1234", task.contextId());
-        assertEquals(TaskState.COMPLETED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, task.status().state());
         List<Artifact> artifacts = task.artifacts();
         assertEquals(1, artifacts.size());
         Artifact artifact = artifacts.get(0);

--- a/client/transport/rest/src/test/java/io/a2a/client/transport/rest/sse/SSEEventListenerTest.java
+++ b/client/transport/rest/src/test/java/io/a2a/client/transport/rest/sse/SSEEventListenerTest.java
@@ -91,7 +91,7 @@ public class SSEEventListenerTest {
         Task task = (Task) receivedEvent.get();
         assertEquals("task-123", task.id());
         assertEquals("context-456", task.contextId());
-        assertEquals(TaskState.WORKING, task.status().state());
+        assertEquals(TaskState.TASK_STATE_WORKING, task.status().state());
     }
 
     @Test
@@ -165,7 +165,7 @@ public class SSEEventListenerTest {
         TaskStatusUpdateEvent taskStatusUpdateEvent = (TaskStatusUpdateEvent) receivedEvent.get();
         assertEquals("1", taskStatusUpdateEvent.taskId());
         assertEquals("2", taskStatusUpdateEvent.contextId());
-        assertEquals(TaskState.SUBMITTED, taskStatusUpdateEvent.status().state());
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, taskStatusUpdateEvent.status().state());
         assertEquals(false, taskStatusUpdateEvent.isFinal());
     }
 
@@ -200,7 +200,7 @@ public class SSEEventListenerTest {
         assertTrue(receivedEvent.get() instanceof TaskStatusUpdateEvent);
         TaskStatusUpdateEvent received = (TaskStatusUpdateEvent) receivedEvent.get();
         assertTrue(received.isFinal());
-        assertEquals(TaskState.COMPLETED, received.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, received.status().state());
 
         // Verify the future was cancelled (auto-close on final event)
         assertTrue(future.wasCancelled());
@@ -236,7 +236,7 @@ public class SSEEventListenerTest {
         assertNotNull(receivedEvent.get());
         assertTrue(receivedEvent.get() instanceof Task);
         Task task = (Task) receivedEvent.get();
-        assertEquals(TaskState.COMPLETED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, task.status().state());
 
         // Verify the future was cancelled (auto-close on final task state)
         assertTrue(future.wasCancelled());

--- a/client/transport/spi/src/test/java/io/a2a/client/transport/spi/sse/SSEEventListenerTest.java
+++ b/client/transport/spi/src/test/java/io/a2a/client/transport/spi/sse/SSEEventListenerTest.java
@@ -10,7 +10,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
 
 import io.a2a.spec.Message;
 import io.a2a.spec.StreamingEventKind;
@@ -22,9 +21,7 @@ import io.a2a.spec.TextPart;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for BaseSSEEventListener abstract class.
@@ -161,7 +158,7 @@ public class SSEEventListenerTest {
         AtomicReference<StreamingEventKind> receivedEvent = new AtomicReference<>();
         TestSSEEventListener listener = createListenerWithEventCapture(receivedEvent);
 
-        Task task = createTask(TaskState.WORKING);
+        Task task = createTask(TaskState.TASK_STATE_WORKING);
 
         listener.setEventToHandle(task);
         listener.onMessage(TEST_TEXT, null);
@@ -209,7 +206,7 @@ public class SSEEventListenerTest {
     @Test
     public void testShouldAutoCloseWithFinalTaskStatusUpdateEvent() {
         TestSSEEventListener listener = createBasicListener();
-        TaskStatusUpdateEvent finalEvent = createTaskStatusUpdateEvent(TaskState.COMPLETED, true);
+        TaskStatusUpdateEvent finalEvent = createTaskStatusUpdateEvent(TaskState.TASK_STATE_COMPLETED, true);
 
         assertTrue(listener.shouldAutoClose(finalEvent));
     }
@@ -217,13 +214,13 @@ public class SSEEventListenerTest {
     @Test
     public void testShouldAutoCloseWithNonFinalTaskStatusUpdateEvent() {
         TestSSEEventListener listener = createBasicListener();
-        TaskStatusUpdateEvent nonFinalEvent = createTaskStatusUpdateEvent(TaskState.WORKING, false);
+        TaskStatusUpdateEvent nonFinalEvent = createTaskStatusUpdateEvent(TaskState.TASK_STATE_WORKING, false);
 
         assertFalse(listener.shouldAutoClose(nonFinalEvent));
     }
 
     @ParameterizedTest
-    @EnumSource(value = TaskState.class, names = {"COMPLETED", "FAILED", "CANCELED"})
+    @EnumSource(value = TaskState.class, names = {"TASK_STATE_COMPLETED", "TASK_STATE_FAILED", "TASK_STATE_CANCELED"})
     public void testShouldAutoCloseWithFinalTaskStates(TaskState finalState) {
         TestSSEEventListener listener = createBasicListener();
         Task task = createTask(finalState);
@@ -233,7 +230,7 @@ public class SSEEventListenerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = TaskState.class, names = {"WORKING", "SUBMITTED"})
+    @EnumSource(value = TaskState.class, names = {"TASK_STATE_WORKING", "TASK_STATE_SUBMITTED"})
     public void testShouldAutoCloseWithNonFinalTaskStates(TaskState nonFinalState) {
         TestSSEEventListener listener = createBasicListener();
         Task task = createTask(nonFinalState);
@@ -255,7 +252,7 @@ public class SSEEventListenerTest {
         AtomicReference<StreamingEventKind> receivedEvent = new AtomicReference<>();
         TestSSEEventListener listener = createListenerWithEventCapture(receivedEvent);
 
-        TaskStatusUpdateEvent finalEvent = createTaskStatusUpdateEvent(TaskState.COMPLETED, true);
+        TaskStatusUpdateEvent finalEvent = createTaskStatusUpdateEvent(TaskState.TASK_STATE_COMPLETED, true);
         CancelCapturingFuture future = new CancelCapturingFuture();
 
         listener.setEventToHandle(finalEvent);
@@ -286,7 +283,7 @@ public class SSEEventListenerTest {
         AtomicReference<StreamingEventKind> receivedEvent = new AtomicReference<>();
         TestSSEEventListener listener = createListenerWithEventCapture(receivedEvent);
 
-        TaskStatusUpdateEvent finalEvent = createTaskStatusUpdateEvent(TaskState.COMPLETED, true);
+        TaskStatusUpdateEvent finalEvent = createTaskStatusUpdateEvent(TaskState.TASK_STATE_COMPLETED, true);
 
         // Should not throw with null future
         listener.setEventToHandle(finalEvent);

--- a/extras/opentelemetry/integration-tests/src/test/java/io/a2a/extras/opentelemetry/it/OpenTelemetryA2ABaseTest.java
+++ b/extras/opentelemetry/integration-tests/src/test/java/io/a2a/extras/opentelemetry/it/OpenTelemetryA2ABaseTest.java
@@ -69,7 +69,7 @@ abstract class OpenTelemetryA2ABaseTest extends BaseTest {
         Task task = Task.builder()
                 .id(taskId)
                 .contextId(contextId)
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .history(Collections.emptyList())
                 .artifacts(Collections.emptyList())
                 .build();
@@ -146,7 +146,7 @@ abstract class OpenTelemetryA2ABaseTest extends BaseTest {
         Task task = Task.builder()
                 .id(taskId)
                 .contextId(contextId)
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .history(Collections.emptyList())
                 .artifacts(Collections.emptyList())
                 .build();
@@ -159,7 +159,7 @@ abstract class OpenTelemetryA2ABaseTest extends BaseTest {
             Task cancelledTask = client.cancelTask(new TaskIdParams(taskId), null);
 
             assertNotNull(cancelledTask);
-            assertEquals(TaskState.CANCELED, cancelledTask.status().state());
+            assertEquals(TaskState.TASK_STATE_CANCELED, cancelledTask.status().state());
 
             Thread.sleep(5000);
 
@@ -191,7 +191,7 @@ abstract class OpenTelemetryA2ABaseTest extends BaseTest {
         Task task = Task.builder()
                 .id(taskId)
                 .contextId(contextId)
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .history(Collections.emptyList())
                 .artifacts(Collections.emptyList())
                 .build();

--- a/extras/opentelemetry/server/src/test/java/io/a2a/extras/opentelemetry/OpenTelemetryRequestHandlerDecoratorTest.java
+++ b/extras/opentelemetry/server/src/test/java/io/a2a/extras/opentelemetry/OpenTelemetryRequestHandlerDecoratorTest.java
@@ -93,7 +93,7 @@ class OpenTelemetryRequestHandlerDecoratorTest {
             Task result = Task.builder()
                     .id("task-123")
                     .contextId("ctx-1")
-                    .status(new TaskStatus(TaskState.COMPLETED))
+                    .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                     .history(Collections.emptyList())
                     .artifacts(Collections.emptyList())
                     .build();
@@ -167,7 +167,7 @@ class OpenTelemetryRequestHandlerDecoratorTest {
             Task result = Task.builder()
                     .id("task-123")
                     .contextId("ctx-1")
-                    .status(new TaskStatus(TaskState.CANCELED))
+                    .status(new TaskStatus(TaskState.TASK_STATE_CANCELED))
                     .history(Collections.emptyList())
                     .artifacts(Collections.emptyList())
                     .build();
@@ -212,7 +212,7 @@ class OpenTelemetryRequestHandlerDecoratorTest {
             EventKind result = Task.builder()
                     .id("task-123")
                     .contextId("ctx-1")
-                    .status(new TaskStatus(TaskState.COMPLETED))
+                    .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                     .history(Collections.emptyList())
                     .artifacts(Collections.emptyList())
                     .build();
@@ -461,7 +461,7 @@ class OpenTelemetryRequestHandlerDecoratorTest {
             Task result = Task.builder()
                     .id("task-123")
                     .contextId("ctx-1")
-                    .status(new TaskStatus(TaskState.COMPLETED))
+                    .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                     .history(Collections.emptyList())
                     .artifacts(Collections.emptyList())
                     .build();
@@ -479,7 +479,7 @@ class OpenTelemetryRequestHandlerDecoratorTest {
             Task result = Task.builder()
                     .id("task-123")
                     .contextId("ctx-1")
-                    .status(new TaskStatus(TaskState.COMPLETED))
+                    .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                     .history(Collections.emptyList())
                     .artifacts(Collections.emptyList())
                     .build();

--- a/extras/push-notification-config-store-database-jpa/src/test/java/io/a2a/extras/pushnotificationconfigstore/database/jpa/JpaDatabasePushNotificationConfigStoreIntegrationTest.java
+++ b/extras/push-notification-config-store-database-jpa/src/test/java/io/a2a/extras/pushnotificationconfigstore/database/jpa/JpaDatabasePushNotificationConfigStoreIntegrationTest.java
@@ -85,7 +85,7 @@ public class JpaDatabasePushNotificationConfigStoreIntegrationTest {
         Task testTask = Task.builder()
             .id("direct-test-task")
             .contextId("test-context")
-            .status(new io.a2a.spec.TaskStatus(io.a2a.spec.TaskState.SUBMITTED))
+            .status(new io.a2a.spec.TaskStatus(io.a2a.spec.TaskState.TASK_STATE_SUBMITTED))
             .build();
 
         // Directly trigger the mock

--- a/extras/push-notification-config-store-database-jpa/src/test/java/io/a2a/extras/pushnotificationconfigstore/database/jpa/JpaPushNotificationConfigStoreTest.java
+++ b/extras/push-notification-config-store-database-jpa/src/test/java/io/a2a/extras/pushnotificationconfigstore/database/jpa/JpaPushNotificationConfigStoreTest.java
@@ -234,7 +234,7 @@ public class JpaPushNotificationConfigStoreTest {
     @Transactional
     public void testSendNotificationSuccess() throws Exception {
         String taskId = "task_send_success";
-        Task task = createSampleTask(taskId, TaskState.COMPLETED);
+        Task task = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
         PushNotificationConfig config = createSamplePushConfig("http://notify.me/here", "cfg1", null);
         configStore.setInfo(taskId, config);
 
@@ -259,7 +259,7 @@ public class JpaPushNotificationConfigStoreTest {
         // Verify the request body contains the task data
         String sentBody = bodyCaptor.getValue();
         assertTrue(sentBody.contains(task.id()));
-        assertTrue(sentBody.contains(task.status().state().asString()));
+        assertTrue(sentBody.contains(task.status().state().name()));
     }
 
     @Test
@@ -267,7 +267,7 @@ public class JpaPushNotificationConfigStoreTest {
     @Disabled("Token authentication is not yet implemented in BasePushNotificationSender (TODO auth)")
     public void testSendNotificationWithToken() throws Exception {
         String taskId = "task_send_with_token";
-        Task task = createSampleTask(taskId, TaskState.COMPLETED);
+        Task task = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
         PushNotificationConfig config = createSamplePushConfig("http://notify.me/here", "cfg1", "unique_token");
         configStore.setInfo(taskId, config);
 
@@ -295,14 +295,14 @@ public class JpaPushNotificationConfigStoreTest {
         // Verify the request body contains the task data
         String sentBody = bodyCaptor.getValue();
         assertTrue(sentBody.contains(task.id()));
-        assertTrue(sentBody.contains(task.status().state().asString()));
+        assertTrue(sentBody.contains(task.status().state().name()));
     }
 
     @Test
     @Transactional
     public void testSendNotificationNoConfig() throws Exception {
         String taskId = "task_send_no_config";
-        Task task = createSampleTask(taskId, TaskState.COMPLETED);
+        Task task = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
 
         notificationSender.sendNotification(task);
 

--- a/extras/queue-manager-replicated/core/src/test/java/io/a2a/extras/queuemanager/replicated/core/EventSerializationTest.java
+++ b/extras/queue-manager-replicated/core/src/test/java/io/a2a/extras/queuemanager/replicated/core/EventSerializationTest.java
@@ -44,7 +44,7 @@ public class EventSerializationTest {
     @Test
     public void testTaskSerialization() throws JsonProcessingException {
         // Create a Task
-        TaskStatus status = new TaskStatus(TaskState.SUBMITTED);
+        TaskStatus status = new TaskStatus(TaskState.TASK_STATE_SUBMITTED);
         Task originalTask = Task.builder()
                 .id("test-task-123")
                 .contextId("test-context-456")
@@ -105,7 +105,7 @@ public class EventSerializationTest {
     @Test
     public void testTaskStatusUpdateEventSerialization() throws JsonProcessingException {
         // Create a TaskStatusUpdateEvent
-        TaskStatus status = new TaskStatus(TaskState.COMPLETED);
+        TaskStatus status = new TaskStatus(TaskState.TASK_STATE_COMPLETED);
         TaskStatusUpdateEvent originalEvent = TaskStatusUpdateEvent.builder()
                 .taskId("test-task-abc")
                 .contextId("test-context-def")
@@ -204,7 +204,7 @@ public class EventSerializationTest {
         TaskStatusUpdateEvent statusEvent = TaskStatusUpdateEvent.builder()
                 .taskId("replicated-test-task")
                 .contextId("replicated-test-context")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
 
         // Create ReplicatedEventQueueItem with StreamingEventKind
@@ -277,7 +277,7 @@ public class EventSerializationTest {
         TaskStatusUpdateEvent statusEvent = TaskStatusUpdateEvent.builder()
                 .taskId("backward-compat-task")
                 .contextId("backward-compat-context")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
 
         // Use the backward compatibility constructor

--- a/extras/queue-manager-replicated/core/src/test/java/io/a2a/extras/queuemanager/replicated/core/ReplicatedQueueManagerTest.java
+++ b/extras/queue-manager-replicated/core/src/test/java/io/a2a/extras/queuemanager/replicated/core/ReplicatedQueueManagerTest.java
@@ -66,7 +66,7 @@ class ReplicatedQueueManagerTest {
         testEvent = TaskStatusUpdateEvent.builder()
                 .taskId("test-task")
                 .contextId("test-context")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
     }
 
@@ -78,7 +78,7 @@ class ReplicatedQueueManagerTest {
         return TaskStatusUpdateEvent.builder()
                 .taskId(taskId)
                 .contextId("test-context")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
     }
 
@@ -274,7 +274,7 @@ class ReplicatedQueueManagerTest {
         TaskStatusUpdateEvent originalEvent = TaskStatusUpdateEvent.builder()
                 .taskId("json-test-task")
                 .contextId("json-test-context")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
         ReplicatedEventQueueItem original = new ReplicatedEventQueueItem("json-test-task", originalEvent);
 
@@ -346,7 +346,7 @@ class ReplicatedQueueManagerTest {
                         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                                 .taskId(taskId)  // Use same taskId as queue
                                 .contextId("test-context")
-                                .status(new TaskStatus(TaskState.WORKING))
+                                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                                 .build();
                         queue.enqueueEvent(event);
                     }
@@ -371,7 +371,7 @@ class ReplicatedQueueManagerTest {
                         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                                 .taskId(taskId)  // Use same taskId as queue
                                 .contextId("test-context")
-                                .status(new TaskStatus(TaskState.COMPLETED))
+                                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                                 .build();
                         ReplicatedEventQueueItem replicatedEvent = new ReplicatedEventQueueItem(taskId, event);
                         queueManager.onReplicatedEvent(replicatedEvent);
@@ -499,7 +499,7 @@ class ReplicatedQueueManagerTest {
         TaskStatusUpdateEvent newEvent = TaskStatusUpdateEvent.builder()
                 .taskId(taskId)
                 .contextId("test-context")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
         ReplicatedEventQueueItem replicatedEvent = new ReplicatedEventQueueItem(taskId, newEvent);
         queueManager.onReplicatedEvent(replicatedEvent);
@@ -534,7 +534,7 @@ class ReplicatedQueueManagerTest {
         Task finalTask = Task.builder()
                 .id(taskId)
                 .contextId("test-context")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
         TaskFinalizedEvent taskFinalizedEvent = new TaskFinalizedEvent(taskId, finalTask);
 

--- a/extras/queue-manager-replicated/replication-mp-reactive/src/test/java/io/a2a/extras/queuemanager/replicated/mp_reactive/ReactiveMessagingReplicationStrategyTest.java
+++ b/extras/queue-manager-replicated/replication-mp-reactive/src/test/java/io/a2a/extras/queuemanager/replicated/mp_reactive/ReactiveMessagingReplicationStrategyTest.java
@@ -43,7 +43,7 @@ class ReactiveMessagingReplicationStrategyTest {
         testEvent = TaskStatusUpdateEvent.builder()
                 .taskId("test-task")
                 .contextId("test-context")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
     }
 
@@ -52,7 +52,7 @@ class ReactiveMessagingReplicationStrategyTest {
         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                 .taskId(taskId)
                 .contextId(contextId)
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
         ReplicatedEventQueueItem replicatedEvent = new ReplicatedEventQueueItem(taskId, event);
         return JsonUtil.toJson(replicatedEvent);

--- a/extras/queue-manager-replicated/tests-multi-instance/tests/src/test/java/io/a2a/extras/queuemanager/replicated/tests/multiinstance/MultiInstanceReplicationTest.java
+++ b/extras/queue-manager-replicated/tests-multi-instance/tests/src/test/java/io/a2a/extras/queuemanager/replicated/tests/multiinstance/MultiInstanceReplicationTest.java
@@ -280,7 +280,7 @@ public class MultiInstanceReplicationTest {
 
             // Task should be in a non-final state (SUBMITTED or WORKING are both valid)
             TaskState state = createdTask.status().state();
-            assertTrue(state == TaskState.SUBMITTED || state == TaskState.WORKING,
+            assertTrue(state == TaskState.TASK_STATE_SUBMITTED || state == TaskState.TASK_STATE_WORKING,
                 "Task should be in SUBMITTED or WORKING state, but was: " + state);
             nonStreamingClient.close();
         } catch (Exception e) {

--- a/extras/queue-manager-replicated/tests-single-instance/src/test/java/io/a2a/extras/queuemanager/replicated/tests/KafkaReplicationIntegrationTest.java
+++ b/extras/queue-manager-replicated/tests-single-instance/src/test/java/io/a2a/extras/queuemanager/replicated/tests/KafkaReplicationIntegrationTest.java
@@ -165,7 +165,7 @@ public class KafkaReplicationIntegrationTest {
         Task task = createdTask.get();
         assertNotNull(task, "Task should be created");
         assertEquals(taskId, task.id());
-        assertEquals(TaskState.SUBMITTED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, task.status().state());
 
         // Wait for the event to be replicated to Kafka
         ReplicatedEventQueueItem replicatedEvent = testConsumer.waitForEvent(taskId, 30);
@@ -184,7 +184,7 @@ public class KafkaReplicationIntegrationTest {
         // Verify the event data is consistent with the task returned from the client
         assertEquals(taskId, statusUpdateEvent.taskId(), "Event task ID should match original task ID");
         assertEquals(contextId, statusUpdateEvent.contextId(), "Event context ID should match original context ID");
-        assertEquals(TaskState.SUBMITTED, statusUpdateEvent.status().state(), "Event should show SUBMITTED state");
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, statusUpdateEvent.status().state(), "Event should show SUBMITTED state");
         assertFalse(statusUpdateEvent.isFinal(), "Event should show final:false");
         assertEquals(TaskStatusUpdateEvent.STREAMING_EVENT_ID, statusUpdateEvent.kind(), "Event should indicate status-update type");
     }
@@ -221,7 +221,7 @@ public class KafkaReplicationIntegrationTest {
         assertTrue(createLatch.await(15, TimeUnit.SECONDS), "Task creation timed out");
         Task initialTask = createdTask.get();
         assertNotNull(initialTask, "Task should be created");
-        assertEquals(TaskState.SUBMITTED, initialTask.status().state(), "Initial task should be in SUBMITTED state");
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, initialTask.status().state(), "Initial task should be in SUBMITTED state");
 
         // Add a small delay to ensure the task is fully processed before resubscription
         Thread.sleep(1000);
@@ -248,7 +248,7 @@ public class KafkaReplicationIntegrationTest {
             // Process subsequent events
             if (event instanceof TaskUpdateEvent taskUpdateEvent) {
                 if (taskUpdateEvent.getUpdateEvent() instanceof TaskStatusUpdateEvent statusEvent) {
-                    if (statusEvent.status().state() == TaskState.COMPLETED) {
+                    if (statusEvent.status().state() == TaskState.TASK_STATE_COMPLETED) {
                         receivedCompletedEvent.set(statusEvent);
                         subscribeLatch.countDown();
                     }
@@ -277,7 +277,7 @@ public class KafkaReplicationIntegrationTest {
         TaskStatusUpdateEvent statusEvent = TaskStatusUpdateEvent.builder()
                 .taskId(taskId)
                 .contextId(contextId)
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
 
         ReplicatedEventQueueItem replicatedEvent = new ReplicatedEventQueueItem(taskId, statusEvent);
@@ -297,7 +297,7 @@ public class KafkaReplicationIntegrationTest {
         // Verify the received event
         TaskStatusUpdateEvent completedEvent = receivedCompletedEvent.get();
         assertNotNull(completedEvent, "Should have received a TaskStatusUpdateEvent");
-        assertEquals(TaskState.COMPLETED, completedEvent.status().state(), "Event should show COMPLETED state");
+        assertEquals(TaskState.TASK_STATE_COMPLETED, completedEvent.status().state(), "Event should show COMPLETED state");
         assertTrue(completedEvent.isFinal(), "Event should be marked as final");
         assertEquals(taskId, completedEvent.taskId(), "Event should have correct task ID");
         assertEquals(contextId, completedEvent.contextId(), "Event should have correct context ID");
@@ -334,7 +334,7 @@ public class KafkaReplicationIntegrationTest {
                 taskIdRef.set(taskEvent.getTask().id());
                 workingLatch.countDown();
             } else if (event instanceof TaskUpdateEvent tue && tue.getUpdateEvent() instanceof TaskStatusUpdateEvent status) {
-                if (status.status().state() == TaskState.WORKING) {
+                if (status.status().state() == TaskState.TASK_STATE_WORKING) {
                     taskIdRef.set(status.taskId());
                     workingLatch.countDown();
                 }

--- a/extras/task-store-database-jpa/src/main/java/io/a2a/extras/taskstore/database/jpa/JpaDatabaseTaskStore.java
+++ b/extras/task-store-database-jpa/src/main/java/io/a2a/extras/taskstore/database/jpa/JpaDatabaseTaskStore.java
@@ -275,7 +275,7 @@ public class JpaDatabaseTaskStore implements TaskStore, TaskStateProvider {
             query.setParameter("contextId", params.contextId());
         }
         if (params.status() != null) {
-            query.setParameter("state", params.status().asString());
+            query.setParameter("state", params.status().name());
         }
         if (params.statusTimestampAfter() != null) {
             query.setParameter("statusTimestampAfter", params.statusTimestampAfter());
@@ -304,7 +304,7 @@ public class JpaDatabaseTaskStore implements TaskStore, TaskStateProvider {
             countQuery.setParameter("contextId", params.contextId());
         }
         if (params.status() != null) {
-            countQuery.setParameter("state", params.status().asString());
+            countQuery.setParameter("state", params.status().name());
         }
         if (params.statusTimestampAfter() != null) {
             countQuery.setParameter("statusTimestampAfter", params.statusTimestampAfter());

--- a/extras/task-store-database-jpa/src/main/java/io/a2a/extras/taskstore/database/jpa/JpaTask.java
+++ b/extras/task-store-database-jpa/src/main/java/io/a2a/extras/taskstore/database/jpa/JpaTask.java
@@ -141,18 +141,11 @@ public class JpaTask {
      */
     private void updateDenormalizedFields(Task task) {
         this.contextId = task.contextId();
-        if (task.status() != null) {
-            io.a2a.spec.TaskState taskState = task.status().state();
-            this.state = (taskState != null) ? taskState.asString() : null;
-            // Extract status timestamp for efficient querying and sorting
-            // Truncate to milliseconds for keyset pagination consistency (pageToken uses millis)
-            this.statusTimestamp = (task.status().timestamp() != null)
-                    ? task.status().timestamp().toInstant().truncatedTo(java.time.temporal.ChronoUnit.MILLIS)
-                    : null;
-        } else {
-            this.state = null;
-            this.statusTimestamp = null;
-        }
+        io.a2a.spec.TaskState taskState = task.status().state();
+        this.state = taskState.name();
+        // Extract status timestamp for efficient querying and sorting
+        // Truncate to milliseconds for keyset pagination consistency (pageToken uses millis)
+        this.statusTimestamp = task.status().timestamp().toInstant().truncatedTo(java.time.temporal.ChronoUnit.MILLIS);
     }
 
     /**
@@ -162,8 +155,6 @@ public class JpaTask {
      * @param task the task to check for finalization
      */
     private void updateFinalizedTimestamp(Task task) {
-        if (task.status() != null && task.status().state() != null) {
-            setFinalizedAt(Instant.now(), task.status().state().isFinal());
-        }
+        setFinalizedAt(Instant.now(), task.status().state().isFinal());
     }
 }

--- a/extras/task-store-database-jpa/src/test/java/io/a2a/extras/taskstore/database/jpa/JpaDatabaseTaskStoreIntegrationTest.java
+++ b/extras/task-store-database-jpa/src/test/java/io/a2a/extras/taskstore/database/jpa/JpaDatabaseTaskStoreIntegrationTest.java
@@ -100,7 +100,7 @@ public class JpaDatabaseTaskStoreIntegrationTest {
         Task createdTask = taskRef.get();
         assertNotNull(createdTask);
         assertEquals(0, createdTask.artifacts().size());
-        assertEquals(TaskState.SUBMITTED, createdTask.status().state());
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, createdTask.status().state());
 
         // Send a message updating the Task
         userMessage = Message.builder()
@@ -129,23 +129,23 @@ public class JpaDatabaseTaskStoreIntegrationTest {
         Task updatedTask = taskRef2.get();
         assertNotNull(updatedTask);
         assertEquals(1, updatedTask.artifacts().size());
-        assertEquals(TaskState.SUBMITTED, updatedTask.status().state());
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, updatedTask.status().state());
 
         Task retrievedTask = client.getTask(new TaskQueryParams(taskId), null);
         assertNotNull(retrievedTask);
         assertEquals(1, retrievedTask.artifacts().size());
-        assertEquals(TaskState.SUBMITTED, retrievedTask.status().state());
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, retrievedTask.status().state());
 
         // Cancel the task
         Task cancelledTask = client.cancelTask(new TaskIdParams(taskId), null);
         assertNotNull(cancelledTask);
         assertEquals(1, cancelledTask.artifacts().size());
-        assertEquals(TaskState.CANCELED, cancelledTask.status().state());
+        assertEquals(TaskState.TASK_STATE_CANCELED, cancelledTask.status().state());
 
         Task retrievedCancelledTask = client.getTask(new TaskQueryParams(taskId), null);
         assertNotNull(retrievedCancelledTask);
         assertEquals(1, retrievedCancelledTask.artifacts().size());
-        assertEquals(TaskState.CANCELED, retrievedCancelledTask.status().state());
+        assertEquals(TaskState.TASK_STATE_CANCELED, retrievedCancelledTask.status().state());
 
         // None of the framework code deletes tasks, so just do this manually
         taskStore.delete(taskId);

--- a/extras/task-store-database-jpa/src/test/java/io/a2a/extras/taskstore/database/jpa/JpaDatabaseTaskStoreTest.java
+++ b/extras/task-store-database-jpa/src/test/java/io/a2a/extras/taskstore/database/jpa/JpaDatabaseTaskStoreTest.java
@@ -49,7 +49,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task = Task.builder()
                 .id("test-task-1")
                 .contextId("test-context-1")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .metadata(new HashMap<>())
                 .build();
 
@@ -62,7 +62,7 @@ public class JpaDatabaseTaskStoreTest {
         assertNotNull(retrieved);
         assertEquals("test-task-1", retrieved.id());
         assertEquals("test-context-1", retrieved.contextId());
-        assertEquals(TaskState.SUBMITTED, retrieved.status().state());
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, retrieved.status().state());
     }
 
     @Test
@@ -79,7 +79,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task = Task.builder()
                 .id("test-task-2")
                 .contextId("test-context-2")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .history(Collections.singletonList(message))
                 .build();
 
@@ -92,7 +92,7 @@ public class JpaDatabaseTaskStoreTest {
         assertNotNull(retrieved);
         assertEquals("test-task-2", retrieved.id());
         assertEquals("test-context-2", retrieved.contextId());
-        assertEquals(TaskState.WORKING, retrieved.status().state());
+        assertEquals(TaskState.TASK_STATE_WORKING, retrieved.status().state());
         assertEquals(1, retrieved.history().size());
         assertEquals("msg-1", retrieved.history().get(0).messageId());
         assertEquals("Hello, agent!", ((TextPart) retrieved.history().get(0).parts().get(0)).text());
@@ -105,7 +105,7 @@ public class JpaDatabaseTaskStoreTest {
         Task initialTask = Task.builder()
                 .id("test-task-3")
                 .contextId("test-context-3")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
         
         taskStore.save(initialTask, false);
@@ -114,7 +114,7 @@ public class JpaDatabaseTaskStoreTest {
         Task updatedTask = Task.builder()
                 .id("test-task-3")
                 .contextId("test-context-3")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
         
         taskStore.save(updatedTask, false);
@@ -124,7 +124,7 @@ public class JpaDatabaseTaskStoreTest {
         
         assertNotNull(retrieved);
         assertEquals("test-task-3", retrieved.id());
-        assertEquals(TaskState.COMPLETED, retrieved.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, retrieved.status().state());
     }
 
     @Test
@@ -141,7 +141,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task = Task.builder()
                 .id("test-task-4")
                 .contextId("test-context-4")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
         
         taskStore.save(task, false);
@@ -175,7 +175,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task = Task.builder()
                 .id("test-task-5")
                 .contextId("test-context-5")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .metadata(metadata)
                 .build();
 
@@ -198,7 +198,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task = Task.builder()
                 .id("test-task-active-1")
                 .contextId("test-context")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
         
         taskStore.save(task, false);
@@ -217,7 +217,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task = Task.builder()
                 .id("test-task-active-2")
                 .contextId("test-context")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
         
         taskStore.save(task, false);
@@ -226,7 +226,7 @@ public class JpaDatabaseTaskStoreTest {
         Task finalTask = Task.builder()
                 .id("test-task-active-2")
                 .contextId("test-context")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
         
         taskStore.save(finalTask, false);
@@ -245,7 +245,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task = Task.builder()
                 .id("test-task-active-3")
                 .contextId("test-context")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
         
         taskStore.save(task, false);
@@ -307,19 +307,19 @@ public class JpaDatabaseTaskStoreTest {
         Task task1 = Task.builder()
                 .id("task-context-1")
                 .contextId("context-A")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
 
         Task task2 = Task.builder()
                 .id("task-context-2")
                 .contextId("context-A")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
 
         Task task3 = Task.builder()
                 .id("task-context-3")
                 .contextId("context-B")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
 
         taskStore.save(task1, false);
@@ -346,19 +346,19 @@ public class JpaDatabaseTaskStoreTest {
         Task task1 = Task.builder()
                 .id("task-status-filter-1")
                 .contextId("context-status-filter-test")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
 
         Task task2 = Task.builder()
                 .id("task-status-filter-2")
                 .contextId("context-status-filter-test")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
 
         Task task3 = Task.builder()
                 .id("task-status-filter-3")
                 .contextId("context-status-filter-test")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
 
         taskStore.save(task1, false);
@@ -369,14 +369,14 @@ public class JpaDatabaseTaskStoreTest {
         ListTasksParams params = ListTasksParams.builder()
                 .contextId("context-status-filter-test")
                 .tenant("tenant")
-                .status(TaskState.WORKING)
+                .status(TaskState.TASK_STATE_WORKING)
                 .build();
         ListTasksResult result = taskStore.list(params);
 
         assertEquals(1, result.totalSize());
         assertEquals(1, result.pageSize());
         assertEquals(1, result.tasks().size());
-        assertEquals(TaskState.WORKING, result.tasks().get(0).status().state());
+        assertEquals(TaskState.TASK_STATE_WORKING, result.tasks().get(0).status().state());
     }
 
     @Test
@@ -386,19 +386,19 @@ public class JpaDatabaseTaskStoreTest {
         Task task1 = Task.builder()
                 .id("task-combined-1")
                 .contextId("context-X")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
 
         Task task2 = Task.builder()
                 .id("task-combined-2")
                 .contextId("context-X")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
 
         Task task3 = Task.builder()
                 .id("task-combined-3")
                 .contextId("context-Y")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
 
         taskStore.save(task1, false);
@@ -409,7 +409,7 @@ public class JpaDatabaseTaskStoreTest {
         ListTasksParams params = ListTasksParams.builder()
                 .contextId("context-X")
                 .tenant("tenant")
-                .status(TaskState.WORKING)
+                .status(TaskState.TASK_STATE_WORKING)
                 .build();
         ListTasksResult result = taskStore.list(params);
 
@@ -417,7 +417,7 @@ public class JpaDatabaseTaskStoreTest {
         assertEquals(1, result.pageSize());
         assertEquals("task-combined-2", result.tasks().get(0).id());
         assertEquals("context-X", result.tasks().get(0).contextId());
-        assertEquals(TaskState.WORKING, result.tasks().get(0).status().state());
+        assertEquals(TaskState.TASK_STATE_WORKING, result.tasks().get(0).status().state());
     }
 
     @Test
@@ -430,7 +430,7 @@ public class JpaDatabaseTaskStoreTest {
             Task task = Task.builder()
                     .id("task-page-" + i)
                     .contextId("context-pagination")
-                    .status(new TaskStatus(TaskState.SUBMITTED, null, sameTimestamp))
+                    .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED, null, sameTimestamp))
                     .build();
             taskStore.save(task, false);
         }
@@ -486,7 +486,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task1 = Task.builder()
                 .id("task-diff-a")
                 .contextId("context-diff-timestamps")
-                .status(new TaskStatus(TaskState.WORKING, null, now.minusMinutes(10)))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING, null, now.minusMinutes(10)))
                 .build();
         taskStore.save(task1, false);
 
@@ -494,7 +494,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task2 = Task.builder()
                 .id("task-diff-b")
                 .contextId("context-diff-timestamps")
-                .status(new TaskStatus(TaskState.WORKING, null, now.minusMinutes(5)))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING, null, now.minusMinutes(5)))
                 .build();
         taskStore.save(task2, false);
 
@@ -502,7 +502,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task3 = Task.builder()
                 .id("task-diff-c")
                 .contextId("context-diff-timestamps")
-                .status(new TaskStatus(TaskState.WORKING, null, now.minusMinutes(5)))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING, null, now.minusMinutes(5)))
                 .build();
         taskStore.save(task3, false);
 
@@ -510,7 +510,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task4 = Task.builder()
                 .id("task-diff-d")
                 .contextId("context-diff-timestamps")
-                .status(new TaskStatus(TaskState.WORKING, null, now))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING, null, now))
                 .build();
         taskStore.save(task4, false);
 
@@ -518,7 +518,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task5 = Task.builder()
                 .id("task-diff-e")
                 .contextId("context-diff-timestamps")
-                .status(new TaskStatus(TaskState.WORKING, null, now.minusMinutes(1)))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING, null, now.minusMinutes(1)))
                 .build();
         taskStore.save(task5, false);
 
@@ -612,7 +612,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task = Task.builder()
                 .id("task-history-limit-unique-1")
                 .contextId("context-history-limit-unique")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .history(longHistory)
                 .build();
 
@@ -650,7 +650,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task = Task.builder()
                 .id("task-artifact-unique-1")
                 .contextId("context-artifact-unique")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .artifacts(artifacts)
                 .build();
 
@@ -689,7 +689,7 @@ public class JpaDatabaseTaskStoreTest {
             Task task = Task.builder()
                     .id("task-default-pagesize-" + String.format("%03d", i))
                     .contextId("context-default-pagesize")
-                    .status(new TaskStatus(TaskState.SUBMITTED))
+                    .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                     .build();
             taskStore.save(task, false);
         }
@@ -713,7 +713,7 @@ public class JpaDatabaseTaskStoreTest {
         Task task = Task.builder()
                 .id("task-invalid-token")
                 .contextId("context-invalid-token")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
         taskStore.save(task, false);
 
@@ -761,19 +761,19 @@ public class JpaDatabaseTaskStoreTest {
         Task task1 = Task.builder()
                 .id("task-order-a")
                 .contextId("context-order")
-                .status(new TaskStatus(TaskState.SUBMITTED, null, sameTimestamp))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED, null, sameTimestamp))
                 .build();
 
         Task task2 = Task.builder()
                 .id("task-order-b")
                 .contextId("context-order")
-                .status(new TaskStatus(TaskState.SUBMITTED, null, sameTimestamp))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED, null, sameTimestamp))
                 .build();
 
         Task task3 = Task.builder()
                 .id("task-order-c")
                 .contextId("context-order")
-                .status(new TaskStatus(TaskState.SUBMITTED, null, sameTimestamp))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED, null, sameTimestamp))
                 .build();
 
         // Save in reverse order

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/json/JsonUtil.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/json/JsonUtil.java
@@ -76,7 +76,6 @@ public class JsonUtil {
                 .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
                 .registerTypeAdapter(OffsetDateTime.class, new OffsetDateTimeTypeAdapter())
                 .registerTypeHierarchyAdapter(A2AError.class, new A2AErrorTypeAdapter())
-                .registerTypeAdapter(TaskState.class, new TaskStateTypeAdapter())
                 .registerTypeAdapter(Message.Role.class, new RoleTypeAdapter())
                 .registerTypeHierarchyAdapter(FileContent.class, new FileContentTypeAdapter());
     }
@@ -435,48 +434,6 @@ public class JsonUtil {
                 default ->
                     new A2AError(code, message == null ? "" : message, data);
             };
-        }
-    }
-
-    /**
-     * Gson TypeAdapter for serializing and deserializing {@link TaskState} enum.
-     * <p>
-     * This adapter ensures that TaskState enum values are serialized using their
-     * wire format string representation (e.g., "completed", "working") rather than
-     * the Java enum constant name (e.g., "COMPLETED", "WORKING").
-     * <p>
-     * For serialization, it uses {@link TaskState#asString()} to get the wire format.
-     * For deserialization, it uses {@link TaskState#fromString(String)} to parse the
-     * wire format back to the enum constant.
-     *
-     * @see TaskState
-     * @see TaskState#asString()
-     * @see TaskState#fromString(String)
-     */
-    static class TaskStateTypeAdapter extends TypeAdapter<TaskState> {
-
-        @Override
-        public void write(JsonWriter out, TaskState value) throws java.io.IOException {
-            if (value == null) {
-                out.nullValue();
-            } else {
-                out.value(value.asString());
-            }
-        }
-
-        @Override
-        public @Nullable
-        TaskState read(JsonReader in) throws java.io.IOException {
-            if (in.peek() == com.google.gson.stream.JsonToken.NULL) {
-                in.nextNull();
-                return null;
-            }
-            String stateString = in.nextString();
-            try {
-                return TaskState.fromString(stateString);
-            } catch (IllegalArgumentException e) {
-                throw new JsonSyntaxException("Invalid TaskState: " + stateString, e);
-            }
         }
     }
 

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/CancelTaskRequest.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/CancelTaskRequest.java
@@ -13,7 +13,7 @@ import io.a2a.spec.TaskState;
  * <p>
  * This request instructs the agent to cancel execution of a specific task identified by ID.
  * The agent should stop processing, clean up resources, and transition the task to
- * {@link TaskState#CANCELED} state if cancellation is possible.
+ * {@link TaskState#TASK_STATE_CANCELED} state if cancellation is possible.
  * <p>
  * Not all tasks can be canceled (e.g., already completed tasks), which may result in
  * a {@link TaskNotCancelableError}.

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/CancelTaskResponse.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/CancelTaskResponse.java
@@ -10,7 +10,7 @@ import io.a2a.spec.TaskState;
  * JSON-RPC response for task cancellation requests.
  * <p>
  * This response contains the updated {@link Task} object after cancellation, typically
- * showing {@link TaskState#CANCELED} status if the cancellation was successful.
+ * showing {@link TaskState#TASK_STATE_CANCELED} status if the cancellation was successful.
  * <p>
  * If the task cannot be canceled (e.g., already completed) or is not found, the error
  * field will contain a {@link io.a2a.spec.A2AError} such as {@link TaskNotCancelableError} or

--- a/jsonrpc-common/src/test/java/io/a2a/jsonrpc/common/json/StreamingEventKindSerializationTest.java
+++ b/jsonrpc-common/src/test/java/io/a2a/jsonrpc/common/json/StreamingEventKindSerializationTest.java
@@ -33,7 +33,7 @@ class StreamingEventKindSerializationTest {
         Task task = Task.builder()
                 .id("task-123")
                 .contextId("context-456")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
 
         // Serialize as StreamingEventKind
@@ -43,7 +43,7 @@ class StreamingEventKindSerializationTest {
         assertNotNull(json);
         assertTrue(json.contains("\"task\""));
         assertTrue(json.contains("\"id\":\"task-123\""));
-        assertTrue(json.contains("\"state\":\"submitted\""));
+        assertTrue(json.contains("\"state\":\"TASK_STATE_SUBMITTED\""));
         assertFalse(json.contains("\"kind\""));
 
         // Deserialize back to StreamingEventKind
@@ -96,7 +96,7 @@ class StreamingEventKindSerializationTest {
         TaskStatusUpdateEvent statusEvent = TaskStatusUpdateEvent.builder()
                 .taskId("task-abc")
                 .contextId("context-def")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
 
         // Serialize as StreamingEventKind
@@ -106,7 +106,7 @@ class StreamingEventKindSerializationTest {
         assertNotNull(json);
         assertTrue(json.contains("\"statusUpdate\""));
         assertTrue(json.contains("\"taskId\":\"task-abc\""));
-        assertTrue(json.contains("\"state\":\"working\""));
+        assertTrue(json.contains("\"state\":\"TASK_STATE_WORKING\""));
         assertTrue(json.contains("\"final\":false"));
         assertFalse(json.contains("\"kind\""));
 
@@ -165,7 +165,7 @@ class StreamingEventKindSerializationTest {
               "id": "task-unwrapped",
               "contextId": "context-999",
               "status": {
-                "state": "completed"
+                "state": "TASK_STATE_COMPLETED"
               }
             }
             """;
@@ -178,7 +178,7 @@ class StreamingEventKindSerializationTest {
         Task task = (Task) deserialized;
         assertEquals("task-unwrapped", task.id());
         assertEquals("context-999", task.contextId());
-        assertEquals(TaskState.COMPLETED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, task.status().state());
     }
 
     @Test
@@ -216,7 +216,7 @@ class StreamingEventKindSerializationTest {
               "taskId": "task-status-unwrapped",
               "contextId": "context-999",
               "status": {
-                "state": "working"
+                "state": "TASK_STATE_WORKING"
               },
               "final": false
             }
@@ -229,7 +229,7 @@ class StreamingEventKindSerializationTest {
         assertInstanceOf(TaskStatusUpdateEvent.class, deserialized);
         TaskStatusUpdateEvent event = (TaskStatusUpdateEvent) deserialized;
         assertEquals("task-status-unwrapped", event.taskId());
-        assertEquals(TaskState.WORKING, event.status().state());
+        assertEquals(TaskState.TASK_STATE_WORKING, event.status().state());
         assertFalse(event.isFinal());
     }
 

--- a/jsonrpc-common/src/test/java/io/a2a/jsonrpc/common/json/TaskSerializationTest.java
+++ b/jsonrpc-common/src/test/java/io/a2a/jsonrpc/common/json/TaskSerializationTest.java
@@ -34,7 +34,7 @@ class TaskSerializationTest {
         Task task = Task.builder()
                 .id("task-123")
                 .contextId("context-456")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
 
         // Serialize to JSON
@@ -43,7 +43,7 @@ class TaskSerializationTest {
         // Verify JSON contains expected fields
         assertNotNull(json);
         assertTrue(json.contains("\"id\":\"task-123\""));
-        assertTrue(json.contains("\"state\":\"submitted\""));
+        assertTrue(json.contains("\"state\":\"TASK_STATE_SUBMITTED\""));
 
         // Deserialize back to Task
         Task deserialized = JsonUtil.fromJson(json, Task.class);
@@ -60,7 +60,7 @@ class TaskSerializationTest {
         Task task = Task.builder()
                 .id("task-123")
                 .contextId("context-456")
-                .status(new TaskStatus(TaskState.WORKING, null, timestamp))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING, null, timestamp))
                 .build();
 
         // Serialize
@@ -89,7 +89,7 @@ class TaskSerializationTest {
         Task task = Task.builder()
                 .id("task-123")
                 .contextId("context-456")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .artifacts(List.of(artifact))
                 .build();
 
@@ -121,7 +121,7 @@ class TaskSerializationTest {
         Task task = Task.builder()
                 .id("task-123")
                 .contextId("context-456")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .history(List.of(message))
                 .build();
 
@@ -149,7 +149,7 @@ class TaskSerializationTest {
         Task task = Task.builder()
                 .id("task-123")
                 .contextId("context-789")
-                .status(new TaskStatus(TaskState.WORKING, null, timestamp))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING, null, timestamp))
                 .history(List.of(
                         Message.builder()
                                 .role(Message.Role.USER)
@@ -190,7 +190,7 @@ class TaskSerializationTest {
     void testTaskWithDifferentStates() throws JsonProcessingException {
         for (TaskState state : TaskState.values()) {
             Task task = Task.builder()
-                    .id("task-" + state.asString())
+                    .id("task-" + state)
                     .contextId("context-123")
                     .status(new TaskStatus(state))
                     .build();
@@ -199,7 +199,7 @@ class TaskSerializationTest {
             String json = JsonUtil.toJson(task);
 
             // Verify state is serialized correctly
-            assertTrue(json.contains("\"state\":\"" + state.asString() + "\""));
+            assertTrue(json.contains("\"state\":\"" + state + "\""));
 
             // Deserialize
             Task deserialized = JsonUtil.fromJson(json, Task.class);
@@ -214,7 +214,7 @@ class TaskSerializationTest {
         Task task = Task.builder()
                 .id("task-123")
                 .contextId("context-456")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 // artifacts, history, metadata not set
                 .build();
 
@@ -227,7 +227,7 @@ class TaskSerializationTest {
         // Verify required fields are present
         assertEquals("task-123", deserialized.id());
         assertEquals("context-456", deserialized.contextId());
-        assertEquals(TaskState.SUBMITTED, deserialized.status().state());
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, deserialized.status().state());
 
         // Verify optional lists default to empty
         assertNotNull(deserialized.artifacts());
@@ -248,7 +248,7 @@ class TaskSerializationTest {
         Task task = Task.builder()
                 .id("task-123")
                 .contextId("context-456")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .artifacts(List.of(artifact))
                 .build();
 
@@ -286,7 +286,7 @@ class TaskSerializationTest {
         Task task = Task.builder()
                 .id("task-123")
                 .contextId("context-456")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .artifacts(List.of(artifact))
                 .build();
 
@@ -321,7 +321,7 @@ class TaskSerializationTest {
         Task task = Task.builder()
                 .id("task-123")
                 .contextId("context-456")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .artifacts(List.of(artifact))
                 .build();
 
@@ -351,7 +351,7 @@ class TaskSerializationTest {
         Task original = Task.builder()
                 .id("task-123")
                 .contextId("context-789")
-                .status(new TaskStatus(TaskState.WORKING, null, timestamp))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING, null, timestamp))
                 .history(List.of(
                         Message.builder()
                                 .role(Message.Role.USER)
@@ -401,21 +401,21 @@ class TaskSerializationTest {
         Task task = Task.builder()
                 .id("task-123")
                 .contextId("context-456")
-                .status(new TaskStatus(TaskState.COMPLETED, statusMessage, null))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED, statusMessage, null))
                 .build();
 
         // Serialize
         String json = JsonUtil.toJson(task);
 
         // Verify JSON contains status message
-        assertTrue(json.contains("\"state\":\"completed\""));
+        assertTrue(json.contains("\"state\":\"TASK_STATE_COMPLETED\""));
         assertTrue(json.contains("Processing complete"));
 
         // Deserialize
         Task deserialized = JsonUtil.fromJson(json, Task.class);
 
         // Verify status message is preserved
-        assertEquals(TaskState.COMPLETED, deserialized.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, deserialized.status().state());
         assertNotNull(deserialized.status().message());
         assertEquals(Message.Role.AGENT, deserialized.status().message().role());
         assertTrue(deserialized.status().message().parts().get(0) instanceof TextPart);
@@ -428,7 +428,7 @@ class TaskSerializationTest {
               "id": "task-123",
               "contextId": "context-456",
               "status": {
-                "state": "submitted"
+                "state": "TASK_STATE_SUBMITTED"
               }
             }
             """;
@@ -437,7 +437,7 @@ class TaskSerializationTest {
 
         assertEquals("task-123", task.id());
         assertEquals("context-456", task.contextId());
-        assertEquals(TaskState.SUBMITTED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, task.status().state());
         assertNull(task.status().message());
         // TaskStatus automatically sets timestamp to current time if not provided
         assertNotNull(task.status().timestamp());
@@ -450,7 +450,7 @@ class TaskSerializationTest {
               "id": "task-123",
               "contextId": "context-456",
               "status": {
-                "state": "completed"
+                "state": "TASK_STATE_COMPLETED"
               },
               "artifacts": [
                 {
@@ -469,7 +469,7 @@ class TaskSerializationTest {
         Task task = JsonUtil.fromJson(json, Task.class);
 
         assertEquals("task-123", task.id());
-        assertEquals(TaskState.COMPLETED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, task.status().state());
         assertEquals(1, task.artifacts().size());
         assertEquals("artifact-1", task.artifacts().get(0).artifactId());
         assertEquals("Result", task.artifacts().get(0).name());
@@ -485,7 +485,7 @@ class TaskSerializationTest {
               "id": "task-123",
               "contextId": "context-456",
               "status": {
-                "state": "completed"
+                "state": "TASK_STATE_COMPLETED"
               },
               "artifacts": [
                 {
@@ -525,7 +525,7 @@ class TaskSerializationTest {
               "id": "task-123",
               "contextId": "context-456",
               "status": {
-                "state": "completed"
+                "state": "TASK_STATE_COMPLETED"
               },
               "artifacts": [
                 {
@@ -564,7 +564,7 @@ class TaskSerializationTest {
               "id": "task-123",
               "contextId": "context-456",
               "status": {
-                "state": "completed"
+                "state": "TASK_STATE_COMPLETED"
               },
               "artifacts": [
                 {
@@ -598,7 +598,7 @@ class TaskSerializationTest {
               "id": "task-123",
               "contextId": "context-456",
               "status": {
-                "state": "working"
+                "state": "TASK_STATE_WORKING"
               },
               "history": [
                 {
@@ -640,7 +640,7 @@ class TaskSerializationTest {
               "id": "task-123",
               "contextId": "context-456",
               "status": {
-                "state": "working",
+                "state": "TASK_STATE_WORKING",
                 "timestamp": "2023-10-01T12:00:00.234-05:00"
               }
             }
@@ -649,7 +649,7 @@ class TaskSerializationTest {
         Task task = JsonUtil.fromJson(json, Task.class);
 
         assertEquals("task-123", task.id());
-        assertEquals(TaskState.WORKING, task.status().state());
+        assertEquals(TaskState.TASK_STATE_WORKING, task.status().state());
         assertNotNull(task.status().timestamp());
         assertEquals("2023-10-01T12:00:00.234-05:00", task.status().timestamp().toString());
     }
@@ -661,7 +661,7 @@ class TaskSerializationTest {
               "id": "task-123",
               "contextId": "context-456",
               "status": {
-                "state": "completed"
+                "state": "TASK_STATE_COMPLETED"
               },
               "metadata": {
                 "key1": "value1",
@@ -692,7 +692,7 @@ class TaskSerializationTest {
         Task task = Task.builder()
                 .id("task-123")
                 .contextId("context-456")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .artifacts(List.of(artifact))
                 .build();
 

--- a/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/A2AServerRoutesTest.java
+++ b/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/A2AServerRoutesTest.java
@@ -151,7 +151,7 @@ public class A2AServerRoutesTest {
         Task responseTask = Task.builder()
                 .id("task-123")
                 .contextId("context-1234")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
         SendMessageResponse realResponse = new SendMessageResponse("1", responseTask);
         when(mockJsonRpcHandler.onMessageSend(any(SendMessageRequest.class), any(ServerCallContext.class)))
@@ -235,7 +235,7 @@ public class A2AServerRoutesTest {
         Task responseTask = Task.builder()
                 .id("de38c76d-d54c-436c-8b9f-4c2703648d64")
                 .contextId("context-1234")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
         GetTaskResponse realResponse = new GetTaskResponse("1", responseTask);
         when(mockJsonRpcHandler.onGetTask(any(GetTaskRequest.class), any(ServerCallContext.class)))
@@ -271,7 +271,7 @@ public class A2AServerRoutesTest {
         Task responseTask = Task.builder()
                 .id("de38c76d-d54c-436c-8b9f-4c2703648d64")
                 .contextId("context-1234")
-                .status(new TaskStatus(TaskState.CANCELED))
+                .status(new TaskStatus(TaskState.TASK_STATE_CANCELED))
                 .build();
         CancelTaskResponse realResponse = new CancelTaskResponse("1", responseTask);
         when(mockJsonRpcHandler.onCancelTask(any(CancelTaskRequest.class), any(ServerCallContext.class)))
@@ -540,7 +540,7 @@ public class A2AServerRoutesTest {
         Task responseTask = Task.builder()
                 .id("de38c76d-d54c-436c-8b9f-4c2703648d64")
                 .contextId("context-1234")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
         GetTaskResponse realResponse = new GetTaskResponse("1", responseTask);
         when(mockJsonRpcHandler.onGetTask(any(GetTaskRequest.class), any(ServerCallContext.class)))
@@ -577,7 +577,7 @@ public class A2AServerRoutesTest {
         Task responseTask = Task.builder()
                 .id("de38c76d-d54c-436c-8b9f-4c2703648d64")
                 .contextId("context-1234")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
         GetTaskResponse realResponse = new GetTaskResponse("1", responseTask);
         when(mockJsonRpcHandler.onGetTask(any(GetTaskRequest.class), any(ServerCallContext.class)))
@@ -614,7 +614,7 @@ public class A2AServerRoutesTest {
         Task responseTask = Task.builder()
                 .id("de38c76d-d54c-436c-8b9f-4c2703648d64")
                 .contextId("context-1234")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
         GetTaskResponse realResponse = new GetTaskResponse("1", responseTask);
         when(mockJsonRpcHandler.onGetTask(any(GetTaskRequest.class), any(ServerCallContext.class)))
@@ -651,7 +651,7 @@ public class A2AServerRoutesTest {
         Task responseTask = Task.builder()
                 .id("de38c76d-d54c-436c-8b9f-4c2703648d64")
                 .contextId("context-1234")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
         GetTaskResponse realResponse = new GetTaskResponse("1", responseTask);
         when(mockJsonRpcHandler.onGetTask(any(GetTaskRequest.class), any(ServerCallContext.class)))

--- a/server-common/src/main/java/io/a2a/server/events/EventConsumer.java
+++ b/server-common/src/main/java/io/a2a/server/events/EventConsumer.java
@@ -205,7 +205,7 @@ public class EventConsumer {
      */
     private boolean isStreamTerminatingTask(Task task) {
         TaskState state = task.status().state();
-        return state.isFinal() || state == TaskState.INPUT_REQUIRED;
+        return state.isFinal() || state == TaskState.TASK_STATE_INPUT_REQUIRED;
     }
 
     public EnhancedRunnable.DoneCallback createAgentRunnableDoneCallback() {

--- a/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
@@ -6,7 +6,6 @@ import static io.a2a.server.util.async.AsyncUtils.processor;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +67,7 @@ import io.a2a.spec.TaskQueryParams;
 import io.a2a.spec.TaskState;
 import io.a2a.spec.TaskStatusUpdateEvent;
 import io.a2a.spec.UnsupportedOperationError;
-import java.util.Collections;
+
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -369,7 +368,7 @@ public class DefaultRequestHandler implements RequestHandler {
         // Check if task is in a non-cancelable state (completed, canceled, failed, rejected)
         if (task.status().state().isFinal()) {
             throw new TaskNotCancelableError(
-                    "Task cannot be canceled - current state: " + task.status().state().asString());
+                    "Task cannot be canceled - current state: " + task.status().state());
         }
 
         TaskManager taskManager = new TaskManager(
@@ -415,9 +414,9 @@ public class DefaultRequestHandler implements RequestHandler {
         }
 
         // Verify task was actually canceled (not completed concurrently)
-        if (tempTask.status().state() != TaskState.CANCELED) {
+        if (tempTask.status().state() != TaskState.TASK_STATE_CANCELED) {
             throw new TaskNotCancelableError(
-                    "Task cannot be canceled - current state: " + tempTask.status().state().asString());
+                    "Task cannot be canceled - current state: " + tempTask.status().state());
         }
 
         return tempTask;

--- a/server-common/src/main/java/io/a2a/server/tasks/AgentEmitter.java
+++ b/server-common/src/main/java/io/a2a/server/tasks/AgentEmitter.java
@@ -237,7 +237,7 @@ public class AgentEmitter {
      * @param message optional message to include with completion
      */
     public void complete(@Nullable Message message) {
-        updateStatus(TaskState.COMPLETED, message);
+        updateStatus(TaskState.TASK_STATE_COMPLETED, message);
     }
 
     /**
@@ -253,7 +253,7 @@ public class AgentEmitter {
      * @param message optional message to include with failure
      */
     public void fail(@Nullable Message message) {
-        updateStatus(TaskState.FAILED, message);
+        updateStatus(TaskState.TASK_STATE_FAILED, message);
     }
 
     /**
@@ -312,7 +312,7 @@ public class AgentEmitter {
      * @param message optional message to include
      */
     public void submit(@Nullable Message message) {
-        updateStatus(TaskState.SUBMITTED, message);
+        updateStatus(TaskState.TASK_STATE_SUBMITTED, message);
     }
 
     /**
@@ -328,7 +328,7 @@ public class AgentEmitter {
      * @param message optional message to include
      */
     public void startWork(@Nullable Message message) {
-        updateStatus(TaskState.WORKING, message);
+        updateStatus(TaskState.TASK_STATE_WORKING, message);
     }
 
     /**
@@ -344,7 +344,7 @@ public class AgentEmitter {
      * @param message optional message to include
      */
     public void cancel(@Nullable Message message) {
-        updateStatus(TaskState.CANCELED, message);
+        updateStatus(TaskState.TASK_STATE_CANCELED, message);
     }
 
     /**
@@ -360,7 +360,7 @@ public class AgentEmitter {
      * @param message optional message to include
      */
     public void reject(@Nullable Message message) {
-        updateStatus(TaskState.REJECTED, message);
+        updateStatus(TaskState.TASK_STATE_REJECTED, message);
     }
 
     /**
@@ -395,7 +395,7 @@ public class AgentEmitter {
      * @param isFinal whether this is a final status (prevents further updates)
      */
     public void requiresInput(@Nullable Message message, boolean isFinal) {
-        updateStatus(TaskState.INPUT_REQUIRED, message, isFinal);
+        updateStatus(TaskState.TASK_STATE_INPUT_REQUIRED, message, isFinal);
     }
 
     /**
@@ -430,7 +430,7 @@ public class AgentEmitter {
      * @param isFinal whether this is a final status (prevents further updates)
      */
     public void requiresAuth(@Nullable Message message, boolean isFinal) {
-        updateStatus(TaskState.AUTH_REQUIRED, message, isFinal);
+        updateStatus(TaskState.TASK_STATE_AUTH_REQUIRED, message, isFinal);
     }
 
     /**

--- a/server-common/src/main/java/io/a2a/server/tasks/ResultAggregator.java
+++ b/server-common/src/main/java/io/a2a/server/tasks/ResultAggregator.java
@@ -168,8 +168,8 @@ public class ResultAggregator {
                     boolean isFinalEvent = (event instanceof Task task && task.status().state().isFinal())
                             || (event instanceof TaskStatusUpdateEvent tsue && tsue.isFinal())
                             || (event instanceof A2AError);  // A2AError events are terminal
-                    boolean isAuthRequired = (event instanceof Task task && task.status().state() == TaskState.AUTH_REQUIRED)
-                            || (event instanceof TaskStatusUpdateEvent tsue && tsue.status().state() == TaskState.AUTH_REQUIRED);
+                    boolean isAuthRequired = (event instanceof Task task && task.status().state() == TaskState.TASK_STATE_AUTH_REQUIRED)
+                            || (event instanceof TaskStatusUpdateEvent tsue && tsue.status().state() == TaskState.TASK_STATE_AUTH_REQUIRED);
 
                     LOGGER.debug("ResultAggregator: Evaluating interrupt (blocking={}, isFinal={}, isAuth={}, eventType={})",
                         blocking, isFinalEvent, isAuthRequired, event.getClass().getSimpleName());

--- a/server-common/src/main/java/io/a2a/server/tasks/TaskManager.java
+++ b/server-common/src/main/java/io/a2a/server/tasks/TaskManager.java
@@ -1,7 +1,7 @@
 package io.a2a.server.tasks;
 
-import static io.a2a.spec.TaskState.FAILED;
-import static io.a2a.spec.TaskState.SUBMITTED;
+import static io.a2a.spec.TaskState.TASK_STATE_FAILED;
+import static io.a2a.spec.TaskState.TASK_STATE_SUBMITTED;
 import static io.a2a.util.Assert.checkNotNullParam;
 import static io.a2a.util.Utils.appendArtifactToTask;
 
@@ -142,7 +142,7 @@ public class TaskManager {
                 TaskStatusUpdateEvent failedEvent = TaskStatusUpdateEvent.builder()
                         .taskId(taskId)
                         .contextId(errorContextId)
-                        .status(new TaskStatus(FAILED))
+                        .status(new TaskStatus(TASK_STATE_FAILED))
                         .build();
                 isFinal = saveTaskEvent(failedEvent, isReplicated);
             } else {
@@ -207,7 +207,7 @@ public class TaskManager {
         return Task.builder()
                 .id(taskId)
                 .contextId(contextId)
-                .status(new TaskStatus(SUBMITTED))
+                .status(new TaskStatus(TASK_STATE_SUBMITTED))
                 .history(history)
                 .build();
     }

--- a/server-common/src/test/java/io/a2a/server/agentexecution/RequestContextTest.java
+++ b/server-common/src/test/java/io/a2a/server/agentexecution/RequestContextTest.java
@@ -122,7 +122,7 @@ public class RequestContextTest {
     @Test
     public void testInitWithTask() {
         var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).build();
-        var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.COMPLETED)).build();
+        var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.TASK_STATE_COMPLETED)).build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
 
         RequestContext context = new RequestContext.Builder()
@@ -141,7 +141,7 @@ public class RequestContextTest {
 
     @Test
     public void testAttachRelatedTask() {
-        var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.COMPLETED)).build();
+        var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.TASK_STATE_COMPLETED)).build();
 
         RequestContext context = new RequestContext.Builder().build();
         assertEquals(0, context.getRelatedTasks().size());
@@ -189,7 +189,7 @@ public class RequestContextTest {
     public void testInitRaisesErrorOnTaskIdMismatch() {
         var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).taskId("task-123").build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
-        var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.COMPLETED)).build();
+        var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.TASK_STATE_COMPLETED)).build();
 
         InvalidParamsError error = assertThrows(InvalidParamsError.class, () ->
                 new RequestContext.Builder()
@@ -205,7 +205,7 @@ public class RequestContextTest {
     public void testInitRaisesErrorOnContextIdMismatch() {
         var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).taskId("task-123").contextId("context-456").build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
-        var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.COMPLETED)).build();
+        var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.TASK_STATE_COMPLETED)).build();
 
         InvalidParamsError error = assertThrows(InvalidParamsError.class, () ->
                 new RequestContext.Builder()
@@ -220,7 +220,7 @@ public class RequestContextTest {
 
     @Test
     public void testWithRelatedTasksProvided() {
-        var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.COMPLETED)).build();
+        var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.TASK_STATE_COMPLETED)).build();
 
         List<Task> relatedTasks = new ArrayList<>();
         relatedTasks.add(mockTask);
@@ -276,7 +276,7 @@ public class RequestContextTest {
     public void testInitWithTaskIdAndExistingTaskIdMatch() {
         var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).taskId("task-123").contextId("context-456").build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
-        var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.COMPLETED)).build();
+        var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.TASK_STATE_COMPLETED)).build();
 
         RequestContext context = new RequestContext.Builder()
                 .setParams(mockParams)
@@ -292,7 +292,7 @@ public class RequestContextTest {
     public void testInitWithContextIdAndExistingContextIdMatch() {
         var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).taskId("task-123").contextId("context-456").build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
-        var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.COMPLETED)).build();
+        var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.TASK_STATE_COMPLETED)).build();
 
         RequestContext context = new RequestContext.Builder()
                 .setParams(mockParams)

--- a/server-common/src/test/java/io/a2a/server/events/EventConsumerTest.java
+++ b/server-common/src/test/java/io/a2a/server/events/EventConsumerTest.java
@@ -47,7 +47,7 @@ public class EventConsumerTest {
             {
                 "id": "123",
                 "contextId": "session-xyz",
-                "status": {"state": "submitted"}
+                "status": {"state": "TASK_STATE_SUBMITTED"}
             }
             """;
 
@@ -158,7 +158,7 @@ public class EventConsumerTest {
                 TaskStatusUpdateEvent.builder()
                         .taskId(TASK_ID)
                         .contextId("session-xyz")
-                        .status(new TaskStatus(TaskState.COMPLETED))
+                        .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                         .build());
 
         for (Event event : events) {
@@ -193,7 +193,7 @@ public class EventConsumerTest {
                 TaskStatusUpdateEvent.builder()
                         .taskId(TASK_ID)
                         .contextId("session-xyz")
-                        .status(new TaskStatus(TaskState.COMPLETED))
+                        .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                         .build());
 
         for (Event event : events) {
@@ -241,7 +241,7 @@ public class EventConsumerTest {
         Task task = Task.builder()
             .id(TASK_ID)
             .contextId("session-xyz")
-            .status(new TaskStatus(TaskState.INPUT_REQUIRED))
+            .status(new TaskStatus(TaskState.TASK_STATE_INPUT_REQUIRED))
             .build();
         List<Event> events = List.of(
             task,
@@ -256,7 +256,7 @@ public class EventConsumerTest {
             TaskStatusUpdateEvent.builder()
                 .taskId(TASK_ID)
                 .contextId("session-xyz")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build());
         for (Event event : events) {
             eventQueue.enqueueEvent(event);

--- a/server-common/src/test/java/io/a2a/server/events/EventQueueTest.java
+++ b/server-common/src/test/java/io/a2a/server/events/EventQueueTest.java
@@ -43,7 +43,7 @@ public class EventQueueTest {
             {
                 "id": "123",
                 "contextId": "session-xyz",
-                "status": {"state": "submitted"}
+                "status": {"state": "TASK_STATE_SUBMITTED"}
             }
             """;
 
@@ -351,7 +351,7 @@ public class EventQueueTest {
         Event event = TaskStatusUpdateEvent.builder()
                 .taskId(TASK_ID)
                 .contextId("session-xyz")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
 
         eventQueue.enqueueEvent(event);

--- a/server-common/src/test/java/io/a2a/server/requesthandlers/AbstractA2ARequestHandlerTest.java
+++ b/server-common/src/test/java/io/a2a/server/requesthandlers/AbstractA2ARequestHandlerTest.java
@@ -58,7 +58,7 @@ public class AbstractA2ARequestHandlerTest {
     protected static final Task MINIMAL_TASK = Task.builder()
             .id("task-123")
             .contextId("session-xyz")
-            .status(new TaskStatus(TaskState.SUBMITTED))
+            .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
             .build();
 
     protected static final Message MESSAGE = Message.builder()

--- a/server-common/src/test/java/io/a2a/server/tasks/AgentEmitterTest.java
+++ b/server-common/src/test/java/io/a2a/server/tasks/AgentEmitterTest.java
@@ -102,141 +102,141 @@ public class AgentEmitterTest {
     @Test
     public void testCompleteWithoutMessage() throws Exception {
         agentEmitter.complete();
-        checkTaskStatusUpdateEventOnQueue(true, TaskState.COMPLETED, null);
+        checkTaskStatusUpdateEventOnQueue(true, TaskState.TASK_STATE_COMPLETED, null);
     }
 
     @Test
     public void testCompleteWithMessage() throws Exception {
         agentEmitter.complete(SAMPLE_MESSAGE);
-        checkTaskStatusUpdateEventOnQueue(true, TaskState.COMPLETED, SAMPLE_MESSAGE);
+        checkTaskStatusUpdateEventOnQueue(true, TaskState.TASK_STATE_COMPLETED, SAMPLE_MESSAGE);
     }
 
     @Test
     public void testSubmitWithoutMessage() throws Exception {
         agentEmitter.submit();
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.SUBMITTED, null);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_SUBMITTED, null);
     }
 
     @Test
     public void testSubmitWithMessage() throws Exception {
         agentEmitter.submit(SAMPLE_MESSAGE);
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.SUBMITTED, SAMPLE_MESSAGE);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_SUBMITTED, SAMPLE_MESSAGE);
     }
 
     @Test
     public void testStartWorkWithoutMessage() throws Exception {
         agentEmitter.startWork();
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.WORKING, null);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_WORKING, null);
     }
 
     @Test
     public void testStartWorkWithMessage() throws Exception {
         agentEmitter.startWork(SAMPLE_MESSAGE);
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.WORKING, SAMPLE_MESSAGE);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_WORKING, SAMPLE_MESSAGE);
     }
 
     @Test
     public void testFailedWithoutMessage() throws Exception {
         agentEmitter.fail();
-        checkTaskStatusUpdateEventOnQueue(true, TaskState.FAILED, null);
+        checkTaskStatusUpdateEventOnQueue(true, TaskState.TASK_STATE_FAILED, null);
     }
 
     @Test
     public void testFailedWithMessage() throws Exception {
         agentEmitter.fail(SAMPLE_MESSAGE);
-        checkTaskStatusUpdateEventOnQueue(true, TaskState.FAILED, SAMPLE_MESSAGE);
+        checkTaskStatusUpdateEventOnQueue(true, TaskState.TASK_STATE_FAILED, SAMPLE_MESSAGE);
     }
 
     @Test
     public void testCanceledWithoutMessage() throws Exception {
         agentEmitter.cancel();
-        checkTaskStatusUpdateEventOnQueue(true, TaskState.CANCELED, null);
+        checkTaskStatusUpdateEventOnQueue(true, TaskState.TASK_STATE_CANCELED, null);
     }
 
     @Test
     public void testCanceledWithMessage() throws Exception {
         agentEmitter.cancel(SAMPLE_MESSAGE);
-        checkTaskStatusUpdateEventOnQueue(true, TaskState.CANCELED, SAMPLE_MESSAGE);
+        checkTaskStatusUpdateEventOnQueue(true, TaskState.TASK_STATE_CANCELED, SAMPLE_MESSAGE);
     }
 
     @Test
     public void testRejectWithoutMessage() throws Exception {
         agentEmitter.reject();
-        checkTaskStatusUpdateEventOnQueue(true, TaskState.REJECTED, null);
+        checkTaskStatusUpdateEventOnQueue(true, TaskState.TASK_STATE_REJECTED, null);
     }
 
     @Test
     public void testRejectWithMessage() throws Exception {
         agentEmitter.reject(SAMPLE_MESSAGE);
-        checkTaskStatusUpdateEventOnQueue(true, TaskState.REJECTED, SAMPLE_MESSAGE);
+        checkTaskStatusUpdateEventOnQueue(true, TaskState.TASK_STATE_REJECTED, SAMPLE_MESSAGE);
     }
 
     @Test
     public void testRequiresInputWithoutMessage() throws Exception {
         agentEmitter.requiresInput();
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.INPUT_REQUIRED, null);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_INPUT_REQUIRED, null);
     }
 
     @Test
     public void testRequiresInputWithMessage() throws Exception {
         agentEmitter.requiresInput(SAMPLE_MESSAGE);
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.INPUT_REQUIRED, SAMPLE_MESSAGE);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_INPUT_REQUIRED, SAMPLE_MESSAGE);
     }
 
     @Test
     public void testRequiresInputWithFinalTrue() throws Exception {
         agentEmitter.requiresInput(true);
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.INPUT_REQUIRED, null);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_INPUT_REQUIRED, null);
     }
 
     @Test
     public void testRequiresInputWithMessageAndFinalTrue() throws Exception {
         agentEmitter.requiresInput(SAMPLE_MESSAGE, true);
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.INPUT_REQUIRED, SAMPLE_MESSAGE);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_INPUT_REQUIRED, SAMPLE_MESSAGE);
     }
 
     @Test
     public void testRequiresAuthWithoutMessage() throws Exception {
         agentEmitter.requiresAuth();
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.AUTH_REQUIRED, null);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_AUTH_REQUIRED, null);
     }
 
     @Test
     public void testRequiresAuthWithMessage() throws Exception {
         agentEmitter.requiresAuth(SAMPLE_MESSAGE);
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.AUTH_REQUIRED, SAMPLE_MESSAGE);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_AUTH_REQUIRED, SAMPLE_MESSAGE);
     }
 
     @Test
     public void testRequiresAuthWithFinalTrue() throws Exception {
         agentEmitter.requiresAuth(true);
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.AUTH_REQUIRED, null);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_AUTH_REQUIRED, null);
     }
 
     @Test
     public void testRequiresAuthWithMessageAndFinalTrue() throws Exception {
         agentEmitter.requiresAuth(SAMPLE_MESSAGE, true);
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.AUTH_REQUIRED, SAMPLE_MESSAGE);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_AUTH_REQUIRED, SAMPLE_MESSAGE);
     }
 
     @Test
     public void testNonTerminalStateUpdatesAllowed() throws Exception {
         // Non-terminal states should be allowed multiple times
         agentEmitter.submit();
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.SUBMITTED, null);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_SUBMITTED, null);
 
         agentEmitter.startWork();
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.WORKING, null);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_WORKING, null);
 
         agentEmitter.requiresInput();
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.INPUT_REQUIRED, null);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_INPUT_REQUIRED, null);
 
         agentEmitter.requiresAuth();
-        checkTaskStatusUpdateEventOnQueue(false, TaskState.AUTH_REQUIRED, null);
+        checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_AUTH_REQUIRED, null);
 
         // Should still be able to complete
         agentEmitter.complete();
-        checkTaskStatusUpdateEventOnQueue(true, TaskState.COMPLETED, null);
+        checkTaskStatusUpdateEventOnQueue(true, TaskState.TASK_STATE_COMPLETED, null);
     }
 
     @Test
@@ -341,7 +341,7 @@ public class AgentEmitterTest {
     public void testTerminalStateProtectionAfterComplete() throws Exception {
         // Complete the task first
         agentEmitter.complete();
-        checkTaskStatusUpdateEventOnQueue(true, TaskState.COMPLETED, null);
+        checkTaskStatusUpdateEventOnQueue(true, TaskState.TASK_STATE_COMPLETED, null);
 
         // Try to update status again - should throw RuntimeException
         RuntimeException exception = assertThrows(RuntimeException.class, () -> agentEmitter.startWork());
@@ -355,7 +355,7 @@ public class AgentEmitterTest {
     public void testTerminalStateProtectionAfterFail() throws Exception {
         // Fail the task first
         agentEmitter.fail();
-        checkTaskStatusUpdateEventOnQueue(true, TaskState.FAILED, null);
+        checkTaskStatusUpdateEventOnQueue(true, TaskState.TASK_STATE_FAILED, null);
 
         // Try to update status again - should throw RuntimeException
         RuntimeException exception = assertThrows(RuntimeException.class, () -> agentEmitter.complete());
@@ -369,7 +369,7 @@ public class AgentEmitterTest {
     public void testTerminalStateProtectionAfterReject() throws Exception {
         // Reject the task first
         agentEmitter.reject();
-        checkTaskStatusUpdateEventOnQueue(true, TaskState.REJECTED, null);
+        checkTaskStatusUpdateEventOnQueue(true, TaskState.TASK_STATE_REJECTED, null);
 
         // Try to update status again - should throw RuntimeException
         RuntimeException exception = assertThrows(RuntimeException.class, () -> agentEmitter.startWork());
@@ -383,7 +383,7 @@ public class AgentEmitterTest {
     public void testTerminalStateProtectionAfterCancel() throws Exception {
         // Cancel the task first
         agentEmitter.cancel();
-        checkTaskStatusUpdateEventOnQueue(true, TaskState.CANCELED, null);
+        checkTaskStatusUpdateEventOnQueue(true, TaskState.TASK_STATE_CANCELED, null);
 
         // Try to update status again - should throw RuntimeException
         RuntimeException exception = assertThrows(RuntimeException.class, () -> agentEmitter.submit());
@@ -427,7 +427,7 @@ public class AgentEmitterTest {
 
         TaskStatusUpdateEvent tsue = (TaskStatusUpdateEvent) event;
         assertTrue(tsue.isFinal());
-        assertTrue(tsue.status().state() == TaskState.COMPLETED || tsue.status().state() == TaskState.FAILED);
+        assertTrue(tsue.status().state() == TaskState.TASK_STATE_COMPLETED || tsue.status().state() == TaskState.TASK_STATE_FAILED);
 
         // No additional events should be queued
         assertNull(eventQueue.dequeueEventItem(0));

--- a/server-common/src/test/java/io/a2a/server/tasks/InMemoryPushNotificationConfigStoreTest.java
+++ b/server-common/src/test/java/io/a2a/server/tasks/InMemoryPushNotificationConfigStoreTest.java
@@ -71,7 +71,7 @@ class InMemoryPushNotificationConfigStoreTest {
         // Verify the request body contains the task data
         String sentBody = bodyCaptor.getValue();
         assertTrue(sentBody.contains(task.id()));
-        assertTrue(sentBody.contains(task.status().state().asString()));
+        assertTrue(sentBody.contains(task.status().state().name()));
     }
 
     private Task createSampleTask(String taskId, TaskState state) {
@@ -236,7 +236,7 @@ class InMemoryPushNotificationConfigStoreTest {
     @Test
     public void testSendNotificationSuccess() throws Exception {
         String taskId = "task_send_success";
-        Task task = createSampleTask(taskId, TaskState.COMPLETED);
+        Task task = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
         PushNotificationConfig config = createSamplePushConfig("http://notify.me/here", "cfg1", null);
         configStore.setInfo(taskId, config);
 
@@ -255,13 +255,13 @@ class InMemoryPushNotificationConfigStoreTest {
         // Verify the request body contains the task data
         String sentBody = bodyCaptor.getValue();
         assertTrue(sentBody.contains(task.id()));
-        assertTrue(sentBody.contains(task.status().state().asString()));
+        assertTrue(sentBody.contains(task.status().state().name()));
     }
 
     @Test
     public void testSendNotificationWithToken() throws Exception {
         String taskId = "task_send_with_token";
-        Task task = createSampleTask(taskId, TaskState.COMPLETED);
+        Task task = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
         PushNotificationConfig config = createSamplePushConfig("http://notify.me/here", "cfg1", "unique_token");
         configStore.setInfo(taskId, config);
 
@@ -287,13 +287,13 @@ class InMemoryPushNotificationConfigStoreTest {
         // Verify the request body contains the task data
         String sentBody = bodyCaptor.getValue();
         assertTrue(sentBody.contains(task.id()));
-        assertTrue(sentBody.contains(task.status().state().asString()));
+        assertTrue(sentBody.contains(task.status().state().name()));
     }
 
     @Test
     public void testSendNotificationNoConfig() throws Exception {
         String taskId = "task_send_no_config";
-        Task task = createSampleTask(taskId, TaskState.COMPLETED);
+        Task task = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
 
         notificationSender.sendNotification(task);
 
@@ -304,7 +304,7 @@ class InMemoryPushNotificationConfigStoreTest {
     @Test
     public void testSendNotificationWithEmptyToken() throws Exception {
         String taskId = "task_send_empty_token";
-        Task task = createSampleTask(taskId, TaskState.COMPLETED);
+        Task task = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
         PushNotificationConfig config = createSamplePushConfig("http://notify.me/here", "cfg1", "");
         configStore.setInfo(taskId, config);
 
@@ -316,7 +316,7 @@ class InMemoryPushNotificationConfigStoreTest {
     @Test
     public void testSendNotificationWithBlankToken() throws Exception {
         String taskId = "task_send_blank_token";
-        Task task = createSampleTask(taskId, TaskState.COMPLETED);
+        Task task = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
         PushNotificationConfig config = createSamplePushConfig("http://notify.me/here", "cfg1", "   ");
         configStore.setInfo(taskId, config);
 

--- a/server-common/src/test/java/io/a2a/server/tasks/PushNotificationSenderTest.java
+++ b/server-common/src/test/java/io/a2a/server/tasks/PushNotificationSenderTest.java
@@ -23,7 +23,6 @@ import io.a2a.jsonrpc.common.json.JsonProcessingException;
 import io.a2a.jsonrpc.common.json.JsonUtil;
 import io.a2a.spec.Artifact;
 import io.a2a.spec.Message;
-import io.a2a.spec.Part;
 import io.a2a.spec.PushNotificationConfig;
 import io.a2a.spec.StreamingEventKind;
 import io.a2a.spec.Task;
@@ -155,7 +154,7 @@ public class PushNotificationSenderTest {
 
     private void testSendNotificationWithInvalidToken(String token, String testName) throws InterruptedException {
         String taskId = testName;
-        Task taskData = createSampleTask(taskId, TaskState.COMPLETED);
+        Task taskData = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
         PushNotificationConfig config = createSamplePushConfig("http://notify.me/here", "cfg1", token);
         
         // Set up the configuration in the store
@@ -206,7 +205,7 @@ public class PushNotificationSenderTest {
     @Test
     public void testSendNotificationSuccess() throws InterruptedException {
         String taskId = "task_send_success";
-        Task taskData = createSampleTask(taskId, TaskState.COMPLETED);
+        Task taskData = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
         PushNotificationConfig config = createSamplePushConfig("http://notify.me/here", "cfg1", null);
 
         // Set up the configuration in the store
@@ -237,7 +236,7 @@ public class PushNotificationSenderTest {
     @Test
     public void testSendNotificationWithTokenSuccess() throws InterruptedException {
         String taskId = "task_send_with_token";
-        Task taskData = createSampleTask(taskId, TaskState.COMPLETED);
+        Task taskData = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
         PushNotificationConfig config = createSamplePushConfig("http://notify.me/here", "cfg1", "unique_token");
 
         // Set up the configuration in the store
@@ -273,7 +272,7 @@ public class PushNotificationSenderTest {
     @Test
     public void testSendNotificationNoConfig() {
         String taskId = "task_send_no_config";
-        Task taskData = createSampleTask(taskId, TaskState.COMPLETED);
+        Task taskData = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
 
         // Don't set any configuration in the store
         sender.sendNotification(taskData);
@@ -295,7 +294,7 @@ public class PushNotificationSenderTest {
     @Test
     public void testSendNotificationMultipleConfigs() throws InterruptedException {
         String taskId = "task_multiple_configs";
-        Task taskData = createSampleTask(taskId, TaskState.COMPLETED);
+        Task taskData = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
         PushNotificationConfig config1 = createSamplePushConfig("http://notify.me/cfg1", "cfg1", null);
         PushNotificationConfig config2 = createSamplePushConfig("http://notify.me/cfg2", "cfg2", null);
 
@@ -329,7 +328,7 @@ public class PushNotificationSenderTest {
     @Test
     public void testSendNotificationHttpError() {
         String taskId = "task_send_http_err";
-        Task taskData = createSampleTask(taskId, TaskState.COMPLETED);
+        Task taskData = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
         PushNotificationConfig config = createSamplePushConfig("http://notify.me/http_error", "cfg1", null);
 
         // Set up the configuration in the store
@@ -384,7 +383,7 @@ public class PushNotificationSenderTest {
         TaskStatusUpdateEvent statusUpdate = TaskStatusUpdateEvent.builder()
                 .taskId(taskId)
                 .contextId("ctx456")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
         PushNotificationConfig config = createSamplePushConfig("http://notify.me/here", "cfg1", null);
 
@@ -405,7 +404,7 @@ public class PushNotificationSenderTest {
         assertTrue(sentEvent instanceof TaskStatusUpdateEvent, "Event should be a TaskStatusUpdateEvent");
         TaskStatusUpdateEvent sentUpdate = (TaskStatusUpdateEvent) sentEvent;
         assertEquals(taskId, sentUpdate.taskId());
-        assertEquals(TaskState.WORKING, sentUpdate.status().state());
+        assertEquals(TaskState.TASK_STATE_WORKING, sentUpdate.status().state());
 
         // Verify StreamResponse wrapper with 'statusUpdate' discriminator
         String rawBody = testHttpClient.rawBodies.get(0);

--- a/server-common/src/test/java/io/a2a/server/tasks/ResultAggregatorTest.java
+++ b/server-common/src/test/java/io/a2a/server/tasks/ResultAggregatorTest.java
@@ -3,7 +3,6 @@ package io.a2a.server.tasks;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -29,7 +28,7 @@ import io.a2a.spec.Task;
 import io.a2a.spec.TaskState;
 import io.a2a.spec.TaskStatus;
 import io.a2a.spec.TextPart;
-import org.junit.jupiter.api.AfterEach;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -136,7 +135,7 @@ public class ResultAggregatorTest {
 
     @Test
     void testGetCurrentResultWithMessageNull() {
-        Task expectedTask = createSampleTask("task_from_tm", TaskState.SUBMITTED, "ctx1");
+        Task expectedTask = createSampleTask("task_from_tm", TaskState.TASK_STATE_SUBMITTED, "ctx1");
         when(mockTaskManager.getTask()).thenReturn(expectedTask);
 
         EventKind result = aggregator.getCurrentResult();
@@ -149,7 +148,7 @@ public class ResultAggregatorTest {
     void testConstructorStoresTaskManagerCorrectly() {
         // Test that constructor properly initializes the aggregator
         // We can't access the private field directly, but we can test behavior
-        Task expectedTask = createSampleTask("test_task", TaskState.SUBMITTED, "ctx1");
+        Task expectedTask = createSampleTask("test_task", TaskState.TASK_STATE_SUBMITTED, "ctx1");
         when(mockTaskManager.getTask()).thenReturn(expectedTask);
 
         EventKind result = aggregator.getCurrentResult();
@@ -161,7 +160,7 @@ public class ResultAggregatorTest {
     @Test
     void testConstructorWithNullMessage() {
         ResultAggregator aggregatorWithNullMessage = new ResultAggregator(mockTaskManager, null, testExecutor, testExecutor);
-        Task expectedTask = createSampleTask("null_msg_task", TaskState.WORKING, "ctx1");
+        Task expectedTask = createSampleTask("null_msg_task", TaskState.TASK_STATE_WORKING, "ctx1");
         when(mockTaskManager.getTask()).thenReturn(expectedTask);
 
         EventKind result = aggregatorWithNullMessage.getCurrentResult();
@@ -172,7 +171,7 @@ public class ResultAggregatorTest {
 
     @Test
     void testGetCurrentResultReturnsTaskWhenNoMessage() {
-        Task expectedTask = createSampleTask("no_message_task", TaskState.COMPLETED, "ctx1");
+        Task expectedTask = createSampleTask("no_message_task", TaskState.TASK_STATE_COMPLETED, "ctx1");
         when(mockTaskManager.getTask()).thenReturn(expectedTask);
 
         EventKind result = aggregator.getCurrentResult();
@@ -185,8 +184,8 @@ public class ResultAggregatorTest {
     @Test
     void testGetCurrentResultWithDifferentTaskStates() {
         // Test with WORKING and COMPLETED states using chained returns
-        Task workingTask = createSampleTask("working_task", TaskState.WORKING, "ctx1");
-        Task completedTask = createSampleTask("completed_task", TaskState.COMPLETED, "ctx1");
+        Task workingTask = createSampleTask("working_task", TaskState.TASK_STATE_WORKING, "ctx1");
+        Task completedTask = createSampleTask("completed_task", TaskState.TASK_STATE_COMPLETED, "ctx1");
         when(mockTaskManager.getTask()).thenReturn(workingTask, completedTask);
 
         // First call returns WORKING task
@@ -201,7 +200,7 @@ public class ResultAggregatorTest {
     @Test
     void testMultipleGetCurrentResultCalls() {
         // Test that multiple calls to getCurrentResult behave consistently
-        Task expectedTask = createSampleTask("multi_call_task", TaskState.SUBMITTED, "ctx1");
+        Task expectedTask = createSampleTask("multi_call_task", TaskState.TASK_STATE_SUBMITTED, "ctx1");
         when(mockTaskManager.getTask()).thenReturn(expectedTask);
 
         EventKind result1 = aggregator.getCurrentResult();
@@ -223,7 +222,7 @@ public class ResultAggregatorTest {
         ResultAggregator messageAggregator = new ResultAggregator(mockTaskManager, message, testExecutor, testExecutor);
 
         // Even if we set up the task manager to return something, message should take precedence
-        Task task = createSampleTask("should_not_be_returned", TaskState.WORKING, "ctx1");
+        Task task = createSampleTask("should_not_be_returned", TaskState.TASK_STATE_WORKING, "ctx1");
         when(mockTaskManager.getTask()).thenReturn(task);
 
         EventKind result = messageAggregator.getCurrentResult();
@@ -237,7 +236,7 @@ public class ResultAggregatorTest {
     void testConsumeAndBreakNonBlocking() throws Exception {
         // Test that with blocking=false, the method returns after the first event
         String taskId = "test-task";
-        Task firstEvent = createSampleTask(taskId, TaskState.WORKING, "ctx1");
+        Task firstEvent = createSampleTask(taskId, TaskState.TASK_STATE_WORKING, "ctx1");
 
         // After processing firstEvent, the current result will be that task
         when(mockTaskManager.getTask()).thenReturn(firstEvent);

--- a/server-common/src/test/java/io/a2a/server/tasks/TaskManagerTest.java
+++ b/server-common/src/test/java/io/a2a/server/tasks/TaskManagerTest.java
@@ -31,7 +31,7 @@ public class TaskManagerTest {
             {
                 "id": "task-abc",
                 "contextId" : "session-xyz",
-                "status": {"state": "submitted"}
+                "status": {"state": "TASK_STATE_SUBMITTED"}
             }""";
 
     Task minimalTask;
@@ -73,7 +73,7 @@ public class TaskManagerTest {
         taskStore.save(initialTask, false);
 
         TaskStatus newStatus = new TaskStatus(
-                TaskState.WORKING,
+                TaskState.TASK_STATE_WORKING,
                 Message.builder()
                         .role(Message.Role.AGENT)
                         .parts(Collections.singletonList(new TextPart("content")))
@@ -140,7 +140,7 @@ public class TaskManagerTest {
         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                 .taskId("new-task")
                 .contextId("some-context")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
 
         taskManagerWithoutId.saveTaskEvent(event, false);
@@ -151,7 +151,7 @@ public class TaskManagerTest {
         Task newTask = taskManagerWithoutId.getTask();
         assertEquals(event.taskId(), newTask.id());
         assertEquals(event.contextId(), newTask.contextId());
-        assertEquals(TaskState.SUBMITTED, newTask.status().state());
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, newTask.status().state());
         assertSame(newTask, task);
     }
 
@@ -161,7 +161,7 @@ public class TaskManagerTest {
         Task task = Task.builder()
                 .id("new-task-id")
                 .contextId("some-context")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
 
         taskManagerWithoutId.saveTaskEvent(task, false);
@@ -335,7 +335,7 @@ public class TaskManagerTest {
         Task differentTask = Task.builder()
                 .id("different-task-id")
                 .contextId("session-xyz")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
 
         assertThrows(A2AServerException.class, () -> {
@@ -351,7 +351,7 @@ public class TaskManagerTest {
         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                 .taskId("different-task-id")
                 .contextId("session-xyz")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
 
         assertThrows(A2AServerException.class, () -> {
@@ -396,7 +396,7 @@ public class TaskManagerTest {
         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                 .taskId("new-task-id")
                 .contextId("some-context")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
 
         taskManagerWithInitialMessage.saveTaskEvent(event, false);
@@ -433,7 +433,7 @@ public class TaskManagerTest {
         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                 .taskId("new-task-id")
                 .contextId("some-context")
-                .status(new TaskStatus(TaskState.SUBMITTED, taskMessage, null))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED, taskMessage, null))
                 .build();
 
         taskManagerWithInitialMessage.saveTaskEvent(event, false);
@@ -561,7 +561,7 @@ public class TaskManagerTest {
         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                 .taskId(minimalTask.id())
                 .contextId(minimalTask.contextId())
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .metadata(newMetadata)
                 .build();
 
@@ -580,7 +580,7 @@ public class TaskManagerTest {
         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                 .taskId(minimalTask.id())
                 .contextId(minimalTask.contextId())
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .metadata(null)
                 .build();
 
@@ -608,7 +608,7 @@ public class TaskManagerTest {
         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                 .taskId(minimalTask.id())
                 .contextId(minimalTask.contextId())
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .metadata(newMetadata)
                 .build();
 
@@ -635,7 +635,7 @@ public class TaskManagerTest {
         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                 .taskId("new-task-id")
                 .contextId("some-context")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
 
         taskManagerWithMessage.saveTaskEvent(event, false);
@@ -645,7 +645,7 @@ public class TaskManagerTest {
         assertNotNull(savedTask);
         assertEquals("new-task-id", savedTask.id());
         assertEquals("some-context", savedTask.contextId());
-        assertEquals(TaskState.SUBMITTED, savedTask.status().state());
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, savedTask.status().state());
 
         // Verify initial message is in history
         assertNotNull(savedTask.history());
@@ -663,7 +663,7 @@ public class TaskManagerTest {
         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                 .taskId("new-task-id")
                 .contextId("some-context")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
 
         taskManagerWithoutMessage.saveTaskEvent(event, false);
@@ -673,7 +673,7 @@ public class TaskManagerTest {
         assertNotNull(savedTask);
         assertEquals("new-task-id", savedTask.id());
         assertEquals("some-context", savedTask.contextId());
-        assertEquals(TaskState.SUBMITTED, savedTask.status().state());
+        assertEquals(TaskState.TASK_STATE_SUBMITTED, savedTask.status().state());
 
         // Verify no history since there was no initial message
         assertTrue(savedTask.history().isEmpty());
@@ -687,7 +687,7 @@ public class TaskManagerTest {
         Task newTask = Task.builder()
                 .id("test-task-id")
                 .contextId("test-context")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
 
         taskManagerWithoutId.saveTaskEvent(newTask, false);
@@ -718,7 +718,7 @@ public class TaskManagerTest {
         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                 .taskId("new-task-id")
                 .contextId("some-context")
-                .status(new TaskStatus(TaskState.SUBMITTED, taskMessage, null))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED, taskMessage, null))
                 .build();
 
         taskManagerWithInitialMessage.saveTaskEvent(event, false);

--- a/spec-grpc/src/main/java/io/a2a/grpc/mapper/A2ACommonFieldMapper.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/mapper/A2ACommonFieldMapper.java
@@ -439,7 +439,7 @@ public interface A2ACommonFieldMapper {
         // Reject invalid enum values (e.g., "INVALID_STATUS" from JSON)
         if (state == io.a2a.grpc.TaskState.UNRECOGNIZED) {
             String validStates = java.util.Arrays.stream(io.a2a.spec.TaskState.values())
-                    .filter(s -> s != io.a2a.spec.TaskState.UNKNOWN)
+                    .filter(s -> s != io.a2a.spec.TaskState.UNRECOGNIZED)
                     .map(Enum::name)
                     .collect(java.util.stream.Collectors.joining(", "));
             throw new InvalidParamsError(null,

--- a/spec-grpc/src/main/java/io/a2a/grpc/mapper/TaskStateMapper.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/mapper/TaskStateMapper.java
@@ -30,15 +30,15 @@ public interface TaskStateMapper {
         }
 
         return switch (domain) {
-            case SUBMITTED -> io.a2a.grpc.TaskState.TASK_STATE_SUBMITTED;
-            case WORKING -> io.a2a.grpc.TaskState.TASK_STATE_WORKING;
-            case INPUT_REQUIRED -> io.a2a.grpc.TaskState.TASK_STATE_INPUT_REQUIRED;
-            case AUTH_REQUIRED -> io.a2a.grpc.TaskState.TASK_STATE_AUTH_REQUIRED;
-            case COMPLETED -> io.a2a.grpc.TaskState.TASK_STATE_COMPLETED;
-            case CANCELED -> io.a2a.grpc.TaskState.TASK_STATE_CANCELED;
-            case FAILED -> io.a2a.grpc.TaskState.TASK_STATE_FAILED;
-            case REJECTED -> io.a2a.grpc.TaskState.TASK_STATE_REJECTED;
-            case UNKNOWN -> io.a2a.grpc.TaskState.UNRECOGNIZED;
+            case TASK_STATE_SUBMITTED -> io.a2a.grpc.TaskState.TASK_STATE_SUBMITTED;
+            case TASK_STATE_WORKING -> io.a2a.grpc.TaskState.TASK_STATE_WORKING;
+            case TASK_STATE_INPUT_REQUIRED -> io.a2a.grpc.TaskState.TASK_STATE_INPUT_REQUIRED;
+            case TASK_STATE_AUTH_REQUIRED -> io.a2a.grpc.TaskState.TASK_STATE_AUTH_REQUIRED;
+            case TASK_STATE_COMPLETED -> io.a2a.grpc.TaskState.TASK_STATE_COMPLETED;
+            case TASK_STATE_CANCELED -> io.a2a.grpc.TaskState.TASK_STATE_CANCELED;
+            case TASK_STATE_FAILED -> io.a2a.grpc.TaskState.TASK_STATE_FAILED;
+            case TASK_STATE_REJECTED -> io.a2a.grpc.TaskState.TASK_STATE_REJECTED;
+            case UNRECOGNIZED -> io.a2a.grpc.TaskState.UNRECOGNIZED;
         };
     }
 
@@ -50,19 +50,19 @@ public interface TaskStateMapper {
      */
     default io.a2a.spec.TaskState fromProto(io.a2a.grpc.TaskState proto) {
         if (proto == null) {
-            return io.a2a.spec.TaskState.UNKNOWN;
+            return io.a2a.spec.TaskState.UNRECOGNIZED;
         }
 
         return switch (proto) {
-            case TASK_STATE_SUBMITTED -> io.a2a.spec.TaskState.SUBMITTED;
-            case TASK_STATE_WORKING -> io.a2a.spec.TaskState.WORKING;
-            case TASK_STATE_INPUT_REQUIRED -> io.a2a.spec.TaskState.INPUT_REQUIRED;
-            case TASK_STATE_AUTH_REQUIRED -> io.a2a.spec.TaskState.AUTH_REQUIRED;
-            case TASK_STATE_COMPLETED -> io.a2a.spec.TaskState.COMPLETED;
-            case TASK_STATE_CANCELED -> io.a2a.spec.TaskState.CANCELED;
-            case TASK_STATE_FAILED -> io.a2a.spec.TaskState.FAILED;
-            case TASK_STATE_REJECTED -> io.a2a.spec.TaskState.REJECTED;
-            case TASK_STATE_UNSPECIFIED, UNRECOGNIZED -> io.a2a.spec.TaskState.UNKNOWN;
+            case TASK_STATE_SUBMITTED -> io.a2a.spec.TaskState.TASK_STATE_SUBMITTED;
+            case TASK_STATE_WORKING -> io.a2a.spec.TaskState.TASK_STATE_WORKING;
+            case TASK_STATE_INPUT_REQUIRED -> io.a2a.spec.TaskState.TASK_STATE_INPUT_REQUIRED;
+            case TASK_STATE_AUTH_REQUIRED -> io.a2a.spec.TaskState.TASK_STATE_AUTH_REQUIRED;
+            case TASK_STATE_COMPLETED -> io.a2a.spec.TaskState.TASK_STATE_COMPLETED;
+            case TASK_STATE_CANCELED -> io.a2a.spec.TaskState.TASK_STATE_CANCELED;
+            case TASK_STATE_FAILED -> io.a2a.spec.TaskState.TASK_STATE_FAILED;
+            case TASK_STATE_REJECTED -> io.a2a.spec.TaskState.TASK_STATE_REJECTED;
+            case TASK_STATE_UNSPECIFIED, UNRECOGNIZED -> io.a2a.spec.TaskState.UNRECOGNIZED;
         };
     }
 }

--- a/spec-grpc/src/test/java/io/a2a/grpc/mapper/StreamResponseMapperTest.java
+++ b/spec-grpc/src/test/java/io/a2a/grpc/mapper/StreamResponseMapperTest.java
@@ -26,7 +26,7 @@ public class StreamResponseMapperTest {
         Task task = Task.builder()
                 .id("task-123")
                 .contextId("context-456")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
 
         // Act
@@ -62,7 +62,7 @@ public class StreamResponseMapperTest {
         Task task = (Task) result;
         assertEquals("task-123", task.id());
         assertEquals("context-456", task.contextId());
-        assertEquals(TaskState.COMPLETED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, task.status().state());
     }
 
     @Test
@@ -118,7 +118,7 @@ public class StreamResponseMapperTest {
         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                 .taskId("task-123")
                 .contextId("context-456")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
 
         // Act
@@ -154,7 +154,7 @@ public class StreamResponseMapperTest {
         TaskStatusUpdateEvent event = (TaskStatusUpdateEvent) result;
         assertEquals("task-123", event.taskId());
         assertEquals("context-456", event.contextId());
-        assertEquals(TaskState.WORKING, event.status().state());
+        assertEquals(TaskState.TASK_STATE_WORKING, event.status().state());
         assertEquals(false, event.isFinal());
     }
 
@@ -231,7 +231,7 @@ public class StreamResponseMapperTest {
         Task originalTask = Task.builder()
                 .id("task-123")
                 .contextId("context-456")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
 
         // Act

--- a/spec-grpc/src/test/java/io/a2a/grpc/utils/ToProtoTest.java
+++ b/spec-grpc/src/test/java/io/a2a/grpc/utils/ToProtoTest.java
@@ -133,7 +133,7 @@ public class ToProtoTest {
     public void convertTask() {
         Task task = Task.builder().id("cancel-task-123")
                 .contextId("session-xyz")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
         io.a2a.grpc.Task result = ProtoUtils.ToProto.task(task);
         assertEquals("session-xyz", result.getContextId());
@@ -143,7 +143,7 @@ public class ToProtoTest {
         assertEquals(0, result.getHistoryCount());
         task = Task.builder().id("cancel-task-123")
                 .contextId("session-xyz")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .artifacts(List.of(Artifact.builder()
                         .artifactId("11")
                         .name("artefact")
@@ -257,7 +257,7 @@ public class ToProtoTest {
 
     @Test
     public void convertTaskStatusUpdateEvent() {
-        TaskStatus completedStatus = new TaskStatus(TaskState.COMPLETED);
+        TaskStatus completedStatus = new TaskStatus(TaskState.TASK_STATE_COMPLETED);
         // Use constructor since Builder doesn't have isFinal method
         TaskStatusUpdateEvent tsue = new TaskStatusUpdateEvent(
                 "1234",
@@ -288,7 +288,7 @@ public class ToProtoTest {
     @Test
     public void convertTaskTimestampStatus() {
         OffsetDateTime expectedTimestamp = OffsetDateTime.parse("2024-10-05T12:34:56Z");
-        TaskStatus testStatus = new TaskStatus(TaskState.COMPLETED, null, expectedTimestamp);
+        TaskStatus testStatus = new TaskStatus(TaskState.TASK_STATE_COMPLETED, null, expectedTimestamp);
         Task task = Task.builder()
                 .id("task-123")
                 .contextId("context-456")
@@ -298,7 +298,7 @@ public class ToProtoTest {
         io.a2a.grpc.Task grpcTask = ProtoUtils.ToProto.task(task);
         task = ProtoUtils.FromProto.task(grpcTask);
         TaskStatus status = task.status();
-        assertEquals(TaskState.COMPLETED, status.state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, status.state());
         assertNotNull(status.timestamp());
         assertEquals(expectedTimestamp, status.timestamp());
     }

--- a/spec/src/main/java/io/a2a/spec/TaskNotCancelableError.java
+++ b/spec/src/main/java/io/a2a/spec/TaskNotCancelableError.java
@@ -9,11 +9,11 @@ import org.jspecify.annotations.Nullable;
  * A2A Protocol error indicating that a task cannot be canceled in its current state.
  * <p>
  * This error is returned when a client attempts to cancel a task
- * but the task is in a terminal state ({@link TaskState#COMPLETED}, {@link TaskState#FAILED},
- * {@link TaskState#CANCELED}) where cancellation is not applicable.
+ * but the task is in a terminal state ({@link TaskState#TASK_STATE_COMPLETED}, {@link TaskState#TASK_STATE_FAILED},
+ * {@link TaskState#TASK_STATE_CANCELED}) where cancellation is not applicable.
  * <p>
- * Tasks can only be canceled when they are in non-terminal states such as {@link TaskState#SUBMITTED}
- * or {@link TaskState#WORKING}.
+ * Tasks can only be canceled when they are in non-terminal states such as {@link TaskState#TASK_STATE_SUBMITTED}
+ * or {@link TaskState#TASK_STATE_WORKING}.
  * <p>
  * Corresponds to A2A-specific error code {@code -32002}.
  * <p>

--- a/spec/src/main/java/io/a2a/spec/TaskState.java
+++ b/spec/src/main/java/io/a2a/spec/TaskState.java
@@ -9,19 +9,19 @@ package io.a2a.spec;
  * <p>
  * <b>Transitional States:</b>
  * <ul>
- *   <li><b>SUBMITTED:</b> Task has been received by the agent and is queued for processing</li>
- *   <li><b>WORKING:</b> Agent is actively processing the task and may produce incremental results</li>
- *   <li><b>INPUT_REQUIRED:</b> Agent needs additional input from the user to continue</li>
- *   <li><b>AUTH_REQUIRED:</b> Agent requires authentication or authorization before proceeding</li>
+ *   <li><b>TASK_STATE_SUBMITTED:</b> Task has been received by the agent and is queued for processing</li>
+ *   <li><b>TASK_STATE_WORKING:</b> Agent is actively processing the task and may produce incremental results</li>
+ *   <li><b>TASK_STATE_INPUT_REQUIRED:</b> Agent needs additional input from the user to continue</li>
+ *   <li><b>TASK_STATE_AUTH_REQUIRED:</b> Agent requires authentication or authorization before proceeding</li>
  * </ul>
  * <p>
  * <b>Terminal States:</b>
  * <ul>
- *   <li><b>COMPLETED:</b> Task finished successfully with all requested work done</li>
- *   <li><b>CANCELED:</b> Task was explicitly canceled by the user or system</li>
- *   <li><b>FAILED:</b> Task failed due to an error during execution</li>
- *   <li><b>REJECTED:</b> Task was rejected by the agent (e.g., invalid request, policy violation)</li>
- *   <li><b>UNKNOWN:</b> Task state cannot be determined (error recovery state)</li>
+ *   <li><b>TASK_STATE_COMPLETED:</b> Task finished successfully with all requested work done</li>
+ *   <li><b>TASK_STATE_CANCELED:</b> Task was explicitly canceled by the user or system</li>
+ *   <li><b>TASK_STATE_FAILED:</b> Task failed due to an error during execution</li>
+ *   <li><b>TASK_STATE_REJECTED:</b> Task was rejected by the agent (e.g., invalid request, policy violation)</li>
+ *   <li><b>UNRECOGNIZED:</b> Task state cannot be determined (error recovery state)</li>
  * </ul>
  * <p>
  * The {@link #isFinal()} method can be used to determine if a state is terminal, which is
@@ -33,54 +33,36 @@ package io.a2a.spec;
  */
 public enum TaskState {
     /** Task has been received and is queued for processing (transitional state). */
-    SUBMITTED("submitted"),
+    TASK_STATE_SUBMITTED(false),
 
     /** Agent is actively processing the task (transitional state). */
-    WORKING("working"),
+    TASK_STATE_WORKING(false),
 
     /** Agent requires additional input from the user to continue (transitional state). */
-    INPUT_REQUIRED("input-required"),
+    TASK_STATE_INPUT_REQUIRED(false),
 
     /** Agent requires authentication or authorization to proceed (transitional state). */
-    AUTH_REQUIRED("auth-required"),
+    TASK_STATE_AUTH_REQUIRED(false),
 
     /** Task completed successfully (terminal state). */
-    COMPLETED("completed", true),
+    TASK_STATE_COMPLETED(true),
 
     /** Task was canceled by user or system (terminal state). */
-    CANCELED("canceled", true),
+    TASK_STATE_CANCELED(true),
 
     /** Task failed due to an error (terminal state). */
-    FAILED("failed", true),
+    TASK_STATE_FAILED(true),
 
     /** Task was rejected by the agent (terminal state). */
-    REJECTED("rejected", true),
+    TASK_STATE_REJECTED(true),
 
     /** Task state is unknown or cannot be determined (terminal state). */
-    UNKNOWN("unknown", true);
+    UNRECOGNIZED(true);
 
-    private final String state;
     private final boolean isFinal;
 
-    TaskState(String state) {
-        this(state, false);
-    }
-
-    TaskState(String state, boolean isFinal) {
-        this.state = state;
+    TaskState(boolean isFinal) {
         this.isFinal = isFinal;
-    }
-
-    /**
-     * Returns the string representation of this task state for JSON serialization.
-     * <p>
-     * This method is used to serialize TaskState values to their
-     * wire format (e.g., "working", "completed").
-     *
-     * @return the string representation of this state
-     */
-    public String asString() {
-        return state;
     }
 
     /**
@@ -90,35 +72,9 @@ public enum TaskState {
      * not transition to any other state. This is used by the event queue system
      * to determine when to close queues and by clients to know when to stop polling.
      *
-     * @return true if this is a terminal state (COMPLETED, CANCELED, FAILED, REJECTED, UNKNOWN),
-     *         false for transitional states (SUBMITTED, WORKING, INPUT_REQUIRED, AUTH_REQUIRED)
+     * @return {@code true} if this is a terminal state, {@code false} else.
      */
     public boolean isFinal(){
         return isFinal;
-    }
-
-    /**
-     * Deserializes a string value into a TaskState enum constant.
-     * <p>
-     * This method is used to deserialize TaskState values from their
-     * wire format during JSON parsing.
-     *
-     * @param state the string representation of the state
-     * @return the corresponding TaskState enum constant
-     * @throws IllegalArgumentException if the state string is not recognized
-     */
-    public static TaskState fromString(String state) {
-        return switch (state) {
-            case "submitted" -> SUBMITTED;
-            case "working" -> WORKING;
-            case "input-required" -> INPUT_REQUIRED;
-            case "auth-required" -> AUTH_REQUIRED;
-            case "completed" -> COMPLETED;
-            case "canceled" -> CANCELED;
-            case "failed" -> FAILED;
-            case "rejected" -> REJECTED;
-            case "unknown" -> UNKNOWN;
-            default -> throw new IllegalArgumentException("Invalid TaskState: " + state);
-        };
     }
 }

--- a/spec/src/main/java/io/a2a/spec/TaskStatusUpdateEvent.java
+++ b/spec/src/main/java/io/a2a/spec/TaskStatusUpdateEvent.java
@@ -1,10 +1,10 @@
 package io.a2a.spec;
 
-import static io.a2a.spec.TaskState.CANCELED;
-import static io.a2a.spec.TaskState.COMPLETED;
-import static io.a2a.spec.TaskState.FAILED;
-import static io.a2a.spec.TaskState.INPUT_REQUIRED;
-import static io.a2a.spec.TaskState.REJECTED;
+import static io.a2a.spec.TaskState.TASK_STATE_CANCELED;
+import static io.a2a.spec.TaskState.TASK_STATE_COMPLETED;
+import static io.a2a.spec.TaskState.TASK_STATE_FAILED;
+import static io.a2a.spec.TaskState.TASK_STATE_INPUT_REQUIRED;
+import static io.a2a.spec.TaskState.TASK_STATE_REJECTED;
 
 import java.util.Map;
 
@@ -59,7 +59,7 @@ public record TaskStatusUpdateEvent(String taskId, TaskStatus status, String con
      * @return true if the task is fianl or waiting for some inputs from the client - false otherwise.
      */
     public boolean isFinalOrInterrupted() {
-        return status.state() == COMPLETED || status.state() == FAILED || status.state() == CANCELED || status.state() == REJECTED || status.state() == INPUT_REQUIRED;
+        return status.state() == TASK_STATE_COMPLETED || status.state() == TASK_STATE_FAILED || status.state() == TASK_STATE_CANCELED || status.state() == TASK_STATE_REJECTED || status.state() == TASK_STATE_INPUT_REQUIRED;
     }
 
     /**

--- a/tck/src/main/java/io/a2a/tck/server/AgentExecutorProducer.java
+++ b/tck/src/main/java/io/a2a/tck/server/AgentExecutorProducer.java
@@ -14,7 +14,6 @@ import io.a2a.spec.Task;
 import io.a2a.spec.TaskNotCancelableError;
 import io.a2a.spec.TaskState;
 import io.a2a.spec.TaskStatus;
-import io.a2a.spec.TaskStatusUpdateEvent;
 
 @ApplicationScoped
 public class AgentExecutorProducer {
@@ -43,7 +42,7 @@ public class AgentExecutorProducer {
                 task = Task.builder()
                         .id(context.getTaskId())
                         .contextId(context.getContextId())
-                        .status(new TaskStatus(TaskState.SUBMITTED))
+                        .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                         .history(List.of(context.getMessage()))
                         .build();
                 agentEmitter.addTask(task);
@@ -76,12 +75,12 @@ public class AgentExecutorProducer {
                 System.out.println("====> No task found");
                 throw new TaskNotCancelableError();
             }
-            if (task.status().state() == TaskState.CANCELED) {
+            if (task.status().state() == TaskState.TASK_STATE_CANCELED) {
                 System.out.println("====> task already canceled");
                 throw new TaskNotCancelableError();
             }
 
-            if (task.status().state() == TaskState.COMPLETED) {
+            if (task.status().state() == TaskState.TASK_STATE_COMPLETED) {
                 System.out.println("====> task already completed");
                 throw new TaskNotCancelableError();
             }

--- a/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
@@ -97,25 +97,25 @@ public abstract class AbstractA2AServerTest {
     protected static final Task MINIMAL_TASK = Task.builder()
             .id("task-123")
             .contextId("session-xyz")
-            .status(new TaskStatus(TaskState.SUBMITTED))
+            .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
             .build();
 
     private static final Task CANCEL_TASK = Task.builder()
             .id("cancel-task-123")
             .contextId("session-xyz")
-            .status(new TaskStatus(TaskState.SUBMITTED))
+            .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
             .build();
 
     private static final Task CANCEL_TASK_NOT_SUPPORTED = Task.builder()
             .id("cancel-task-not-supported-123")
             .contextId("session-xyz")
-            .status(new TaskStatus(TaskState.SUBMITTED))
+            .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
             .build();
 
     private static final Task SEND_MESSAGE_NOT_SUPPORTED = Task.builder()
             .id("task-not-supported-123")
             .contextId("session-xyz")
-            .status(new TaskStatus(TaskState.SUBMITTED))
+            .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
             .build();
 
     protected static final Message MESSAGE = Message.builder()
@@ -185,7 +185,7 @@ public abstract class AbstractA2AServerTest {
             Task response = getClient().getTask(new TaskQueryParams(MINIMAL_TASK.id()));
             assertEquals("task-123", response.id());
             assertEquals("session-xyz", response.contextId());
-            assertEquals(TaskState.SUBMITTED, response.status().state());
+            assertEquals(TaskState.TASK_STATE_SUBMITTED, response.status().state());
         } catch (A2AClientException e) {
             fail("Unexpected exception during getTask: " + e.getMessage(), e);
         } finally {
@@ -212,7 +212,7 @@ public abstract class AbstractA2AServerTest {
             Task task = getClient().cancelTask(new TaskIdParams(CANCEL_TASK.id()));
             assertEquals(CANCEL_TASK.id(), task.id());
             assertEquals(CANCEL_TASK.contextId(), task.contextId());
-            assertEquals(TaskState.CANCELED, task.status().state());
+            assertEquals(TaskState.TASK_STATE_CANCELED, task.status().state());
         } catch (A2AClientException e) {
             fail("Unexpected exception during cancel task: " + e.getMessage(), e);
         } finally {
@@ -251,17 +251,17 @@ public abstract class AbstractA2AServerTest {
         Task task1 = Task.builder()
                 .id("list-task-1")
                 .contextId("context-1")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
         Task task2 = Task.builder()
                 .id("list-task-2")
                 .contextId("context-1")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
         Task task3 = Task.builder()
                 .id("list-task-3")
                 .contextId("context-2")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
 
         saveTaskInTaskStore(task1);
@@ -290,17 +290,17 @@ public abstract class AbstractA2AServerTest {
         Task task1 = Task.builder()
                 .id("list-task-ctx-1")
                 .contextId("context-filter-1")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
         Task task2 = Task.builder()
                 .id("list-task-ctx-2")
                 .contextId("context-filter-1")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
         Task task3 = Task.builder()
                 .id("list-task-ctx-3")
                 .contextId("context-filter-2")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
 
         saveTaskInTaskStore(task1);
@@ -331,17 +331,17 @@ public abstract class AbstractA2AServerTest {
         Task task1 = Task.builder()
                 .id("list-task-status-1")
                 .contextId("context-status")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
         Task task2 = Task.builder()
                 .id("list-task-status-2")
                 .contextId("context-status")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
         Task task3 = Task.builder()
                 .id("list-task-status-3")
                 .contextId("context-status")
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
 
         saveTaskInTaskStore(task1);
@@ -351,7 +351,7 @@ public abstract class AbstractA2AServerTest {
         try {
             // Filter by status WORKING
             io.a2a.spec.ListTasksParams params = ListTasksParams.builder()
-                    .status(TaskState.WORKING)
+                    .status(TaskState.TASK_STATE_WORKING)
                     .tenant("")
                     .build();
             ListTasksResult result = getClient().listTasks(params);
@@ -361,7 +361,7 @@ public abstract class AbstractA2AServerTest {
             assertTrue(result.tasks().size() >= 2, "Should have at least 2 WORKING tasks");
             assertTrue(result.tasks().stream()
                     .filter(t -> t.id().startsWith("list-task-status-"))
-                    .allMatch(t -> TaskState.WORKING.equals(t.status().state())));
+                    .allMatch(t -> TaskState.TASK_STATE_WORKING.equals(t.status().state())));
         } finally {
             deleteTaskInTaskStore(task1.id());
             deleteTaskInTaskStore(task2.id());
@@ -375,17 +375,17 @@ public abstract class AbstractA2AServerTest {
         Task task1 = Task.builder()
                 .id("page-task-1")
                 .contextId("page-context")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
         Task task2 = Task.builder()
                 .id("page-task-2")
                 .contextId("page-context")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
         Task task3 = Task.builder()
                 .id("page-task-3")
                 .contextId("page-context")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build();
 
         saveTaskInTaskStore(task1);
@@ -436,7 +436,7 @@ public abstract class AbstractA2AServerTest {
         Task taskWithHistory = Task.builder()
                 .id("list-task-history")
                 .contextId("context-history")
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .history(history)
                 .build();
 
@@ -715,7 +715,7 @@ public abstract class AbstractA2AServerTest {
                     TaskStatusUpdateEvent.builder()
                             .taskId(MINIMAL_TASK.id())
                             .contextId(MINIMAL_TASK.contextId())
-                            .status(new TaskStatus(TaskState.COMPLETED))
+                            .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                             .build());
 
             for (Event event : events) {
@@ -741,7 +741,7 @@ public abstract class AbstractA2AServerTest {
             assertNotNull(receivedStatusEvent);
             assertEquals(MINIMAL_TASK.id(), receivedStatusEvent.taskId());
             assertEquals(MINIMAL_TASK.contextId(), receivedStatusEvent.contextId());
-            assertEquals(TaskState.COMPLETED, receivedStatusEvent.status().state());
+            assertEquals(TaskState.TASK_STATE_COMPLETED, receivedStatusEvent.status().state());
             assertNotNull(receivedStatusEvent.status().timestamp());
         } finally {
             deleteTaskInTaskStore(MINIMAL_TASK.id());
@@ -833,7 +833,7 @@ public abstract class AbstractA2AServerTest {
                     TaskStatusUpdateEvent.builder()
                             .taskId(MINIMAL_TASK.id())
                             .contextId(MINIMAL_TASK.contextId())
-                            .status(new TaskStatus(TaskState.COMPLETED))
+                            .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                             .build());
 
             for (Event event : events) {
@@ -859,7 +859,7 @@ public abstract class AbstractA2AServerTest {
             assertNotNull(receivedStatusEvent);
             assertEquals(MINIMAL_TASK.id(), receivedStatusEvent.taskId());
             assertEquals(MINIMAL_TASK.contextId(), receivedStatusEvent.contextId());
-            assertEquals(TaskState.COMPLETED, receivedStatusEvent.status().state());
+            assertEquals(TaskState.TASK_STATE_COMPLETED, receivedStatusEvent.status().state());
             assertNotNull(receivedStatusEvent.status().timestamp());
         } finally {
             deleteTaskInTaskStore(MINIMAL_TASK.id());
@@ -1204,7 +1204,7 @@ public abstract class AbstractA2AServerTest {
         saveTaskInTaskStore(Task.builder()
                 .id("task-456")
                 .contextId("session-xyz")
-                .status(new TaskStatus(TaskState.SUBMITTED))
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
                 .build());
 
         PushNotificationConfig notificationConfig1
@@ -1558,7 +1558,7 @@ public abstract class AbstractA2AServerTest {
                     TaskState state = te.getTask().status().state();
                     initialState.set(state);
                     // Only count down when we receive INPUT_REQUIRED, not intermediate states like WORKING
-                    if (state == TaskState.INPUT_REQUIRED) {
+                    if (state == TaskState.TASK_STATE_INPUT_REQUIRED) {
                         initialLatch.countDown();
                     }
                 } else {
@@ -1570,7 +1570,7 @@ public abstract class AbstractA2AServerTest {
             getNonStreamingClient().sendMessage(initialMessage, List.of(initialConsumer), null);
             assertTrue(initialLatch.await(10, TimeUnit.SECONDS));
             assertFalse(initialUnexpectedEvent.get());
-            assertEquals(TaskState.INPUT_REQUIRED, initialState.get());
+            assertEquals(TaskState.TASK_STATE_INPUT_REQUIRED, initialState.get());
 
             // 2. Send input message - AgentExecutor will complete the task
             Message inputMessage = Message.builder(MESSAGE)
@@ -1592,7 +1592,7 @@ public abstract class AbstractA2AServerTest {
                     TaskState state = te.getTask().status().state();
                     completedState.set(state);
                     // Only count down when we receive COMPLETED, not intermediate states like WORKING
-                    if (state == TaskState.COMPLETED) {
+                    if (state == TaskState.TASK_STATE_COMPLETED) {
                         completionLatch.countDown();
                     }
                 } else {
@@ -1604,7 +1604,7 @@ public abstract class AbstractA2AServerTest {
             getNonStreamingClient().sendMessage(inputMessage, List.of(completionConsumer), null);
             assertTrue(completionLatch.await(10, TimeUnit.SECONDS));
             assertFalse(completionUnexpectedEvent.get());
-            assertEquals(TaskState.COMPLETED, completedState.get());
+            assertEquals(TaskState.TASK_STATE_COMPLETED, completedState.get());
 
         } finally {
             deleteTaskInTaskStore(inputRequiredTaskId);
@@ -2237,7 +2237,7 @@ public abstract class AbstractA2AServerTest {
         Task workingTask = Task.builder()
                 .id(taskId)
                 .contextId(contextId)
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
         saveTaskInTaskStore(workingTask);
 

--- a/transport/grpc/src/test/java/io/a2a/transport/grpc/handler/GrpcHandlerTest.java
+++ b/transport/grpc/src/test/java/io/a2a/transport/grpc/handler/GrpcHandlerTest.java
@@ -1,6 +1,5 @@
 package io.a2a.transport.grpc.handler;
 
-import static io.a2a.spec.AgentInterface.CURRENT_PROTOCOL_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
@@ -23,7 +22,6 @@ import io.a2a.server.events.EventConsumer;
 import io.a2a.server.requesthandlers.AbstractA2ARequestHandlerTest;
 import io.a2a.server.requesthandlers.DefaultRequestHandler;
 import io.a2a.server.requesthandlers.RequestHandler;
-import io.a2a.server.tasks.AgentEmitter;
 import io.a2a.spec.AgentCapabilities;
 import io.a2a.spec.AgentCard;
 import io.a2a.spec.AgentExtension;
@@ -371,7 +369,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
                 TaskStatusUpdateEvent.builder()
                         .taskId(task.id())
                         .contextId(task.contextId())
-                        .status(new io.a2a.spec.TaskStatus(io.a2a.spec.TaskState.WORKING))
+                        .status(new io.a2a.spec.TaskStatus(io.a2a.spec.TaskState.TASK_STATE_WORKING))
                         .build());
 
         StreamRecorder<StreamResponse> streamRecorder;
@@ -421,7 +419,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
                     TaskStatusUpdateEvent.builder()
                             .taskId(AbstractA2ARequestHandlerTest.MINIMAL_TASK.id())
                             .contextId(AbstractA2ARequestHandlerTest.MINIMAL_TASK.contextId())
-                            .status(new io.a2a.spec.TaskStatus(io.a2a.spec.TaskState.COMPLETED))
+                            .status(new io.a2a.spec.TaskStatus(io.a2a.spec.TaskState.TASK_STATE_COMPLETED))
                             .build());
 
             agentExecutorExecute = (context, agentEmitter) -> {
@@ -482,7 +480,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
             TaskStatusUpdateEvent statusUpdate = (TaskStatusUpdateEvent) httpClient.events.get(2);
             Assertions.assertEquals(AbstractA2ARequestHandlerTest.MINIMAL_TASK.id(), statusUpdate.taskId());
             Assertions.assertEquals(AbstractA2ARequestHandlerTest.MINIMAL_TASK.contextId(), statusUpdate.contextId());
-            Assertions.assertEquals(io.a2a.spec.TaskState.COMPLETED, statusUpdate.status().state());
+            Assertions.assertEquals(io.a2a.spec.TaskState.TASK_STATE_COMPLETED, statusUpdate.status().state());
         } finally {
             mainEventBusProcessor.setPushNotificationExecutor(null);
         }
@@ -562,7 +560,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
                 TaskStatusUpdateEvent.builder()
                         .taskId(AbstractA2ARequestHandlerTest.MINIMAL_TASK.id())
                         .contextId(AbstractA2ARequestHandlerTest.MINIMAL_TASK.contextId())
-                        .status(new io.a2a.spec.TaskStatus(io.a2a.spec.TaskState.WORKING))
+                        .status(new io.a2a.spec.TaskStatus(io.a2a.spec.TaskState.TASK_STATE_WORKING))
                         .build());
 
         StreamRecorder<StreamResponse> streamRecorder = StreamRecorder.create();

--- a/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -142,7 +142,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
         Task task = response.getResult();
         assertEquals(MINIMAL_TASK.id(), task.id());
         assertEquals(MINIMAL_TASK.contextId(), task.contextId());
-        assertEquals(TaskState.CANCELED, task.status().state());
+        assertEquals(TaskState.TASK_STATE_CANCELED, task.status().state());
     }
 
     @Test
@@ -310,7 +310,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
 
             // Create multiple events to be sent during streaming
         Task taskEvent = Task.builder(MINIMAL_TASK)
-                .status(new TaskStatus(TaskState.WORKING))
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                 .build();
 
         TaskArtifactUpdateEvent artifactEvent = TaskArtifactUpdateEvent.builder()
@@ -325,7 +325,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
         TaskStatusUpdateEvent statusEvent = TaskStatusUpdateEvent.builder()
                 .taskId(MINIMAL_TASK.id())
                 .contextId(MINIMAL_TASK.contextId())
-                .status(new TaskStatus(TaskState.COMPLETED))
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                 .build();
 
         // Configure the agent executor to enqueue multiple events
@@ -397,7 +397,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
         Task receivedTask = assertInstanceOf(Task.class, results.get(0), "First event should be a Task");
         assertEquals(MINIMAL_TASK.id(), receivedTask.id());
         assertEquals(MINIMAL_TASK.contextId(), receivedTask.contextId());
-        assertEquals(TaskState.WORKING, receivedTask.status().state());
+        assertEquals(TaskState.TASK_STATE_WORKING, receivedTask.status().state());
 
         // Verify the second event is the artifact update
         TaskArtifactUpdateEvent receivedArtifact = assertInstanceOf(TaskArtifactUpdateEvent.class, results.get(1),
@@ -409,13 +409,13 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
         TaskStatusUpdateEvent receivedStatus = assertInstanceOf(TaskStatusUpdateEvent.class, results.get(2),
                 "Third event should be a TaskStatusUpdateEvent");
         assertEquals(MINIMAL_TASK.id(), receivedStatus.taskId());
-        assertEquals(TaskState.COMPLETED, receivedStatus.status().state());
+        assertEquals(TaskState.TASK_STATE_COMPLETED, receivedStatus.status().state());
 
         // Verify events were persisted to TaskStore (poll for final state)
         for (int i = 0; i < 50; i++) {
             Task storedTask = taskStore.get(MINIMAL_TASK.id());
             if (storedTask != null && storedTask.status() != null
-                    && TaskState.COMPLETED.equals(storedTask.status().state())) {
+                    && TaskState.TASK_STATE_COMPLETED.equals(storedTask.status().state())) {
                 return; // Success - task finalized in TaskStore
             }
             Thread.sleep(100);
@@ -441,7 +441,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
                 TaskStatusUpdateEvent.builder()
                         .taskId(MINIMAL_TASK.id())
                         .contextId(MINIMAL_TASK.contextId())
-                        .status(new TaskStatus(TaskState.COMPLETED))
+                        .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                         .build());
 
         Message message = Message.builder(MESSAGE)
@@ -588,7 +588,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
                 TaskStatusUpdateEvent.builder()
                         .taskId(task.id())
                         .contextId(task.contextId())
-                        .status(new TaskStatus(TaskState.WORKING))
+                        .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                         .build());
 
         Message message = Message.builder(MESSAGE)
@@ -719,7 +719,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
                     TaskStatusUpdateEvent.builder()
                             .taskId(MINIMAL_TASK.id())
                             .contextId(MINIMAL_TASK.contextId())
-                            .status(new TaskStatus(TaskState.COMPLETED))
+                            .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
                             .build());
 
 
@@ -806,7 +806,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
             TaskStatusUpdateEvent statusUpdate = (TaskStatusUpdateEvent) httpClient.events.get(2);
             assertEquals(MINIMAL_TASK.id(), statusUpdate.taskId());
             assertEquals(MINIMAL_TASK.contextId(), statusUpdate.contextId());
-            assertEquals(TaskState.COMPLETED, statusUpdate.status().state());
+            assertEquals(TaskState.TASK_STATE_COMPLETED, statusUpdate.status().state());
         } finally {
             mainEventBusProcessor.setPushNotificationExecutor(null);
         }
@@ -910,7 +910,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
                 TaskStatusUpdateEvent.builder()
                         .taskId(MINIMAL_TASK.id())
                         .contextId(MINIMAL_TASK.contextId())
-                        .status(new TaskStatus(TaskState.WORKING))
+                        .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
                         .build());
 
         SubscribeToTaskRequest request = new SubscribeToTaskRequest("1", new TaskIdParams(MINIMAL_TASK.id()));

--- a/transport/rest/src/main/java/io/a2a/transport/rest/handler/RestHandler.java
+++ b/transport/rest/src/main/java/io/a2a/transport/rest/handler/RestHandler.java
@@ -221,33 +221,13 @@ public class RestHandler {
                 paramsBuilder.contextId(contextId);
             }
             if (status != null) {
-                TaskState taskState = null;
+                TaskState taskState;
 
-                // Try JSON format first (e.g., "working", "completed")
                 try {
-                    taskState = TaskState.fromString(status);
+                    taskState = TaskState.valueOf(status);
                 } catch (IllegalArgumentException e) {
-                    // Try protobuf enum format (e.g., "TASK_STATE_WORKING")
-                    if (status.startsWith(TASK_STATE_PREFIX)) {
-                        String enumName = status.substring(TASK_STATE_PREFIX.length());
-                        try {
-                            taskState = TaskState.valueOf(enumName);
-                        } catch (IllegalArgumentException protoError) {
-                            // Fall through to error handling below
-                        }
-                    } else {
-                        // Try enum constant name directly (e.g., "WORKING")
-                        try {
-                            taskState = TaskState.valueOf(status);
-                        } catch (IllegalArgumentException valueOfError) {
-                            // Fall through to error handling below
-                        }
-                    }
-                }
-
-                if (taskState == null) {
                     String validStates = Arrays.stream(TaskState.values())
-                            .map(TaskState::asString)
+                            .map(TaskState::name)
                             .collect(Collectors.joining(", "));
                     Map<String, Object> errorData = new HashMap<>();
                     errorData.put("parameter", "status");

--- a/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
+++ b/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
@@ -63,7 +63,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
         taskStore.save(MINIMAL_TASK, false);
 
-        RestHandler.HTTPRestResponse response = handler.listTasks(callContext, "", null, "submitted", null, null,
+        RestHandler.HTTPRestResponse response = handler.listTasks(callContext, "", null, "TASK_STATE_SUBMITTED", null, null,
                 null, null, null);
 
         Assertions.assertEquals(200, response.getStatusCode());
@@ -911,8 +911,8 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
         taskStore.save(MINIMAL_TASK, false);
 
-        // Enum constant format (SUBMITTED) should be accepted
-        RestHandler.HTTPRestResponse response = handler.listTasks(callContext, "", null, "SUBMITTED", null, null,
+        // Enum constant format (TASK_STATE_SUBMITTED) should be accepted
+        RestHandler.HTTPRestResponse response = handler.listTasks(callContext, "", null, "TASK_STATE_SUBMITTED", null, null,
                 null, null, null);
 
         Assertions.assertEquals(200, response.getStatusCode());


### PR DESCRIPTION
Use the protobuf names for the TaskState enums and remove their
textual representations so that the enum names are consistent with their String name.
Rename UNKNOWN to UNRECOGNIZED to be consistent with the Protobuf definitions.

TaskState.TASK_STATE_SUBMITTED is a mouthful but we have static imports for a reason :)

This impacts the JPA serialization but I think it's worth having the same textual representation
for the task state on the wire and the DB.
Remove the TaskStateAdapter that is no longer needed for the JSON serialization.

This fixes #652.