### PR TITLE
fix: use SERVER_URL constant in A2ACardResolver constructor in HelloWorldClient #664

### DIFF
--- a/examples/helloworld/client/src/main/java/io/a2a/examples/helloworld/HelloWorldClient.java
+++ b/examples/helloworld/client/src/main/java/io/a2a/examples/helloworld/HelloWorldClient.java
@@ -53,7 +53,7 @@ public class HelloWorldClient {
     public static void main(String[] args) {
         OpenTelemetrySdk openTelemetrySdk = null;
         try {
-            AgentCard publicAgentCard = new A2ACardResolver("http://localhost:9999").getAgentCard();
+            AgentCard publicAgentCard = new A2ACardResolver(SERVER_URL).getAgentCard();
             System.out.println("Successfully fetched public agent card:");
             System.out.println(JsonUtil.toJson(publicAgentCard));
             System.out.println("Using public agent card for client initialization (default).");


### PR DESCRIPTION
## Description

Replace the hardcoded string literal `"http://localhost:9999"` with the existing `SERVER_URL` constant in the `A2ACardResolver` constructor call inside `HelloWorldClient`.

Fixes #664 🦕