### PR TITLE
fix!: Remove includingDefaultValueFields() from JsonFormat.printer() in JSONRPCUtils

### DIFF
--- a/spec-grpc/src/main/java/io/a2a/grpc/utils/JSONRPCUtils.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/utils/JSONRPCUtils.java
@@ -576,7 +576,7 @@ public class JSONRPCUtils {
                 output.name("method").value(method);
             }
             if (payload != null) {
-                String resultValue = JsonFormat.printer().includingDefaultValueFields().omittingInsignificantWhitespace().print(payload);
+                String resultValue = JsonFormat.printer().omittingInsignificantWhitespace().print(payload);
                 output.name("params").jsonValue(resultValue);
             }
             output.endObject();
@@ -599,7 +599,7 @@ public class JSONRPCUtils {
                     output.name("id").value(number.longValue());
                 }
             }
-            String resultValue = JsonFormat.printer().includingDefaultValueFields().omittingInsignificantWhitespace().print(builder);
+            String resultValue = JsonFormat.printer().omittingInsignificantWhitespace().print(builder);
             output.name("result").jsonValue(resultValue);
             output.endObject();
             return result.toString();


### PR DESCRIPTION
# Description

Remove the `includingDefaultValueFields()` call from `JsonFormat.printer()` in `toJsonRPCRequest` and `toJsonRPCResultResponse` methods to prevent unset protobuf fields (e.g. `filename`, `mediaType`, `metadata`) from being emitted as default values in the serialized JSON output.

Add tests to verify that a `TextPart` with no metadata serializes with only the `text` field present, and that optional fields such as `filename`, `mediaType`, and `metadata` are excluded when not explicitly set.

Fixes #689