### PR TITLE
feat!: Update Message.Role enum

### DIFF
--- a/client/base/src/main/java/io/a2a/A2A.java
+++ b/client/base/src/main/java/io/a2a/A2A.java
@@ -74,7 +74,7 @@ public class A2A {
      * @see #createUserTextMessage(String, String, String)
      */
     public static Message toUserMessage(String text) {
-        return toMessage(text, Message.Role.USER, null);
+        return toMessage(text, Message.Role.ROLE_USER, null);
     }
 
     /**
@@ -96,7 +96,7 @@ public class A2A {
      * @see #toUserMessage(String)
      */
     public static Message toUserMessage(String text, String messageId) {
-        return toMessage(text, Message.Role.USER, messageId);
+        return toMessage(text, Message.Role.ROLE_USER, messageId);
     }
 
     /**
@@ -117,7 +117,7 @@ public class A2A {
      * @see #toAgentMessage(String, String)
      */
     public static Message toAgentMessage(String text) {
-        return toMessage(text, Message.Role.AGENT, null);
+        return toMessage(text, Message.Role.ROLE_AGENT, null);
     }
 
     /**
@@ -133,7 +133,7 @@ public class A2A {
      * @return an agent message with the specified text and ID
      */
     public static Message toAgentMessage(String text, String messageId) {
-        return toMessage(text, Message.Role.AGENT, messageId);
+        return toMessage(text, Message.Role.ROLE_AGENT, messageId);
     }
 
     /**
@@ -180,7 +180,7 @@ public class A2A {
      * @see Message#taskId()
      */
     public static Message createUserTextMessage(String text, String contextId, String taskId) {
-        return toMessage(text, Message.Role.USER, null, contextId, taskId);
+        return toMessage(text, Message.Role.ROLE_USER, null, contextId, taskId);
     }
 
     /**
@@ -195,7 +195,7 @@ public class A2A {
      * @see #createUserTextMessage(String, String, String)
      */
     public static Message createAgentTextMessage(String text, String contextId, String taskId) {
-        return toMessage(text, Message.Role.AGENT, null, contextId, taskId);
+        return toMessage(text, Message.Role.ROLE_AGENT, null, contextId, taskId);
     }
 
     /**
@@ -225,7 +225,7 @@ public class A2A {
         if (parts == null || parts.isEmpty()) {
             throw new IllegalArgumentException("Parts cannot be null or empty");
         }
-        return toMessage(parts, Message.Role.AGENT, null, contextId, taskId);
+        return toMessage(parts, Message.Role.ROLE_AGENT, null, contextId, taskId);
     }
 
     private static Message toMessage(String text, Message.Role role, String messageId) {

--- a/client/base/src/test/java/io/a2a/A2ATest.java
+++ b/client/base/src/test/java/io/a2a/A2ATest.java
@@ -20,7 +20,7 @@ public class A2ATest {
         String text = "Hello, world!";
         Message message = A2A.toUserMessage(text);
         
-        assertEquals(Message.Role.USER, message.role());
+        assertEquals(Message.Role.ROLE_USER, message.role());
         assertEquals(1, message.parts().size());
         assertEquals(text, ((TextPart) message.parts().get(0)).text());
         assertNotNull(message.messageId());
@@ -34,7 +34,7 @@ public class A2ATest {
         String messageId = "test-message-id";
         Message message = A2A.toUserMessage(text, messageId);
         
-        assertEquals(Message.Role.USER, message.role());
+        assertEquals(Message.Role.ROLE_USER, message.role());
         assertEquals(messageId, message.messageId());
     }
 
@@ -43,7 +43,7 @@ public class A2ATest {
         String text = "Hello, I'm an agent!";
         Message message = A2A.toAgentMessage(text);
         
-        assertEquals(Message.Role.AGENT, message.role());
+        assertEquals(Message.Role.ROLE_AGENT, message.role());
         assertEquals(1, message.parts().size());
         assertEquals(text, ((TextPart) message.parts().get(0)).text());
         assertNotNull(message.messageId());
@@ -55,7 +55,7 @@ public class A2ATest {
         String messageId = "agent-message-id";
         Message message = A2A.toAgentMessage(text, messageId);
         
-        assertEquals(Message.Role.AGENT, message.role());
+        assertEquals(Message.Role.ROLE_AGENT, message.role());
         assertEquals(messageId, message.messageId());
     }
 
@@ -67,7 +67,7 @@ public class A2ATest {
         
         Message message = A2A.createUserTextMessage(text, contextId, taskId);
         
-        assertEquals(Message.Role.USER, message.role());
+        assertEquals(Message.Role.ROLE_USER, message.role());
         assertEquals(contextId, message.contextId());
         assertEquals(taskId, message.taskId());
         assertEquals(1, message.parts().size());
@@ -83,7 +83,7 @@ public class A2ATest {
         
         Message message = A2A.createUserTextMessage(text, null, null);
         
-        assertEquals(Message.Role.USER, message.role());
+        assertEquals(Message.Role.ROLE_USER, message.role());
         assertNull(message.contextId());
         assertNull(message.taskId());
         assertEquals(1, message.parts().size());
@@ -98,7 +98,7 @@ public class A2ATest {
         
         Message message = A2A.createAgentTextMessage(text, contextId, taskId);
         
-        assertEquals(Message.Role.AGENT, message.role());
+        assertEquals(Message.Role.ROLE_AGENT, message.role());
         assertEquals(contextId, message.contextId());
         assertEquals(taskId, message.taskId());
         assertEquals(1, message.parts().size());
@@ -117,7 +117,7 @@ public class A2ATest {
         
         Message message = A2A.createAgentPartsMessage(parts, contextId, taskId);
         
-        assertEquals(Message.Role.AGENT, message.role());
+        assertEquals(Message.Role.ROLE_AGENT, message.role());
         assertEquals(contextId, message.contextId());
         assertEquals(taskId, message.taskId());
         assertEquals(2, message.parts().size());

--- a/client/base/src/test/java/io/a2a/client/AuthenticationAuthorizationTest.java
+++ b/client/base/src/test/java/io/a2a/client/AuthenticationAuthorizationTest.java
@@ -66,7 +66,7 @@ public class AuthenticationAuthorizationTest {
     public void setUp() {
         server = new ClientAndServer(4001);
         MESSAGE = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("test message")))
                 .contextId("context-1234")
                 .messageId("message-1234")

--- a/client/base/src/test/java/io/a2a/client/ClientTaskManagerTest.java
+++ b/client/base/src/test/java/io/a2a/client/ClientTaskManagerTest.java
@@ -42,7 +42,7 @@ public class ClientTaskManagerTest {
         
         sampleMessage = Message.builder()
                 .messageId("msg1")
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("Hello")))
                 .build();
     }
@@ -196,7 +196,7 @@ public class ClientTaskManagerTest {
     public void testUpdateWithMessageMovesStatusMessage() {
         Message statusMessage = Message.builder()
                 .messageId("status_msg")
-                .role(Message.Role.AGENT)
+                .role(Message.Role.ROLE_AGENT)
                 .parts(Collections.singletonList(new TextPart("Status")))
                 .build();
         
@@ -219,7 +219,7 @@ public class ClientTaskManagerTest {
     public void testUpdateWithMessagePreservesExistingHistory() {
         Message existingMessage = Message.builder()
                 .messageId("existing_msg")
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("Existing")))
                 .build();
         
@@ -256,7 +256,7 @@ public class ClientTaskManagerTest {
         // Second status update
         Message secondMessage = Message.builder()
                 .messageId("msg2")
-                .role(Message.Role.AGENT)
+                .role(Message.Role.ROLE_AGENT)
                 .parts(Collections.singletonList(new TextPart("Second message")))
                 .build();
         

--- a/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportStreamingTest.java
+++ b/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportStreamingTest.java
@@ -54,7 +54,7 @@ public class JSONRPCTransportStreamingTest {
         // The goal here is just to verify the correct parameters are being used
         // This is a unit test of the parameter construction, not the streaming itself
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("test message")))
                 .contextId("context-test")
                 .messageId("message-test")
@@ -73,7 +73,7 @@ public class JSONRPCTransportStreamingTest {
         assertNotNull(params);
         assertEquals(message, params.message());
         assertEquals(configuration, params.configuration());
-        assertEquals(Message.Role.USER, params.message().role());
+        assertEquals(Message.Role.ROLE_USER, params.message().role());
         assertEquals("test message", ((TextPart) params.message().parts().get(0)).text());
     }
 
@@ -95,7 +95,7 @@ public class JSONRPCTransportStreamingTest {
 
         JSONRPCTransport client = new JSONRPCTransport("http://localhost:4001");
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("tell me some jokes")))
                 .contextId("context-1234")
                 .messageId("message-1234")

--- a/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportTest.java
+++ b/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportTest.java
@@ -103,7 +103,7 @@ public class JSONRPCTransportTest {
 
         JSONRPCTransport client = new JSONRPCTransport("http://localhost:4001");
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("tell me a joke")))
                 .contextId("context-1234")
                 .messageId("message-1234")
@@ -151,7 +151,7 @@ public class JSONRPCTransportTest {
 
         JSONRPCTransport client = new JSONRPCTransport("http://localhost:4001");
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("tell me a joke")))
                 .contextId("context-1234")
                 .messageId("message-1234")
@@ -168,7 +168,7 @@ public class JSONRPCTransportTest {
         EventKind result = client.sendMessage(params, null);
         assertInstanceOf(Message.class, result);
         Message agentMessage = (Message) result;
-        assertEquals(Message.Role.AGENT, agentMessage.role());
+        assertEquals(Message.Role.ROLE_AGENT, agentMessage.role());
         Part<?> part = agentMessage.parts().get(0);
         assertTrue(part instanceof TextPart);
         assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart) part).text());
@@ -193,7 +193,7 @@ public class JSONRPCTransportTest {
 
         JSONRPCTransport client = new JSONRPCTransport("http://localhost:4001");
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("tell me a joke")))
                 .contextId("context-1234")
                 .messageId("message-1234")
@@ -248,7 +248,7 @@ public class JSONRPCTransportTest {
         assertNotNull(history);
         assertEquals(1, history.size());
         Message message = history.get(0);
-        assertEquals(Message.Role.USER, message.role());
+        assertEquals(Message.Role.ROLE_USER, message.role());
         List<Part<?>> parts = message.parts();
         assertNotNull(parts);
         assertEquals(3, parts.size());
@@ -435,7 +435,7 @@ public class JSONRPCTransportTest {
 
         JSONRPCTransport client = new JSONRPCTransport("http://localhost:4001");
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(List.of(
                         new TextPart("analyze this image"),
                         new FilePart(new FileWithUri("image/jpeg", null, "file:///path/to/image.jpg"))
@@ -495,7 +495,7 @@ public class JSONRPCTransportTest {
         data.put("timestamp", "2024-01-15T10:30:00Z");
 
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(List.of(
                         new TextPart("process this data"),
                         new DataPart(data)
@@ -552,7 +552,7 @@ public class JSONRPCTransportTest {
         data.put("labels", List.of("Q1", "Q2", "Q3", "Q4"));
 
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(List.of(
                         new TextPart("analyze this data and image"),
                         new FilePart(new FileWithBytes("image/png", "chart.png", "aGVsbG8=")),
@@ -617,7 +617,7 @@ public class JSONRPCTransportTest {
 
         JSONRPCTransport client = new JSONRPCTransport("http://localhost:4001");
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("test message")))
                 .contextId("context-test")
                 .messageId("message-test")
@@ -673,7 +673,7 @@ public class JSONRPCTransportTest {
 
         JSONRPCTransport client = new JSONRPCTransport("http://localhost:4001");
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("test message")))
                 .contextId("context-test")
                 .messageId("message-test")

--- a/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/sse/SSEEventListenerTest.java
+++ b/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/sse/SSEEventListenerTest.java
@@ -73,7 +73,7 @@ public class SSEEventListenerTest {
         assertNotNull(receivedEvent.get());
         assertTrue(receivedEvent.get() instanceof Message);
         Message message = (Message) receivedEvent.get();
-        assertEquals(Message.Role.AGENT, message.role());
+        assertEquals(Message.Role.ROLE_AGENT, message.role());
         assertEquals("msg-123", message.messageId());
         assertEquals("context-456", message.contextId());
         assertEquals(1, message.parts().size());

--- a/client/transport/rest/src/test/java/io/a2a/client/transport/rest/RestTransportTest.java
+++ b/client/transport/rest/src/test/java/io/a2a/client/transport/rest/RestTransportTest.java
@@ -110,7 +110,7 @@ public class RestTransportTest {
     @Test
     public void testSendMessage() throws Exception {
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("tell me a joke")))
                 .contextId("context-1234")
                 .messageId("message-1234")
@@ -143,7 +143,7 @@ public class RestTransportTest {
         assertEquals(1, task.history().size());
         Message history = task.history().get(0);
         assertEquals("message", history.kind());
-        assertEquals(Message.Role.USER, history.role());
+        assertEquals(Message.Role.ROLE_USER, history.role());
         assertEquals("context-1234", history.contextId());
         assertEquals("message-1234", history.messageId());
         assertEquals("9b511af4-b27c-47fa-aecf-2a93c08a44f8", history.taskId());
@@ -215,7 +215,7 @@ public class RestTransportTest {
         assertEquals(1, task.history().size());
         Message history = task.history().get(0);
         assertEquals("message", history.kind());
-        assertEquals(Message.Role.USER, history.role());
+        assertEquals(Message.Role.ROLE_USER, history.role());
         assertEquals("message-123", history.messageId());
         assertEquals(3, history.parts().size());
         assertTrue(history.parts().get(0) instanceof io.a2a.spec.TextPart);
@@ -252,7 +252,7 @@ public class RestTransportTest {
 
         RestTransport client = new RestTransport(CARD);
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("tell me some jokes")))
                 .contextId("context-1234")
                 .messageId("message-1234")
@@ -478,7 +478,7 @@ public class RestTransportTest {
 
         RestTransport client = new RestTransport(CARD);
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("test message")))
                 .contextId("context-test")
                 .messageId("message-test")
@@ -526,7 +526,7 @@ public class RestTransportTest {
 
         RestTransport client = new RestTransport(CARD);
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("test message")))
                 .contextId("context-test")
                 .messageId("message-test")
@@ -573,7 +573,7 @@ public class RestTransportTest {
 
         RestTransport client = new RestTransport(CARD);
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("test message")))
                 .contextId("context-test")
                 .messageId("message-test")

--- a/client/transport/rest/src/test/java/io/a2a/client/transport/rest/sse/SSEEventListenerTest.java
+++ b/client/transport/rest/src/test/java/io/a2a/client/transport/rest/sse/SSEEventListenerTest.java
@@ -126,7 +126,7 @@ public class SSEEventListenerTest {
         assertNotNull(receivedEvent.get());
         assertTrue(receivedEvent.get() instanceof Message);
         Message message = (Message) receivedEvent.get();
-        assertEquals(Message.Role.AGENT, message.role());
+        assertEquals(Message.Role.ROLE_AGENT, message.role());
         assertEquals("msg-123", message.messageId());
         assertEquals("context-456", message.contextId());
         assertEquals(1, message.parts().size());

--- a/client/transport/spi/src/test/java/io/a2a/client/transport/spi/sse/SSEEventListenerTest.java
+++ b/client/transport/spi/src/test/java/io/a2a/client/transport/spi/sse/SSEEventListenerTest.java
@@ -144,7 +144,7 @@ public class SSEEventListenerTest {
         AtomicReference<StreamingEventKind> receivedEvent = new AtomicReference<>();
         TestSSEEventListener listener = createListenerWithEventCapture(receivedEvent);
 
-        Message message = createMessage(Message.Role.USER);
+        Message message = createMessage(Message.Role.ROLE_USER);
 
         listener.setEventToHandle(message);
         listener.onMessage(TEST_TEXT, null);
@@ -242,7 +242,7 @@ public class SSEEventListenerTest {
     @Test
     public void testShouldAutoCloseWithMessage() {
         TestSSEEventListener listener = createBasicListener();
-        Message message = createMessage(Message.Role.AGENT);
+        Message message = createMessage(Message.Role.ROLE_AGENT);
 
         assertFalse(listener.shouldAutoClose(message));
     }
@@ -268,7 +268,7 @@ public class SSEEventListenerTest {
         AtomicReference<StreamingEventKind> receivedEvent = new AtomicReference<>();
         TestSSEEventListener listener = createListenerWithEventCapture(receivedEvent);
 
-        Message message = createMessage(Message.Role.AGENT);
+        Message message = createMessage(Message.Role.ROLE_AGENT);
         CancelCapturingFuture future = new CancelCapturingFuture();
 
         listener.setEventToHandle(message);

--- a/examples/cloud-deployment/server/src/test/java/io/a2a/examples/cloud/A2ACloudExampleClient.java
+++ b/examples/cloud-deployment/server/src/test/java/io/a2a/examples/cloud/A2ACloudExampleClient.java
@@ -281,7 +281,7 @@ public class A2ACloudExampleClient {
                     .build();
 
             Message message = Message.builder()
-                    .role(Message.Role.USER)
+                    .role(Message.Role.ROLE_USER)
                     .parts(new TextPart("process"))
                     .taskId(serverTaskId)
                     .build();
@@ -326,7 +326,7 @@ public class A2ACloudExampleClient {
                 .build();
 
         Message completeMessage = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(new TextPart("complete"))
                 .taskId(serverTaskId)
                 .build();

--- a/extras/opentelemetry/client/src/main/java/io/a2a/extras/opentelemetry/client/OpenTelemetryClientTransport.java
+++ b/extras/opentelemetry/client/src/main/java/io/a2a/extras/opentelemetry/client/OpenTelemetryClientTransport.java
@@ -78,7 +78,7 @@ public class OpenTelemetryClientTransport implements ClientTransport {
                 spanBuilder.setAttribute(GENAI_MESSAGE_ID, request.message().messageId());
             }
             if (request.message().role() != null) {
-                spanBuilder.setAttribute(GENAI_ROLE, request.message().role().asString());
+                spanBuilder.setAttribute(GENAI_ROLE, request.message().role().name());
             }
             if (request.message().extensions() != null && !request.message().extensions().isEmpty()) {
                 spanBuilder.setAttribute(GENAI_EXTENSIONS, String.join(",", request.message().extensions()));
@@ -123,7 +123,7 @@ public class OpenTelemetryClientTransport implements ClientTransport {
                 spanBuilder.setAttribute(GENAI_MESSAGE_ID, request.message().messageId());
             }
             if (request.message().role() != null) {
-                spanBuilder.setAttribute(GENAI_ROLE, request.message().role().asString());
+                spanBuilder.setAttribute(GENAI_ROLE, request.message().role().name());
             }
             if (request.message().extensions() != null && !request.message().extensions().isEmpty()) {
                 spanBuilder.setAttribute(GENAI_EXTENSIONS, String.join(",", request.message().extensions()));

--- a/extras/opentelemetry/client/src/test/java/io/a2a/extras/opentelemetry/client/OpenTelemetryClientTransportTest.java
+++ b/extras/opentelemetry/client/src/test/java/io/a2a/extras/opentelemetry/client/OpenTelemetryClientTransportTest.java
@@ -378,7 +378,7 @@ class OpenTelemetryClientTransportTest {
         Message event = Message.builder()
                 .messageId("test-id")
                 .taskId("task-id")
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(List.of(new TextPart("test content")))
                 .build();
 

--- a/extras/opentelemetry/server/src/main/java/io/a2a/extras/opentelemetry/OpenTelemetryRequestHandlerDecorator.java
+++ b/extras/opentelemetry/server/src/main/java/io/a2a/extras/opentelemetry/OpenTelemetryRequestHandlerDecorator.java
@@ -210,7 +210,7 @@ public abstract class OpenTelemetryRequestHandlerDecorator implements RequestHan
                 spanBuilder.setAttribute(GENAI_MESSAGE_ID, params.message().messageId());
             }
             if (params.message().role() != null) {
-                spanBuilder.setAttribute(GENAI_ROLE, params.message().role().asString());
+                spanBuilder.setAttribute(GENAI_ROLE, params.message().role().name());
             }
             if (params.message().extensions() != null && !params.message().extensions().isEmpty()) {
                 spanBuilder.setAttribute(GENAI_EXTENSIONS, String.join(",", params.message().extensions()));
@@ -258,7 +258,7 @@ public abstract class OpenTelemetryRequestHandlerDecorator implements RequestHan
                 spanBuilder.setAttribute(GENAI_MESSAGE_ID, params.message().messageId());
             }
             if (params.message().role() != null) {
-                spanBuilder.setAttribute(GENAI_ROLE, params.message().role().asString());
+                spanBuilder.setAttribute(GENAI_ROLE, params.message().role().name());
             }
             if (params.message().extensions() != null && !params.message().extensions().isEmpty()) {
                 spanBuilder.setAttribute(GENAI_EXTENSIONS, String.join(",", params.message().extensions()));

--- a/extras/opentelemetry/server/src/test/java/io/a2a/extras/opentelemetry/OpenTelemetryRequestHandlerDecoratorTest.java
+++ b/extras/opentelemetry/server/src/test/java/io/a2a/extras/opentelemetry/OpenTelemetryRequestHandlerDecoratorTest.java
@@ -202,7 +202,7 @@ class OpenTelemetryRequestHandlerDecoratorTest {
         @Test
         void onMessageSend_createsSpanAndDelegatesToHandler() throws A2AError {
             Message message = Message.builder()
-                    .role(Message.Role.USER)
+                    .role(Message.Role.ROLE_USER)
                     .parts(List.of(new TextPart("test message")))
                     .messageId("msg-123")
                     .contextId("ctx-1")
@@ -230,7 +230,7 @@ class OpenTelemetryRequestHandlerDecoratorTest {
         @Test
         void onMessageSend_withError_setsErrorStatus() throws A2AError {
             Message message = Message.builder()
-                    .role(Message.Role.USER)
+                    .role(Message.Role.ROLE_USER)
                     .parts(List.of(new TextPart("test message")))
                     .messageId("msg-123")
                     .contextId("ctx-1")
@@ -253,7 +253,7 @@ class OpenTelemetryRequestHandlerDecoratorTest {
         @Test
         void onMessageSendStream_createsSpanWithSpecialMessage() throws A2AError {
             Message message = Message.builder()
-                    .role(Message.Role.USER)
+                    .role(Message.Role.ROLE_USER)
                     .parts(List.of(new TextPart("test message")))
                     .messageId("msg-123")
                     .contextId("ctx-1")
@@ -275,7 +275,7 @@ class OpenTelemetryRequestHandlerDecoratorTest {
         @Test
         void onMessageSendStream_withError_setsErrorStatus() throws A2AError {
             Message message = Message.builder()
-                    .role(Message.Role.USER)
+                    .role(Message.Role.ROLE_USER)
                     .parts(List.of(new TextPart("test message")))
                     .messageId("msg-123")
                     .contextId("ctx-1")

--- a/extras/push-notification-config-store-database-jpa/src/test/java/io/a2a/extras/pushnotificationconfigstore/database/jpa/JpaDatabasePushNotificationConfigStoreIntegrationTest.java
+++ b/extras/push-notification-config-store-database-jpa/src/test/java/io/a2a/extras/pushnotificationconfigstore/database/jpa/JpaDatabasePushNotificationConfigStoreIntegrationTest.java
@@ -104,7 +104,7 @@ public class JpaDatabasePushNotificationConfigStoreIntegrationTest {
 
         // Step 1: Create the task
         Message createMessage = Message.builder()
-            .role(Message.Role.USER)
+            .role(Message.Role.ROLE_USER)
             .parts(List.of(new TextPart("create"))) // Send the "create" command
             .taskId(taskId)
             .messageId("test-msg-1")
@@ -139,7 +139,7 @@ public class JpaDatabasePushNotificationConfigStoreIntegrationTest {
 
         // Step 4: Update the task to trigger the notification
         Message updateMessage = Message.builder()
-            .role(Message.Role.USER)
+            .role(Message.Role.ROLE_USER)
             .parts(List.of(new TextPart("update"))) // Send the "update" command
             .taskId(taskId)
             .messageId("test-msg-2")

--- a/extras/queue-manager-replicated/core/src/test/java/io/a2a/extras/queuemanager/replicated/core/EventSerializationTest.java
+++ b/extras/queue-manager-replicated/core/src/test/java/io/a2a/extras/queuemanager/replicated/core/EventSerializationTest.java
@@ -75,7 +75,7 @@ public class EventSerializationTest {
     public void testMessageSerialization() throws JsonProcessingException {
         // Create a Message
         Message originalMessage = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(List.of(new TextPart("Hello, world!")))
                 .taskId("test-task-789")
                 .messageId("test-msg-456")

--- a/extras/queue-manager-replicated/tests-single-instance/src/test/java/io/a2a/extras/queuemanager/replicated/tests/KafkaReplicationIntegrationTest.java
+++ b/extras/queue-manager-replicated/tests-single-instance/src/test/java/io/a2a/extras/queuemanager/replicated/tests/KafkaReplicationIntegrationTest.java
@@ -136,7 +136,7 @@ public class KafkaReplicationIntegrationTest {
 
         // Send A2A message that should trigger events and replication
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(List.of(new TextPart("create")))
                 .taskId(taskId)
                 .messageId("test-msg-" + System.currentTimeMillis())
@@ -199,7 +199,7 @@ public class KafkaReplicationIntegrationTest {
 
         // First create a task in the A2A system using non-streaming client
         Message createMessage = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(List.of(new TextPart("create")))
                 .taskId(taskId)
                 .messageId("create-msg-" + System.currentTimeMillis())
@@ -319,7 +319,7 @@ public class KafkaReplicationIntegrationTest {
         // Use polling (non-blocking) client with "working" command
         // This creates task in WORKING state (non-final) and keeps queue alive
         Message workingMessage = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(List.of(new TextPart("working")))
                 .taskId(taskId)
                 .messageId("working-msg-" + System.currentTimeMillis())
@@ -414,7 +414,7 @@ public class KafkaReplicationIntegrationTest {
 
         // Create a task that will be completed (finalized)
         Message completeMessage = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(List.of(new TextPart("complete")))
                 .taskId(taskId)
                 .messageId("complete-msg-" + System.currentTimeMillis())

--- a/extras/task-store-database-jpa/src/test/java/io/a2a/extras/taskstore/database/jpa/JpaDatabaseTaskStoreIntegrationTest.java
+++ b/extras/task-store-database-jpa/src/test/java/io/a2a/extras/taskstore/database/jpa/JpaDatabaseTaskStoreIntegrationTest.java
@@ -75,7 +75,7 @@ public class JpaDatabaseTaskStoreIntegrationTest {
         // Send a message creating the Task
         assertNull(taskStore.get(taskId));
         Message userMessage = Message.builder()
-            .role(Message.Role.USER)
+            .role(Message.Role.ROLE_USER)
             .parts(Collections.singletonList(new TextPart("create")))
             .taskId(taskId)
             .messageId("test-msg-1")
@@ -104,7 +104,7 @@ public class JpaDatabaseTaskStoreIntegrationTest {
 
         // Send a message updating the Task
         userMessage = Message.builder()
-            .role(Message.Role.USER)
+            .role(Message.Role.ROLE_USER)
             .parts(Collections.singletonList(new TextPart("add-artifact")))
             .taskId(taskId)
             .messageId("test-msg-2")

--- a/extras/task-store-database-jpa/src/test/java/io/a2a/extras/taskstore/database/jpa/JpaDatabaseTaskStoreTest.java
+++ b/extras/task-store-database-jpa/src/test/java/io/a2a/extras/taskstore/database/jpa/JpaDatabaseTaskStoreTest.java
@@ -70,7 +70,7 @@ public class JpaDatabaseTaskStoreTest {
     public void testSaveAndRetrieveTaskWithHistory() {
         // Create a message for the task history
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("Hello, agent!")))
                 .messageId("msg-1")
                 .build();
@@ -601,7 +601,7 @@ public class JpaDatabaseTaskStoreTest {
         List<Message> longHistory = new ArrayList<>();
         for (int i = 1; i <= 10; i++) {
             Message message = Message.builder()
-                    .role(Message.Role.USER)
+                    .role(Message.Role.ROLE_USER)
                     .parts(Collections.singletonList(new TextPart("Message " + i)))
                     .messageId("msg-history-limit-" + i)
                     .build();

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/json/JsonUtil.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/json/JsonUtil.java
@@ -59,7 +59,6 @@ import io.a2a.spec.Task;
 import io.a2a.spec.TaskArtifactUpdateEvent;
 import io.a2a.spec.TaskNotCancelableError;
 import io.a2a.spec.TaskNotFoundError;
-import io.a2a.spec.TaskState;
 import io.a2a.spec.TaskStatusUpdateEvent;
 import io.a2a.spec.TextPart;
 import io.a2a.spec.UnsupportedOperationError;
@@ -76,7 +75,6 @@ public class JsonUtil {
                 .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
                 .registerTypeAdapter(OffsetDateTime.class, new OffsetDateTimeTypeAdapter())
                 .registerTypeHierarchyAdapter(A2AError.class, new A2AErrorTypeAdapter())
-                .registerTypeAdapter(Message.Role.class, new RoleTypeAdapter())
                 .registerTypeHierarchyAdapter(FileContent.class, new FileContentTypeAdapter());
     }
 
@@ -434,52 +432,6 @@ public class JsonUtil {
                 default ->
                     new A2AError(code, message == null ? "" : message, data);
             };
-        }
-    }
-
-    /**
-     * Gson TypeAdapter for serializing and deserializing {@link Message.Role} enum.
-     * <p>
-     * This adapter ensures that Message.Role enum values are serialized using their
-     * wire format string representation (e.g., "user", "agent") rather than the Java
-     * enum constant name (e.g., "USER", "AGENT").
-     * <p>
-     * For serialization, it uses {@link Message.Role#asString()} to get the wire format.
-     * For deserialization, it parses the string to the enum constant.
-     *
-     * @see Message.Role
-     * @see Message.Role#asString()
-     */
-    static class RoleTypeAdapter extends TypeAdapter<Message.Role> {
-
-        @Override
-        public void write(JsonWriter out, Message.Role value) throws java.io.IOException {
-            if (value == null) {
-                out.nullValue();
-            } else {
-                out.value(value.asString());
-            }
-        }
-
-        @Override
-        public Message.@Nullable Role read(JsonReader in) throws java.io.IOException {
-            if (in.peek() == com.google.gson.stream.JsonToken.NULL) {
-                in.nextNull();
-                return null;
-            }
-            String roleString = in.nextString();
-            try {
-                return switch (roleString) {
-                    case "user" ->
-                        Message.Role.USER;
-                    case "agent" ->
-                        Message.Role.AGENT;
-                    default ->
-                        throw new IllegalArgumentException("Invalid Role: " + roleString);
-                };
-            } catch (IllegalArgumentException e) {
-                throw new JsonSyntaxException("Invalid Message.Role: " + roleString, e);
-            }
         }
     }
 

--- a/jsonrpc-common/src/test/java/io/a2a/jsonrpc/common/json/StreamingEventKindSerializationTest.java
+++ b/jsonrpc-common/src/test/java/io/a2a/jsonrpc/common/json/StreamingEventKindSerializationTest.java
@@ -61,7 +61,7 @@ class StreamingEventKindSerializationTest {
     void testMessageSerialization() throws JsonProcessingException {
         // Create a Message
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(List.of(new TextPart("Hello, agent!")))
                 .taskId("task-789")
                 .messageId("msg-123")
@@ -75,7 +75,7 @@ class StreamingEventKindSerializationTest {
         assertNotNull(json);
         assertTrue(json.contains("\"message\""));
         assertTrue(json.contains("\"taskId\":\"task-789\""));
-        assertTrue(json.contains("\"role\":\"user\""));
+        assertTrue(json.contains("\"role\":\"ROLE_USER\""));
         assertTrue(json.contains("Hello, agent!"));
         assertFalse(json.contains("\"kind\""));
 
@@ -186,7 +186,7 @@ class StreamingEventKindSerializationTest {
         // Test that unwrapped Message format (direct deserialization) still works
         String json = """
             {
-              "role": "agent",
+              "role": "ROLE_AGENT",
               "parts": [
                 {
                   "text": "Unwrapped message"
@@ -205,7 +205,7 @@ class StreamingEventKindSerializationTest {
         Message message = (Message) deserialized;
         assertEquals("msg-unwrapped", message.messageId());
         assertEquals("task-999", message.taskId());
-        assertEquals(Message.Role.AGENT, message.role());
+        assertEquals(Message.Role.ROLE_AGENT, message.role());
     }
 
     @Test

--- a/jsonrpc-common/src/test/java/io/a2a/jsonrpc/common/json/TaskSerializationTest.java
+++ b/jsonrpc-common/src/test/java/io/a2a/jsonrpc/common/json/TaskSerializationTest.java
@@ -114,7 +114,7 @@ class TaskSerializationTest {
     @Test
     void testTaskWithHistory() throws JsonProcessingException {
         Message message = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(List.of(new TextPart("Test message")))
                 .build();
 
@@ -129,7 +129,7 @@ class TaskSerializationTest {
         String json = JsonUtil.toJson(task);
 
         // Verify JSON contains history data
-        assertTrue(json.contains("\"role\":\"user\""));
+        assertTrue(json.contains("\"role\":\"ROLE_USER\""));
         assertTrue(json.contains("Test message"));
 
         // Deserialize
@@ -138,7 +138,7 @@ class TaskSerializationTest {
         // Verify history is preserved
         assertNotNull(deserialized.history());
         assertEquals(1, deserialized.history().size());
-        assertEquals(Message.Role.USER, deserialized.history().get(0).role());
+        assertEquals(Message.Role.ROLE_USER, deserialized.history().get(0).role());
         assertEquals(1, deserialized.history().get(0).parts().size());
     }
 
@@ -152,11 +152,11 @@ class TaskSerializationTest {
                 .status(new TaskStatus(TaskState.TASK_STATE_WORKING, null, timestamp))
                 .history(List.of(
                         Message.builder()
-                                .role(Message.Role.USER)
+                                .role(Message.Role.ROLE_USER)
                                 .parts(List.of(new TextPart("User message")))
                                 .build(),
                         Message.builder()
-                                .role(Message.Role.AGENT)
+                                .role(Message.Role.ROLE_AGENT)
                                 .parts(List.of(new TextPart("Agent response")))
                                 .build()
                 ))
@@ -354,7 +354,7 @@ class TaskSerializationTest {
                 .status(new TaskStatus(TaskState.TASK_STATE_WORKING, null, timestamp))
                 .history(List.of(
                         Message.builder()
-                                .role(Message.Role.USER)
+                                .role(Message.Role.ROLE_USER)
                                 .parts(List.of(
                                         new TextPart("Text"),
                                         new FilePart(new FileWithBytes("text/plain", "file.txt", "data")),
@@ -394,7 +394,7 @@ class TaskSerializationTest {
     @Test
     void testTaskStatusWithMessage() throws JsonProcessingException {
         Message statusMessage = Message.builder()
-                .role(Message.Role.AGENT)
+                .role(Message.Role.ROLE_AGENT)
                 .parts(List.of(new TextPart("Processing complete")))
                 .build();
 
@@ -417,7 +417,7 @@ class TaskSerializationTest {
         // Verify status message is preserved
         assertEquals(TaskState.TASK_STATE_COMPLETED, deserialized.status().state());
         assertNotNull(deserialized.status().message());
-        assertEquals(Message.Role.AGENT, deserialized.status().message().role());
+        assertEquals(Message.Role.ROLE_AGENT, deserialized.status().message().role());
         assertTrue(deserialized.status().message().parts().get(0) instanceof TextPart);
     }
 
@@ -602,7 +602,7 @@ class TaskSerializationTest {
               },
               "history": [
                 {
-                  "role": "user",
+                  "role": "ROLE_USER",
                   "parts": [
                     {
                       "text": "User message"
@@ -611,7 +611,7 @@ class TaskSerializationTest {
                   "messageId": "msg-1"
                 },
                 {
-                  "role": "agent",
+                  "role": "ROLE_AGENT",
                   "parts": [
                     {
                       "text": "Agent response"
@@ -627,8 +627,8 @@ class TaskSerializationTest {
 
         assertEquals("task-123", task.id());
         assertEquals(2, task.history().size());
-        assertEquals(Message.Role.USER, task.history().get(0).role());
-        assertEquals(Message.Role.AGENT, task.history().get(1).role());
+        assertEquals(Message.Role.ROLE_USER, task.history().get(0).role());
+        assertEquals(Message.Role.ROLE_AGENT, task.history().get(1).role());
         assertTrue(task.history().get(0).parts().get(0) instanceof TextPart);
         assertEquals("User message", ((TextPart) task.history().get(0).parts().get(0)).text());
     }

--- a/server-common/src/main/java/io/a2a/server/tasks/AgentEmitter.java
+++ b/server-common/src/main/java/io/a2a/server/tasks/AgentEmitter.java
@@ -443,7 +443,7 @@ public class AgentEmitter {
      */
     public Message newAgentMessage(List<Part<?>> parts, @Nullable Map<String, Object> metadata) {
         return Message.builder()
-                .role(Message.Role.AGENT)
+                .role(Message.Role.ROLE_AGENT)
                 .taskId(taskId)
                 .contextId(contextId)
                 .messageId(UUID.randomUUID().toString())
@@ -614,7 +614,7 @@ public class AgentEmitter {
     public Message.Builder messageBuilder() {
         Message.Builder builder = Message.builder()
                 .contextId(contextId)
-                .role(Message.Role.AGENT)
+                .role(Message.Role.ROLE_AGENT)
                 .messageId(UUID.randomUUID().toString());
 
         // Only set taskId if present (messages can exist without tasks)

--- a/server-common/src/test/java/io/a2a/server/agentexecution/RequestContextTest.java
+++ b/server-common/src/test/java/io/a2a/server/agentexecution/RequestContextTest.java
@@ -46,7 +46,7 @@ public class RequestContextTest {
 
     @Test
     public void testInitWithParamsNoIds() {
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
 
         UUID taskId = UUID.fromString("00000000-0000-0000-0000-000000000001");
@@ -73,7 +73,7 @@ public class RequestContextTest {
     @Test
     public void testInitWithTaskId() {
         String taskId = "task-123";
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).taskId(taskId).build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).taskId(taskId).build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
 
         RequestContext context = new RequestContext.Builder()
@@ -88,7 +88,7 @@ public class RequestContextTest {
     @Test
     public void testInitWithContextId() {
         String contextId = "context-456";
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).contextId(contextId).build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).contextId(contextId).build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
 
         RequestContext context = new RequestContext.Builder()
@@ -104,7 +104,7 @@ public class RequestContextTest {
     public void testInitWithBothIds() {
         String taskId = "task-123";
         String contextId = "context-456";
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).taskId(taskId).contextId(contextId).build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).taskId(taskId).contextId(contextId).build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
 
         RequestContext context = new RequestContext.Builder()
@@ -121,7 +121,7 @@ public class RequestContextTest {
 
     @Test
     public void testInitWithTask() {
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).build();
         var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.TASK_STATE_COMPLETED)).build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
 
@@ -159,7 +159,7 @@ public class RequestContextTest {
     @Test
     public void testCheckOrGenerateTaskIdWithExistingTaskId() {
         String existingId = "existing-task-id";
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).taskId(existingId).build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).taskId(existingId).build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
 
         RequestContext context = new RequestContext.Builder()
@@ -174,7 +174,7 @@ public class RequestContextTest {
     public void testCheckOrGenerateContextIdWithExistingContextId() {
         String existingId = "existing-context-id";
 
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).contextId(existingId).build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).contextId(existingId).build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
 
         RequestContext context = new RequestContext.Builder()
@@ -187,7 +187,7 @@ public class RequestContextTest {
 
     @Test
     public void testInitRaisesErrorOnTaskIdMismatch() {
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).taskId("task-123").build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).taskId("task-123").build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
         var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.TASK_STATE_COMPLETED)).build();
 
@@ -203,7 +203,7 @@ public class RequestContextTest {
 
     @Test
     public void testInitRaisesErrorOnContextIdMismatch() {
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).taskId("task-123").contextId("context-456").build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).taskId("task-123").contextId("context-456").build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
         var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.TASK_STATE_COMPLETED)).build();
 
@@ -242,7 +242,7 @@ public class RequestContextTest {
 
     @Test
     public void testMessagePropertyWithParams() {
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
 
         RequestContext context = new RequestContext.Builder()
@@ -260,7 +260,7 @@ public class RequestContextTest {
         String existingTaskId = "existing-task-id";
         String existingContextId = "existing-context-id";
 
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart("")))
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart("")))
                 .taskId(existingTaskId).contextId(existingContextId).build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
 
@@ -274,7 +274,7 @@ public class RequestContextTest {
 
     @Test
     public void testInitWithTaskIdAndExistingTaskIdMatch() {
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).taskId("task-123").contextId("context-456").build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).taskId("task-123").contextId("context-456").build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
         var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.TASK_STATE_COMPLETED)).build();
 
@@ -290,7 +290,7 @@ public class RequestContextTest {
 
     @Test
     public void testInitWithContextIdAndExistingContextIdMatch() {
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).taskId("task-123").contextId("context-456").build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).taskId("task-123").contextId("context-456").build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
         var mockTask = Task.builder().id("task-123").contextId("context-456").status(new TaskStatus(TaskState.TASK_STATE_COMPLETED)).build();
 
@@ -307,7 +307,7 @@ public class RequestContextTest {
 
     @Test
     void testMessageBuilderGeneratesId() {
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
 
         RequestContext context = new RequestContext.Builder()
@@ -320,7 +320,7 @@ public class RequestContextTest {
 
     @Test
     void testMessageBuilderUsesProvidedId() {
-        var mockMessage = Message.builder().messageId("123").role(Message.Role.USER).parts(List.of(new TextPart(""))).build();
+        var mockMessage = Message.builder().messageId("123").role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
 
         RequestContext context = new RequestContext.Builder()
@@ -362,7 +362,7 @@ public class RequestContextTest {
         String builderContextId = "builder-context-id";
 
         // Message has no IDs, but builder provides them
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).build();
         var mockParams = MessageSendParams.builder().message(mockMessage).configuration(defaultConfiguration()).build();
 
         RequestContext context = new RequestContext.Builder()
@@ -385,7 +385,7 @@ public class RequestContextTest {
         String sharedContextId = "shared-context-id";
 
         var mockMessage = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(List.of(new TextPart("")))
                 .taskId(sharedTaskId)
                 .contextId(sharedContextId)
@@ -410,7 +410,7 @@ public class RequestContextTest {
         String tenantId = "customer-123";
         String builderTaskId = "builder-task-id";
 
-        var mockMessage = Message.builder().role(Message.Role.USER).parts(List.of(new TextPart(""))).build();
+        var mockMessage = Message.builder().role(Message.Role.ROLE_USER).parts(List.of(new TextPart(""))).build();
         var mockParams = MessageSendParams.builder()
                 .message(mockMessage)
                 .configuration(defaultConfiguration())

--- a/server-common/src/test/java/io/a2a/server/events/EventConsumerTest.java
+++ b/server-common/src/test/java/io/a2a/server/events/EventConsumerTest.java
@@ -53,7 +53,7 @@ public class EventConsumerTest {
 
     private static final String MESSAGE_PAYLOAD = """
             {
-                "role": "agent",
+                "role": "ROLE_AGENT",
                 "parts": [{"text": "test message"}],
                 "messageId": "111"
             }

--- a/server-common/src/test/java/io/a2a/server/events/EventQueueTest.java
+++ b/server-common/src/test/java/io/a2a/server/events/EventQueueTest.java
@@ -49,7 +49,7 @@ public class EventQueueTest {
 
     private static final String MESSAGE_PAYLOAD = """
             {
-                "role": "agent",
+                "role": "ROLE_AGENT",
                 "parts": [{"text": "test message"}],
                 "messageId": "111"
             }

--- a/server-common/src/test/java/io/a2a/server/requesthandlers/AbstractA2ARequestHandlerTest.java
+++ b/server-common/src/test/java/io/a2a/server/requesthandlers/AbstractA2ARequestHandlerTest.java
@@ -63,7 +63,7 @@ public class AbstractA2ARequestHandlerTest {
 
     protected static final Message MESSAGE = Message.builder()
             .messageId("111")
-            .role(Message.Role.AGENT)
+            .role(Message.Role.ROLE_AGENT)
             .parts(new TextPart("test message"))
             .build();
     private static final String PREFERRED_TRANSPORT = "preferred-transport";

--- a/server-common/src/test/java/io/a2a/server/tasks/AgentEmitterTest.java
+++ b/server-common/src/test/java/io/a2a/server/tasks/AgentEmitterTest.java
@@ -1,6 +1,6 @@
 package io.a2a.server.tasks;
 
-import static io.a2a.spec.Message.Role.AGENT;
+import static io.a2a.spec.Message.Role.ROLE_AGENT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -38,7 +38,7 @@ public class AgentEmitterTest {
             .taskId(TEST_TASK_ID)
             .contextId(TEST_TASK_CONTEXT_ID)
             .parts(new TextPart("Test message"))
-            .role(AGENT)
+            .role(ROLE_AGENT)
             .build();
 
     private static final List<Part<?>> SAMPLE_PARTS = List.of(new TextPart("Test message"));
@@ -243,7 +243,7 @@ public class AgentEmitterTest {
     public void testNewAgentMessage() throws Exception {
         Message message = agentEmitter.newAgentMessage(SAMPLE_PARTS, null);
 
-        assertEquals(AGENT, message.role());
+        assertEquals(ROLE_AGENT, message.role());
         assertEquals(TEST_TASK_ID, message.taskId());
         assertEquals(TEST_TASK_CONTEXT_ID, message.contextId());
         assertNotNull(message.messageId());
@@ -256,7 +256,7 @@ public class AgentEmitterTest {
         Map<String, Object> metadata = Map.of("key", "value");
         Message message = agentEmitter.newAgentMessage(SAMPLE_PARTS, metadata);
 
-        assertEquals(AGENT, message.role());
+        assertEquals(ROLE_AGENT, message.role());
         assertEquals(TEST_TASK_ID, message.taskId());
         assertEquals(TEST_TASK_CONTEXT_ID, message.contextId());
         assertNotNull(message.messageId());

--- a/server-common/src/test/java/io/a2a/server/tasks/PushNotificationSenderTest.java
+++ b/server-common/src/test/java/io/a2a/server/tasks/PushNotificationSenderTest.java
@@ -349,7 +349,7 @@ public class PushNotificationSenderTest {
         String taskId = "task_send_message";
         Message message = Message.builder()
                 .taskId(taskId)
-                .role(Message.Role.AGENT)
+                .role(Message.Role.ROLE_AGENT)
                 .parts(new TextPart("Hello from agent"))
                 .build();
         PushNotificationConfig config = createSamplePushConfig("http://notify.me/here", "cfg1", null);

--- a/server-common/src/test/java/io/a2a/server/tasks/ResultAggregatorTest.java
+++ b/server-common/src/test/java/io/a2a/server/tasks/ResultAggregatorTest.java
@@ -112,7 +112,7 @@ public class ResultAggregatorTest {
 
     @Test
     void testConstructorWithMessage() {
-        Message initialMessage = createSampleMessage("initial", "msg1", Message.Role.USER);
+        Message initialMessage = createSampleMessage("initial", "msg1", Message.Role.ROLE_USER);
         ResultAggregator aggregatorWithMessage = new ResultAggregator(mockTaskManager, initialMessage, testExecutor, testExecutor);
 
         // Test that the message is properly stored by checking getCurrentResult
@@ -123,7 +123,7 @@ public class ResultAggregatorTest {
 
     @Test
     void testGetCurrentResultWithMessageSet() {
-        Message sampleMessage = createSampleMessage("hola", "msg1", Message.Role.USER);
+        Message sampleMessage = createSampleMessage("hola", "msg1", Message.Role.ROLE_USER);
         ResultAggregator aggregatorWithMessage = new ResultAggregator(mockTaskManager, sampleMessage, testExecutor, testExecutor);
 
         EventKind result = aggregatorWithMessage.getCurrentResult();
@@ -218,7 +218,7 @@ public class ResultAggregatorTest {
     @Test
     void testGetCurrentResultWithMessageTakesPrecedence() {
         // Test that when both message and task are available, message takes precedence
-        Message message = createSampleMessage("priority message", "pri1", Message.Role.USER);
+        Message message = createSampleMessage("priority message", "pri1", Message.Role.ROLE_USER);
         ResultAggregator messageAggregator = new ResultAggregator(mockTaskManager, message, testExecutor, testExecutor);
 
         // Even if we set up the task manager to return something, message should take precedence

--- a/server-common/src/test/java/io/a2a/server/tasks/TaskManagerTest.java
+++ b/server-common/src/test/java/io/a2a/server/tasks/TaskManagerTest.java
@@ -75,7 +75,7 @@ public class TaskManagerTest {
         TaskStatus newStatus = new TaskStatus(
                 TaskState.TASK_STATE_WORKING,
                 Message.builder()
-                        .role(Message.Role.AGENT)
+                        .role(Message.Role.ROLE_AGENT)
                         .parts(Collections.singletonList(new TextPart("content")))
                         .messageId("messageId")
                         .build(),
@@ -385,7 +385,7 @@ public class TaskManagerTest {
         // Test that adding a task with no message, and there is a TaskManager.initialMessage, 
         // the initialMessage gets used
         Message initialMessage = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("initial message")))
                 .messageId("initial-msg-id")
                 .build();
@@ -416,7 +416,7 @@ public class TaskManagerTest {
     public void testTaskWithMessageDoesNotUseInitialMessage() throws A2AServerException {
         // Test that adding a task with a message does not use the initial message
         Message initialMessage = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("initial message")))
                 .messageId("initial-msg-id")
                 .build();
@@ -424,7 +424,7 @@ public class TaskManagerTest {
         TaskManager taskManagerWithInitialMessage = new TaskManager(null, null, taskStore, initialMessage);
         
         Message taskMessage = Message.builder()
-                .role(Message.Role.AGENT)
+                .role(Message.Role.ROLE_AGENT)
                 .parts(Collections.singletonList(new TextPart("task message")))
                 .messageId("task-msg-id")
                 .build();
@@ -625,7 +625,7 @@ public class TaskManagerTest {
     public void testCreateTaskWithInitialMessage() throws A2AServerException {
         // Test equivalent of _init_task_obj functionality
         Message initialMessage = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("initial message")))
                 .messageId("initial-msg-id")
                 .build();
@@ -702,7 +702,7 @@ public class TaskManagerTest {
     @Test
     public void testUpdateWithMessage() throws A2AServerException {
         Message initialMessage = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("initial message")))
                 .messageId("initial-msg-id")
                 .build();
@@ -710,7 +710,7 @@ public class TaskManagerTest {
         TaskManager taskManagerWithInitialMessage = new TaskManager(null, null, taskStore, initialMessage);
 
         Message taskMessage = Message.builder()
-                .role(Message.Role.AGENT)
+                .role(Message.Role.ROLE_AGENT)
                 .parts(Collections.singletonList(new TextPart("task message")))
                 .messageId("task-msg-id")
                 .build();
@@ -725,7 +725,7 @@ public class TaskManagerTest {
         Task saved = taskManagerWithInitialMessage.getTask();
 
         Message updateMessage = Message.builder()
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("update message")))
                 .messageId("update-msg-id")
                 .build();

--- a/spec-grpc/src/main/java/io/a2a/grpc/mapper/RoleMapper.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/mapper/RoleMapper.java
@@ -1,5 +1,6 @@
 package io.a2a.grpc.mapper;
 
+import io.a2a.grpc.Role;
 import io.a2a.spec.Message;
 import org.mapstruct.Mapper;
 
@@ -8,8 +9,9 @@ import org.mapstruct.Mapper;
  * <p>
  * Handles enum conversion between domain and protobuf role representations:
  * <ul>
- *   <li>USER (domain) ↔ ROLE_USER (proto)</li>
- *   <li>AGENT (domain) ↔ ROLE_AGENT (proto)</li>
+ *   <li>ROLE_USER (domain) ↔ ROLE_USER (proto)</li>
+ *   <li>ROLE_AGENT (domain) ↔ ROLE_AGENT (proto)</li>
+ *   <li>ROLE_UNSPECIFIED (domain) ↔ ROLE_UNSPECIFIED (proto)</li>
  * </ul>
  * <p>
  * <b>Manual Implementation Required:</b> Uses manual switch statements instead of @ValueMapping
@@ -22,31 +24,29 @@ public interface RoleMapper {
 
     /**
      * Converts domain Role to proto Role.
-     * Maps USER → ROLE_USER, AGENT → ROLE_AGENT.
      */
     default io.a2a.grpc.Role toProto(Message.Role domain) {
         if (domain == null) {
             return io.a2a.grpc.Role.ROLE_UNSPECIFIED;
         }
         return switch (domain) {
-            case USER -> io.a2a.grpc.Role.ROLE_USER;
-            case AGENT -> io.a2a.grpc.Role.ROLE_AGENT;
+            case ROLE_USER -> io.a2a.grpc.Role.ROLE_USER;
+            case ROLE_AGENT -> io.a2a.grpc.Role.ROLE_AGENT;
+            case ROLE_UNSPECIFIED -> Role.ROLE_UNSPECIFIED;
         };
     }
 
     /**
      * Converts proto Role to domain Role.
-     * Maps ROLE_USER → USER, ROLE_AGENT → AGENT.
-     * ROLE_UNSPECIFIED returns null.
      */
     default Message.Role fromProto(io.a2a.grpc.Role proto) {
         if (proto == null || proto == io.a2a.grpc.Role.ROLE_UNSPECIFIED) {
             return null;
         }
         return switch (proto) {
-            case ROLE_USER -> Message.Role.USER;
-            case ROLE_AGENT -> Message.Role.AGENT;
-            default -> null;
+            case ROLE_USER -> Message.Role.ROLE_USER;
+            case ROLE_AGENT -> Message.Role.ROLE_AGENT;
+            default -> Message.Role.ROLE_UNSPECIFIED;
         };
     }
 }

--- a/spec-grpc/src/test/java/io/a2a/grpc/mapper/StreamResponseMapperTest.java
+++ b/spec-grpc/src/test/java/io/a2a/grpc/mapper/StreamResponseMapperTest.java
@@ -71,7 +71,7 @@ public class StreamResponseMapperTest {
         Message message = Message.builder()
                 .messageId("msg-123")
                 .contextId("context-456")
-                .role(Message.Role.USER)
+                .role(Message.Role.ROLE_USER)
                 .parts(Collections.singletonList(new TextPart("Hello")))
                 .build();
 
@@ -109,7 +109,7 @@ public class StreamResponseMapperTest {
         Message message = (Message) result;
         assertEquals("msg-123", message.messageId());
         assertEquals("context-456", message.contextId());
-        assertEquals(Message.Role.USER, message.role());
+        assertEquals(Message.Role.ROLE_USER, message.role());
     }
 
     @Test
@@ -253,7 +253,7 @@ public class StreamResponseMapperTest {
         Message originalMessage = Message.builder()
                 .messageId("msg-123")
                 .contextId("context-456")
-                .role(Message.Role.AGENT)
+                .role(Message.Role.ROLE_AGENT)
                 .parts(Collections.singletonList(new TextPart("Response")))
                 .build();
 

--- a/spec-grpc/src/test/java/io/a2a/grpc/utils/JSONRPCUtilsTest.java
+++ b/spec-grpc/src/test/java/io/a2a/grpc/utils/JSONRPCUtilsTest.java
@@ -10,6 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.gson.JsonSyntaxException;
+
+import io.a2a.grpc.Role;
 import io.a2a.jsonrpc.common.json.InvalidParamsJsonMappingException;
 import io.a2a.jsonrpc.common.json.JsonMappingException;
 import io.a2a.jsonrpc.common.json.JsonProcessingException;
@@ -18,8 +20,10 @@ import io.a2a.jsonrpc.common.wrappers.GetTaskPushNotificationConfigRequest;
 import io.a2a.jsonrpc.common.wrappers.GetTaskPushNotificationConfigResponse;
 import io.a2a.jsonrpc.common.wrappers.CreateTaskPushNotificationConfigRequest;
 import io.a2a.jsonrpc.common.wrappers.CreateTaskPushNotificationConfigResponse;
+import io.a2a.jsonrpc.common.wrappers.SendMessageRequest;
 import io.a2a.spec.InvalidParamsError;
 import io.a2a.spec.JSONParseError;
+import io.a2a.spec.Message;
 import io.a2a.spec.PushNotificationConfig;
 import io.a2a.spec.TaskPushNotificationConfig;
 import org.junit.jupiter.api.Test;
@@ -203,11 +207,12 @@ public class JSONRPCUtilsTest {
               }
             }""";
         InvalidParamsJsonMappingException exception = assertThrows(
-            InvalidParamsJsonMappingException.class,
-            () -> JSONRPCUtils.parseRequestBody(missingRoleMessage, null)
+                InvalidParamsJsonMappingException.class,
+                () -> JSONRPCUtils.parseRequestBody(missingRoleMessage, null)
         );
         assertEquals(18, exception.getId());
     }
+
     @Test
     public void testParseUnknownField_ThrowsJsonMappingException() throws JsonMappingException {
         String unkownFieldMessage=  """

--- a/spec-grpc/src/test/java/io/a2a/grpc/utils/ToProtoTest.java
+++ b/spec-grpc/src/test/java/io/a2a/grpc/utils/ToProtoTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 public class ToProtoTest {
 
     private static final Message SIMPLE_MESSAGE = Message.builder()
-            .role(Message.Role.USER)
+            .role(Message.Role.ROLE_USER)
             .parts(Collections.singletonList(new TextPart("tell me a joke")))
             .contextId("context-1234")
             .messageId("message-1234")
@@ -188,7 +188,7 @@ public class ToProtoTest {
         assertEquals(false, result.getParts(0).hasUrl());
         assertEquals(false, result.getParts(0).hasData());
         Message message = Message.builder()
-                .role(Message.Role.AGENT)
+                .role(Message.Role.ROLE_AGENT)
                 .parts(Collections.singletonList(new TextPart("tell me a joke")))
                 .messageId("message-1234")
                 .build();

--- a/spec/src/main/java/io/a2a/spec/Message.java
+++ b/spec/src/main/java/io/a2a/spec/Message.java
@@ -35,14 +35,12 @@ import org.jspecify.annotations.Nullable;
  * @see <a href="https://a2a-protocol.org/latest/">A2A Protocol Specification</a>
  */
 public record Message(Role role, List<Part<?>> parts,
-        String messageId, @Nullable
-        String contextId,
-        @Nullable
-        String taskId, @Nullable
-        List<String> referenceTaskIds,
-        @Nullable
-        Map<String, Object> metadata, @Nullable
-        List<String> extensions
+        String messageId,
+        @Nullable String contextId,
+        @Nullable String taskId,
+        @Nullable List<String> referenceTaskIds,
+        @Nullable Map<String, Object> metadata,
+        @Nullable List<String> extensions
         ) implements EventKind, StreamingEventKind {
 
     /**
@@ -110,26 +108,15 @@ public record Message(Role role, List<Part<?>> parts,
         /**
          * Message originated from the user (client side).
          */
-        USER("user"),
+        ROLE_USER,
         /**
          * Message originated from the agent (server side).
          */
-        AGENT("agent");
-
-        private final String role;
-
-        Role(String role) {
-            this.role = role;
-        }
-
+        ROLE_AGENT,
         /**
-         * Returns the string representation of the role for JSON serialization.
-         *
-         * @return the role as a string ("user" or "agent")
+         * Unspecified role.
          */
-        public String asString() {
-            return this.role;
-        }
+        ROLE_UNSPECIFIED;
     }
 
     /**

--- a/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
@@ -120,7 +120,7 @@ public abstract class AbstractA2AServerTest {
 
     protected static final Message MESSAGE = Message.builder()
             .messageId("111")
-            .role(Message.Role.AGENT)
+            .role(Message.Role.ROLE_AGENT)
             .parts(new TextPart("test message"))
             .build();
     public static final String APPLICATION_JSON = "application/json";

--- a/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -831,7 +831,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
         Message message = Message.builder()
                 .taskId(MINIMAL_TASK.id())
                 .contextId(MINIMAL_TASK.contextId())
-                .role(Message.Role.AGENT)
+                .role(Message.Role.ROLE_AGENT)
                 .parts(new TextPart("text"))
                 .build();
         SendMessageResponse smr


### PR DESCRIPTION
Align the enum values with the protobuf definition to simplify the serialiazition. Remove the string representation to rely directly on the enum textual serialization.

Remove the nullabitily of the Message role fied. If not present, it will be mapped to the ROLE_UNSPECIFIED. Remove the RoleTypeAdapter as the GSON serialization is handled automatically from the enum.

This fixes #661