### PR TITLE
fix: Use Kafka 4.2.0 for Kubernetes example

### DIFF
--- a/.github/workflows/cloud-deployment-example.yml
+++ b/.github/workflows/cloud-deployment-example.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Kind
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
           kind version

--- a/examples/cloud-deployment/k8s/02-kafka.yaml
+++ b/examples/cloud-deployment/k8s/02-kafka.yaml
@@ -33,8 +33,8 @@ metadata:
     strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 4.0.0
-    metadataVersion: 4.0-IV0
+    version: 4.2.0
+    metadataVersion: 4.2-IV0
     listeners:
       - name: plain
         port: 9092

--- a/examples/cloud-deployment/scripts/deploy.sh
+++ b/examples/cloud-deployment/scripts/deploy.sh
@@ -177,12 +177,13 @@ if ! kubectl get namespace kafka > /dev/null 2>&1; then
 fi
 
 if ! kubectl get crd kafkas.kafka.strimzi.io > /dev/null 2>&1; then
-    echo "Installing Strimzi operator... at https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.50.1/strimzi-cluster-operator-0.50.1.yaml"
-    curl -sL 'https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.50.1/strimzi-cluster-operator-0.50.1.yaml' \
-        | sed 's/namespace: .*/namespace: kafka/' \
-        | kubectl apply -f - -n kafka
-#    echo "Installing Strimzi operator..."
-#    kubectl create -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka
+# Keep this around in case we need to hardcode operator version again in the future
+#    echo "Installing Strimzi operator... at https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.50.1/strimzi-cluster-operator-0.50.1.yaml"
+#    curl -sL 'https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.50.1/strimzi-cluster-operator-0.50.1.yaml' \
+#        | sed 's/namespace: .*/namespace: kafka/' \
+#        | kubectl apply -f - -n kafka
+    echo "Installing Strimzi operator..."
+    kubectl create -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka
 
     echo "Waiting for Strimzi operator deployment to be created..."
     for i in {1..30}; do


### PR DESCRIPTION
Partially revert fb06d43b34b252ecd8df5c264e548f3eefb6edfd / #710, since now we can use https://strimzi.io/install/latest?namespace=kafka again
