### PR TITLE
fix!: Make tenant optional in MessageSendParams

### DIFF
--- a/spec/src/main/java/io/a2a/spec/MessageSendParams.java
+++ b/spec/src/main/java/io/a2a/spec/MessageSendParams.java
@@ -17,29 +17,25 @@ import org.jspecify.annotations.Nullable;
  * @param message the message to send to the agent (required)
  * @param configuration optional configuration for message processing behavior
  * @param metadata optional arbitrary key-value metadata for the request
- * @param tenant optional tenant, provided as a path parameter.
+ * @param tenant optional tenant identifier provided as a path parameter; defaults to empty string if not specified
  * @see MessageSendConfiguration for available configuration options
  * @see <a href="https://a2a-protocol.org/latest/">A2A Protocol Specification</a>
  */
 public record MessageSendParams(Message message, @Nullable MessageSendConfiguration configuration,
-                                @Nullable Map<String, Object> metadata, String tenant) {
+                                @Nullable Map<String, Object> metadata, @Nullable String tenant) {
 
     /**
-     * Compact constructor for validation.
-     * Validates that required parameters are not null.
-     *
-     * @param message the message to send
-     * @param configuration optional message send configuration
-     * @param metadata optional metadata
-     * @param tenant the tenant identifier
+     * Compact constructor for validation and normalization.
+     * Validates that {@code message} is not null and normalizes
+     * {@code tenant} to an empty string if null.
      */
     public MessageSendParams {
         Assert.checkNotNullParam("message", message);
-        Assert.checkNotNullParam("tenant", tenant);
+        tenant = tenant == null ? "" : tenant;
     }
 
     /**
-     * Convenience constructor with default tenant.
+     * Convenience constructor that sets tenant to empty string by default.
      *
      * @param message the message to send (required)
      * @param configuration optional configuration for message processing
@@ -50,9 +46,9 @@ public record MessageSendParams(Message message, @Nullable MessageSendConfigurat
     }
 
     /**
-     * Create a new Builder
+     * Creates a new {@link Builder} for constructing {@link MessageSendParams}.
      *
-     * @return the builder
+     * @return a new builder instance
      */
     public static Builder builder() {
         return new Builder();
@@ -112,10 +108,10 @@ public record MessageSendParams(Message message, @Nullable MessageSendConfigurat
         /**
          * Sets optional tenant for the request.
          *
-         * @param tenant arbitrary key-value metadata
+         * @param tenant optional tenant identifier
          * @return this builder
          */
-        public Builder tenant(String tenant) {
+        public Builder tenant(@Nullable String tenant) {
             this.tenant = tenant;
             return this;
         }
@@ -131,7 +127,7 @@ public record MessageSendParams(Message message, @Nullable MessageSendConfigurat
                     Assert.checkNotNullParam("message", message),
                     configuration,
                     metadata,
-                    tenant == null ? "" : tenant);
+                    tenant);
         }
     }
 }


### PR DESCRIPTION
# Description

The `tenant` field in `MessageSendParams` was previously required and validated as non-null in the compact constructor, which forced callers to always provide a tenant even when it is not applicable.

This change makes `tenant` truly optional:
- Remove `Assert.checkNotNullParam("tenant", tenant)` from the compact
  constructor so that null values are accepted at construction time
- Annotate the `tenant` record component with `@Nullable` to clearly
  signal that null may be passed by callers
- Normalize null tenant to an empty string in the compact constructor,
  which is the single point of normalization for all construction paths
- Update `Builder.tenant()` to accept a `@Nullable String` so that
  callers can explicitly pass null without a type violation
- Simplify `Builder.build()` to pass `tenant` directly, delegating
  normalization to the compact constructor

Javadoc is updated across the class to accurately reflect the optional nature, default value, and normalization behavior of `tenant`.

Fixes: #693
