### PR TITLE
fix: Use case-insensitive matching for A2A headers in gRPC transport

### DIFF
--- a/client/transport/grpc/src/main/java/io/a2a/client/transport/grpc/GrpcTransport.java
+++ b/client/transport/grpc/src/main/java/io/a2a/client/transport/grpc/GrpcTransport.java
@@ -390,16 +390,17 @@ public class GrpcTransport implements ClientTransport {
         Metadata metadata = new Metadata();
 
         if (context != null && context.getHeaders() != null) {
-            // Set a2a-version header if present
-            String versionHeader = context.getHeaders().get(A2AHeaders.A2A_VERSION.toLowerCase());
-            if (versionHeader != null) {
-                metadata.put(VERSION_KEY, versionHeader);
-            }
-
-            // Set a2a-extensions header if present
-            String extensionsHeader = context.getHeaders().get(A2AHeaders.A2A_EXTENSIONS.toLowerCase());
-            if (extensionsHeader != null) {
-                metadata.put(EXTENSIONS_KEY, extensionsHeader);
+            // Set a2a-version and a2a-extensions headers if present, ignoring case
+            for (Map.Entry<String, String> header : context.getHeaders().entrySet()) {
+                if (A2AHeaders.A2A_VERSION.equalsIgnoreCase(header.getKey())) {
+                    if (header.getValue() != null) {
+                        metadata.put(VERSION_KEY, header.getValue());
+                    }
+                } else if (A2AHeaders.A2A_EXTENSIONS.equalsIgnoreCase(header.getKey())) {
+                    if (header.getValue() != null) {
+                        metadata.put(EXTENSIONS_KEY, header.getValue());
+                    }
+                }
             }
 
             // Add other headers as needed in the future


### PR DESCRIPTION
Follow-up to #709. Use equalsIgnoreCase when matching A2A headers instead of toLowerCase() key lookups.
