### PR TITLE
fix!: Rename `blocking` to `returnImmediately` in SendMessageConfiguration

### DIFF
--- a/client/base/src/main/java/io/a2a/client/Client.java
+++ b/client/base/src/main/java/io/a2a/client/Client.java
@@ -696,7 +696,7 @@ public class Client extends AbstractClient {
     private MessageSendConfiguration createMessageSendConfiguration(@Nullable TaskPushNotificationConfig taskPushNotificationConfig) {
         return MessageSendConfiguration.builder()
                 .acceptedOutputModes(clientConfig.getAcceptedOutputModes())
-                .blocking(!clientConfig.isPolling())
+                .returnImmediately(clientConfig.isPolling())
                 .historyLength(clientConfig.getHistoryLength())
                 .taskPushNotificationConfig(taskPushNotificationConfig)
                 .build();

--- a/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportStreamingTest.java
+++ b/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportStreamingTest.java
@@ -62,7 +62,7 @@ public class JSONRPCTransportStreamingTest {
 
         MessageSendConfiguration configuration = MessageSendConfiguration.builder()
                 .acceptedOutputModes(List.of("text"))
-                .blocking(false)
+                .returnImmediately(true)
                 .build();
 
         MessageSendParams params = MessageSendParams.builder()
@@ -102,7 +102,7 @@ public class JSONRPCTransportStreamingTest {
                 .build();
         MessageSendConfiguration configuration = MessageSendConfiguration.builder()
                 .acceptedOutputModes(List.of("text"))
-                .blocking(false)
+                .returnImmediately(true)
                 .build();
         MessageSendParams params = MessageSendParams.builder()
                 .message(message)

--- a/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportTest.java
+++ b/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JSONRPCTransportTest.java
@@ -111,7 +111,7 @@ public class JSONRPCTransportTest {
                 .build();
         MessageSendConfiguration configuration = MessageSendConfiguration.builder()
                 .acceptedOutputModes(List.of("text"))
-                .blocking(true)
+                .returnImmediately(false)
                 .build();
         MessageSendParams params = MessageSendParams.builder()
                 .message(message)
@@ -159,7 +159,7 @@ public class JSONRPCTransportTest {
                 .build();
         MessageSendConfiguration configuration = MessageSendConfiguration.builder()
                 .acceptedOutputModes(List.of("text"))
-                .blocking(true)
+                .returnImmediately(false)
                 .build();
         MessageSendParams params = MessageSendParams.builder()
                 .message(message)
@@ -201,7 +201,7 @@ public class JSONRPCTransportTest {
                 .build();
         MessageSendConfiguration configuration = MessageSendConfiguration.builder()
                 .acceptedOutputModes(List.of("text"))
-                .blocking(true)
+                .returnImmediately(false)
                 .build();
         MessageSendParams params = MessageSendParams.builder()
                 .message(message)
@@ -446,7 +446,7 @@ public class JSONRPCTransportTest {
                 .build();
         MessageSendConfiguration configuration = MessageSendConfiguration.builder()
                 .acceptedOutputModes(List.of("text"))
-                .blocking(true)
+                .returnImmediately(false)
                 .build();
         MessageSendParams params = MessageSendParams.builder()
                 .message(message)
@@ -506,7 +506,7 @@ public class JSONRPCTransportTest {
                 .build();
         MessageSendConfiguration configuration = MessageSendConfiguration.builder()
                 .acceptedOutputModes(List.of("text"))
-                .blocking(true)
+                .returnImmediately(false)
                 .build();
         MessageSendParams params = MessageSendParams.builder()
                 .message(message)
@@ -564,7 +564,7 @@ public class JSONRPCTransportTest {
                 .build();
         MessageSendConfiguration configuration = MessageSendConfiguration.builder()
                 .acceptedOutputModes(List.of("text"))
-                .blocking(true)
+                .returnImmediately(false)
                 .build();
         MessageSendParams params = MessageSendParams.builder()
                 .message(message)
@@ -625,7 +625,7 @@ public class JSONRPCTransportTest {
                 .build();
         MessageSendConfiguration configuration = MessageSendConfiguration.builder()
                 .acceptedOutputModes(List.of("text"))
-                .blocking(true)
+                .returnImmediately(false)
                 .build();
         MessageSendParams params = MessageSendParams.builder()
                 .message(message)
@@ -681,7 +681,7 @@ public class JSONRPCTransportTest {
                 .build();
         MessageSendConfiguration configuration = MessageSendConfiguration.builder()
                 .acceptedOutputModes(List.of("text"))
-                .blocking(true)
+                .returnImmediately(false)
                 .build();
         MessageSendParams params = MessageSendParams.builder()
                 .message(message)

--- a/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JsonMessages.java
+++ b/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JsonMessages.java
@@ -151,7 +151,7 @@ public class JsonMessages {
               "acceptedOutputModes":[
                 "text"
               ],
-              "blocking":true
+              "returnImmediately":false
             },
             "metadata":{
 
@@ -201,7 +201,7 @@ public class JsonMessages {
                   "acceptedOutputModes":[
                     "text"
                   ],
-                  "blocking":true
+                  "returnImmediately":false
                 },
                 "metadata":{
                   
@@ -385,7 +385,7 @@ public class JsonMessages {
                    "acceptedOutputModes":[
                      "text"
                    ],
-                   "blocking":true
+                   "returnImmediately":false
                  },
                  "metadata":{
                    
@@ -452,7 +452,7 @@ public class JsonMessages {
                   "acceptedOutputModes":[
                     "text"
                   ],
-                  "blocking":true
+                  "returnImmediately":false
                 },
                 "metadata":{
                   
@@ -523,7 +523,7 @@ public class JsonMessages {
                   "acceptedOutputModes":[
                     "text"
                   ],
-                  "blocking":true
+                  "returnImmediately":false
                 },
                 "metadata":{
                   

--- a/client/transport/rest/src/test/java/io/a2a/client/transport/rest/RestTransportTest.java
+++ b/client/transport/rest/src/test/java/io/a2a/client/transport/rest/RestTransportTest.java
@@ -259,7 +259,7 @@ public class RestTransportTest {
                 .build();
         MessageSendConfiguration configuration = MessageSendConfiguration.builder()
                 .acceptedOutputModes(List.of("text"))
-                .blocking(false)
+                .returnImmediately(true)
                 .build();
         MessageSendParams params = MessageSendParams.builder()
                 .message(message)
@@ -577,7 +577,7 @@ public class RestTransportTest {
                 .build();
         MessageSendConfiguration configuration = MessageSendConfiguration.builder()
                 .acceptedOutputModes(List.of("text"))
-                .blocking(false)
+                .returnImmediately(true)
                 .build();
         MessageSendParams params = MessageSendParams.builder()
                 .message(message)

--- a/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/A2AServerRoutesTest.java
+++ b/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/A2AServerRoutesTest.java
@@ -141,7 +141,7 @@ public class A2AServerRoutesTest {
               },
               "configuration": {
                 "acceptedOutputModes": ["text"],
-                 "blocking": true
+                 "returnImmediately": false
               },
               "metadata": {}
              }
@@ -193,7 +193,7 @@ public class A2AServerRoutesTest {
               },
               "configuration": {
                 "acceptedOutputModes": ["text"],
-                "blocking": true
+                "returnImmediately": false
               },
               "metadata": {}
              }
@@ -692,7 +692,7 @@ public class A2AServerRoutesTest {
               },
               "configuration": {
                 "acceptedOutputModes": ["text"],
-                "blocking": true
+                "returnImmediately": false
               },
               "metadata": {}
              }

--- a/server-common/src/main/java/io/a2a/server/agentexecution/RequestContext.java
+++ b/server-common/src/main/java/io/a2a/server/agentexecution/RequestContext.java
@@ -51,7 +51,7 @@ import org.jspecify.annotations.Nullable;
  *
  *     // Access configuration if needed
  *     MessageSendConfiguration config = context.getConfiguration();
- *     boolean isBlocking = config != null && config.blocking();
+ *     boolean returnImmediately = config != null && Boolean.TRUE.equals(config.returnImmediately());
  *
  *     // Process and respond...
  * }

--- a/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
@@ -447,8 +447,8 @@ public class DefaultRequestHandler implements RequestHandler {
 
         // Log return behavior from client request
         if (params.configuration() != null && params.configuration().returnImmediately() != null) {
-            LOGGER.debug("DefaultRequestHandler: Client requested returnImmediately={} for task {}",
-                params.configuration().returnImmediately(), taskId.get());
+            LOGGER.debug("DefaultRequestHandler: Client requested returnImmediately={}, using blocking={} for task {}",
+                params.configuration().returnImmediately(), blocking, taskId.get());
         } else if (params.configuration() != null) {
             LOGGER.debug("DefaultRequestHandler: Client sent configuration but returnImmediately=null, using default blocking={} for task {}", blocking, taskId.get());
         } else {

--- a/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
@@ -441,15 +441,16 @@ public class DefaultRequestHandler implements RequestHandler {
         final java.util.concurrent.atomic.AtomicReference<@NonNull String> taskId = new java.util.concurrent.atomic.AtomicReference<>(queueTaskId);
         ResultAggregator resultAggregator = new ResultAggregator(mss.taskManager, null, executor, eventConsumerExecutor);
 
-        // Default to blocking=false per A2A spec (return after task creation)
-        boolean blocking = params.configuration() != null && Boolean.TRUE.equals(params.configuration().blocking());
+        // Default to blocking per A2A spec (returnImmediately defaults to false, meaning wait for completion)
+        boolean returnImmediately = params.configuration() != null && Boolean.TRUE.equals(params.configuration().returnImmediately());
+        boolean blocking = !returnImmediately;
 
-        // Log blocking behavior from client request
-        if (params.configuration() != null && params.configuration().blocking() != null) {
-            LOGGER.debug("DefaultRequestHandler: Client requested blocking={} for task {}",
-                params.configuration().blocking(), taskId.get());
+        // Log return behavior from client request
+        if (params.configuration() != null && params.configuration().returnImmediately() != null) {
+            LOGGER.debug("DefaultRequestHandler: Client requested returnImmediately={} for task {}",
+                params.configuration().returnImmediately(), taskId.get());
         } else if (params.configuration() != null) {
-            LOGGER.debug("DefaultRequestHandler: Client sent configuration but blocking=null, using default blocking={} for task {}", blocking, taskId.get());
+            LOGGER.debug("DefaultRequestHandler: Client sent configuration but returnImmediately=null, using default blocking={} for task {}", blocking, taskId.get());
         } else {
             LOGGER.debug("DefaultRequestHandler: Client sent no configuration, using default blocking={} for task {}", blocking, taskId.get());
         }

--- a/server-common/src/test/java/io/a2a/server/agentexecution/RequestContextTest.java
+++ b/server-common/src/test/java/io/a2a/server/agentexecution/RequestContextTest.java
@@ -30,7 +30,7 @@ public class RequestContextTest {
     private static MessageSendConfiguration defaultConfiguration() {
         return MessageSendConfiguration.builder()
                 .acceptedOutputModes(List.of())
-                .blocking(false)
+                .returnImmediately(true)
                 .build();
     }
 

--- a/server-common/src/test/java/io/a2a/server/requesthandlers/DefaultRequestHandlerTest.java
+++ b/server-common/src/test/java/io/a2a/server/requesthandlers/DefaultRequestHandlerTest.java
@@ -55,7 +55,7 @@ import org.junit.jupiter.api.Test;
 public class DefaultRequestHandlerTest {
 
     private static final MessageSendConfiguration DEFAULT_CONFIG = MessageSendConfiguration.builder()
-        .blocking(false)
+        .returnImmediately(true)
         .acceptedOutputModes(List.of())
         .build();
 

--- a/spec-grpc/src/main/java/io/a2a/grpc/A2A.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/A2A.java
@@ -295,248 +295,248 @@ public final class A2A extends com.google.protobuf.GeneratedFile {
       "oogle/api/field_behavior.proto\032\033google/p" +
       "rotobuf/empty.proto\032\034google/protobuf/str" +
       "uct.proto\032\037google/protobuf/timestamp.pro" +
-      "to\"\311\001\n\030SendMessageConfiguration\022\035\n\025accep" +
+      "to\"\323\001\n\030SendMessageConfiguration\022\035\n\025accep" +
       "ted_output_modes\030\001 \003(\t\022L\n\035task_push_noti" +
       "fication_config\030\002 \001(\0132%.lf.a2a.v1.TaskPu" +
       "shNotificationConfig\022\033\n\016history_length\030\003" +
-      " \001(\005H\000\210\001\001\022\020\n\010blocking\030\004 \001(\010B\021\n\017_history_" +
-      "length\"\317\001\n\004Task\022\017\n\002id\030\001 \001(\tB\003\340A\002\022\022\n\ncont" +
-      "ext_id\030\002 \001(\t\022*\n\006status\030\003 \001(\0132\025.lf.a2a.v1" +
-      ".TaskStatusB\003\340A\002\022&\n\tartifacts\030\004 \003(\0132\023.lf" +
-      ".a2a.v1.Artifact\022#\n\007history\030\005 \003(\0132\022.lf.a" +
-      "2a.v1.Message\022)\n\010metadata\030\006 \001(\0132\027.google" +
-      ".protobuf.Struct\"\212\001\n\nTaskStatus\022(\n\005state" +
-      "\030\001 \001(\0162\024.lf.a2a.v1.TaskStateB\003\340A\002\022#\n\007mes" +
-      "sage\030\002 \001(\0132\022.lf.a2a.v1.Message\022-\n\ttimest" +
-      "amp\030\003 \001(\0132\032.google.protobuf.Timestamp\"\270\001" +
-      "\n\004Part\022\016\n\004text\030\001 \001(\tH\000\022\r\n\003raw\030\002 \001(\014H\000\022\r\n" +
-      "\003url\030\003 \001(\tH\000\022&\n\004data\030\004 \001(\0132\026.google.prot" +
-      "obuf.ValueH\000\022)\n\010metadata\030\005 \001(\0132\027.google." +
-      "protobuf.Struct\022\020\n\010filename\030\006 \001(\t\022\022\n\nmed" +
-      "ia_type\030\007 \001(\tB\t\n\007content\"\353\001\n\007Message\022\027\n\n" +
-      "message_id\030\001 \001(\tB\003\340A\002\022\022\n\ncontext_id\030\002 \001(" +
-      "\t\022\017\n\007task_id\030\003 \001(\t\022\"\n\004role\030\004 \001(\0162\017.lf.a2" +
-      "a.v1.RoleB\003\340A\002\022#\n\005parts\030\005 \003(\0132\017.lf.a2a.v" +
-      "1.PartB\003\340A\002\022)\n\010metadata\030\006 \001(\0132\027.google.p" +
-      "rotobuf.Struct\022\022\n\nextensions\030\007 \003(\t\022\032\n\022re" +
-      "ference_task_ids\030\010 \003(\t\"\253\001\n\010Artifact\022\030\n\013a" +
-      "rtifact_id\030\001 \001(\tB\003\340A\002\022\014\n\004name\030\002 \001(\t\022\023\n\013d" +
-      "escription\030\003 \001(\t\022#\n\005parts\030\004 \003(\0132\017.lf.a2a" +
-      ".v1.PartB\003\340A\002\022)\n\010metadata\030\005 \001(\0132\027.google" +
-      ".protobuf.Struct\022\022\n\nextensions\030\006 \003(\t\"\235\001\n" +
-      "\025TaskStatusUpdateEvent\022\024\n\007task_id\030\001 \001(\tB" +
-      "\003\340A\002\022\027\n\ncontext_id\030\002 \001(\tB\003\340A\002\022*\n\006status\030" +
-      "\003 \001(\0132\025.lf.a2a.v1.TaskStatusB\003\340A\002\022)\n\010met" +
-      "adata\030\004 \001(\0132\027.google.protobuf.Struct\"\303\001\n" +
-      "\027TaskArtifactUpdateEvent\022\024\n\007task_id\030\001 \001(" +
-      "\tB\003\340A\002\022\027\n\ncontext_id\030\002 \001(\tB\003\340A\002\022*\n\010artif" +
-      "act\030\003 \001(\0132\023.lf.a2a.v1.ArtifactB\003\340A\002\022\016\n\006a" +
-      "ppend\030\004 \001(\010\022\022\n\nlast_chunk\030\005 \001(\010\022)\n\010metad" +
-      "ata\030\006 \001(\0132\027.google.protobuf.Struct\">\n\022Au" +
-      "thenticationInfo\022\023\n\006scheme\030\001 \001(\tB\003\340A\002\022\023\n" +
-      "\013credentials\030\002 \001(\t\"p\n\016AgentInterface\022\020\n\003" +
-      "url\030\001 \001(\tB\003\340A\002\022\035\n\020protocol_binding\030\002 \001(\t" +
-      "B\003\340A\002\022\016\n\006tenant\030\003 \001(\t\022\035\n\020protocol_versio" +
-      "n\030\004 \001(\tB\003\340A\002\"\306\005\n\tAgentCard\022\021\n\004name\030\001 \001(\t" +
-      "B\003\340A\002\022\030\n\013description\030\002 \001(\tB\003\340A\002\022<\n\024suppo" +
-      "rted_interfaces\030\003 \003(\0132\031.lf.a2a.v1.AgentI" +
-      "nterfaceB\003\340A\002\022*\n\010provider\030\004 \001(\0132\030.lf.a2a" +
-      ".v1.AgentProvider\022\024\n\007version\030\005 \001(\tB\003\340A\002\022" +
-      "\036\n\021documentation_url\030\006 \001(\tH\000\210\001\001\0227\n\014capab" +
-      "ilities\030\007 \001(\0132\034.lf.a2a.v1.AgentCapabilit" +
-      "iesB\003\340A\002\022C\n\020security_schemes\030\010 \003(\0132).lf." +
-      "a2a.v1.AgentCard.SecuritySchemesEntry\022=\n" +
-      "\025security_requirements\030\t \003(\0132\036.lf.a2a.v1" +
-      ".SecurityRequirement\022 \n\023default_input_mo" +
-      "des\030\n \003(\tB\003\340A\002\022!\n\024default_output_modes\030\013" +
-      " \003(\tB\003\340A\002\022*\n\006skills\030\014 \003(\0132\025.lf.a2a.v1.Ag" +
-      "entSkillB\003\340A\002\0221\n\nsignatures\030\r \003(\0132\035.lf.a" +
-      "2a.v1.AgentCardSignature\022\025\n\010icon_url\030\016 \001" +
-      "(\tH\001\210\001\001\032Q\n\024SecuritySchemesEntry\022\013\n\003key\030\001" +
-      " \001(\t\022(\n\005value\030\002 \001(\0132\031.lf.a2a.v1.Security" +
-      "Scheme:\0028\001B\024\n\022_documentation_urlB\013\n\t_ico" +
-      "n_url\"<\n\rAgentProvider\022\020\n\003url\030\001 \001(\tB\003\340A\002" +
-      "\022\031\n\014organization\030\002 \001(\tB\003\340A\002\"\332\001\n\021AgentCap" +
-      "abilities\022\026\n\tstreaming\030\001 \001(\010H\000\210\001\001\022\037\n\022pus" +
-      "h_notifications\030\002 \001(\010H\001\210\001\001\022-\n\nextensions" +
-      "\030\003 \003(\0132\031.lf.a2a.v1.AgentExtension\022 \n\023ext" +
-      "ended_agent_card\030\004 \001(\010H\002\210\001\001B\014\n\n_streamin" +
-      "gB\025\n\023_push_notificationsB\026\n\024_extended_ag" +
-      "ent_card\"m\n\016AgentExtension\022\013\n\003uri\030\001 \001(\t\022" +
-      "\023\n\013description\030\002 \001(\t\022\020\n\010required\030\003 \001(\010\022\'" +
-      "\n\006params\030\004 \001(\0132\027.google.protobuf.Struct\"" +
-      "\331\001\n\nAgentSkill\022\017\n\002id\030\001 \001(\tB\003\340A\002\022\021\n\004name\030" +
-      "\002 \001(\tB\003\340A\002\022\030\n\013description\030\003 \001(\tB\003\340A\002\022\021\n\004" +
-      "tags\030\004 \003(\tB\003\340A\002\022\020\n\010examples\030\005 \003(\t\022\023\n\013inp" +
-      "ut_modes\030\006 \003(\t\022\024\n\014output_modes\030\007 \003(\t\022=\n\025" +
-      "security_requirements\030\010 \003(\0132\036.lf.a2a.v1." +
-      "SecurityRequirement\"m\n\022AgentCardSignatur" +
-      "e\022\026\n\tprotected\030\001 \001(\tB\003\340A\002\022\026\n\tsignature\030\002" +
-      " \001(\tB\003\340A\002\022\'\n\006header\030\003 \001(\0132\027.google.proto" +
-      "buf.Struct\"\241\001\n\032TaskPushNotificationConfi" +
-      "g\022\016\n\006tenant\030\001 \001(\t\022\n\n\002id\030\002 \001(\t\022\017\n\007task_id" +
-      "\030\003 \001(\t\022\020\n\003url\030\004 \001(\tB\003\340A\002\022\r\n\005token\030\005 \001(\t\022" +
-      "5\n\016authentication\030\006 \001(\0132\035.lf.a2a.v1.Auth" +
-      "enticationInfo\"\032\n\nStringList\022\014\n\004list\030\001 \003" +
-      "(\t\"\232\001\n\023SecurityRequirement\022<\n\007schemes\030\001 " +
-      "\003(\0132+.lf.a2a.v1.SecurityRequirement.Sche" +
-      "mesEntry\032E\n\014SchemesEntry\022\013\n\003key\030\001 \001(\t\022$\n" +
-      "\005value\030\002 \001(\0132\025.lf.a2a.v1.StringList:\0028\001\"" +
-      "\200\003\n\016SecurityScheme\022B\n\027api_key_security_s" +
-      "cheme\030\001 \001(\0132\037.lf.a2a.v1.APIKeySecuritySc" +
-      "hemeH\000\022F\n\031http_auth_security_scheme\030\002 \001(" +
-      "\0132!.lf.a2a.v1.HTTPAuthSecuritySchemeH\000\022A" +
-      "\n\026oauth2_security_scheme\030\003 \001(\0132\037.lf.a2a." +
-      "v1.OAuth2SecuritySchemeH\000\022Q\n\037open_id_con" +
-      "nect_security_scheme\030\004 \001(\0132&.lf.a2a.v1.O" +
-      "penIdConnectSecuritySchemeH\000\022B\n\024mtls_sec" +
-      "urity_scheme\030\005 \001(\0132\".lf.a2a.v1.MutualTls" +
-      "SecuritySchemeH\000B\010\n\006scheme\"U\n\024APIKeySecu" +
-      "rityScheme\022\023\n\013description\030\001 \001(\t\022\025\n\010locat" +
-      "ion\030\002 \001(\tB\003\340A\002\022\021\n\004name\030\003 \001(\tB\003\340A\002\"Y\n\026HTT" +
-      "PAuthSecurityScheme\022\023\n\013description\030\001 \001(\t" +
-      "\022\023\n\006scheme\030\002 \001(\tB\003\340A\002\022\025\n\rbearer_format\030\003" +
-      " \001(\t\"s\n\024OAuth2SecurityScheme\022\023\n\013descript" +
-      "ion\030\001 \001(\t\022)\n\005flows\030\002 \001(\0132\025.lf.a2a.v1.OAu" +
-      "thFlowsB\003\340A\002\022\033\n\023oauth2_metadata_url\030\003 \001(" +
-      "\t\"T\n\033OpenIdConnectSecurityScheme\022\023\n\013desc" +
-      "ription\030\001 \001(\t\022 \n\023open_id_connect_url\030\002 \001" +
-      "(\tB\003\340A\002\".\n\027MutualTlsSecurityScheme\022\023\n\013de" +
-      "scription\030\001 \001(\t\"\301\002\n\nOAuthFlows\022C\n\022author" +
-      "ization_code\030\001 \001(\0132%.lf.a2a.v1.Authoriza" +
-      "tionCodeOAuthFlowH\000\022C\n\022client_credential" +
-      "s\030\002 \001(\0132%.lf.a2a.v1.ClientCredentialsOAu" +
-      "thFlowH\000\0224\n\010implicit\030\003 \001(\0132\034.lf.a2a.v1.I" +
-      "mplicitOAuthFlowB\002\030\001H\000\0224\n\010password\030\004 \001(\013" +
-      "2\034.lf.a2a.v1.PasswordOAuthFlowB\002\030\001H\000\0225\n\013" +
-      "device_code\030\005 \001(\0132\036.lf.a2a.v1.DeviceCode" +
-      "OAuthFlowH\000B\006\n\004flow\"\367\001\n\032AuthorizationCod" +
-      "eOAuthFlow\022\036\n\021authorization_url\030\001 \001(\tB\003\340" +
-      "A\002\022\026\n\ttoken_url\030\002 \001(\tB\003\340A\002\022\023\n\013refresh_ur" +
-      "l\030\003 \001(\t\022F\n\006scopes\030\004 \003(\01321.lf.a2a.v1.Auth" +
-      "orizationCodeOAuthFlow.ScopesEntryB\003\340A\002\022" +
-      "\025\n\rpkce_required\030\005 \001(\010\032-\n\013ScopesEntry\022\013\n" +
-      "\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\300\001\n\032Client" +
-      "CredentialsOAuthFlow\022\026\n\ttoken_url\030\001 \001(\tB" +
-      "\003\340A\002\022\023\n\013refresh_url\030\002 \001(\t\022F\n\006scopes\030\003 \003(" +
-      "\01321.lf.a2a.v1.ClientCredentialsOAuthFlow" +
-      ".ScopesEntryB\003\340A\002\032-\n\013ScopesEntry\022\013\n\003key\030" +
-      "\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\254\001\n\021ImplicitOAu" +
-      "thFlow\022\031\n\021authorization_url\030\001 \001(\t\022\023\n\013ref" +
-      "resh_url\030\002 \001(\t\0228\n\006scopes\030\003 \003(\0132(.lf.a2a." +
-      "v1.ImplicitOAuthFlow.ScopesEntry\032-\n\013Scop" +
+      " \001(\005H\000\210\001\001\022\032\n\022return_immediately\030\004 \001(\010B\021\n" +
+      "\017_history_length\"\317\001\n\004Task\022\017\n\002id\030\001 \001(\tB\003\340" +
+      "A\002\022\022\n\ncontext_id\030\002 \001(\t\022*\n\006status\030\003 \001(\0132\025" +
+      ".lf.a2a.v1.TaskStatusB\003\340A\002\022&\n\tartifacts\030" +
+      "\004 \003(\0132\023.lf.a2a.v1.Artifact\022#\n\007history\030\005 " +
+      "\003(\0132\022.lf.a2a.v1.Message\022)\n\010metadata\030\006 \001(" +
+      "\0132\027.google.protobuf.Struct\"\212\001\n\nTaskStatu" +
+      "s\022(\n\005state\030\001 \001(\0162\024.lf.a2a.v1.TaskStateB\003" +
+      "\340A\002\022#\n\007message\030\002 \001(\0132\022.lf.a2a.v1.Message" +
+      "\022-\n\ttimestamp\030\003 \001(\0132\032.google.protobuf.Ti" +
+      "mestamp\"\270\001\n\004Part\022\016\n\004text\030\001 \001(\tH\000\022\r\n\003raw\030" +
+      "\002 \001(\014H\000\022\r\n\003url\030\003 \001(\tH\000\022&\n\004data\030\004 \001(\0132\026.g" +
+      "oogle.protobuf.ValueH\000\022)\n\010metadata\030\005 \001(\013" +
+      "2\027.google.protobuf.Struct\022\020\n\010filename\030\006 " +
+      "\001(\t\022\022\n\nmedia_type\030\007 \001(\tB\t\n\007content\"\353\001\n\007M" +
+      "essage\022\027\n\nmessage_id\030\001 \001(\tB\003\340A\002\022\022\n\nconte" +
+      "xt_id\030\002 \001(\t\022\017\n\007task_id\030\003 \001(\t\022\"\n\004role\030\004 \001" +
+      "(\0162\017.lf.a2a.v1.RoleB\003\340A\002\022#\n\005parts\030\005 \003(\0132" +
+      "\017.lf.a2a.v1.PartB\003\340A\002\022)\n\010metadata\030\006 \001(\0132" +
+      "\027.google.protobuf.Struct\022\022\n\nextensions\030\007" +
+      " \003(\t\022\032\n\022reference_task_ids\030\010 \003(\t\"\253\001\n\010Art" +
+      "ifact\022\030\n\013artifact_id\030\001 \001(\tB\003\340A\002\022\014\n\004name\030" +
+      "\002 \001(\t\022\023\n\013description\030\003 \001(\t\022#\n\005parts\030\004 \003(" +
+      "\0132\017.lf.a2a.v1.PartB\003\340A\002\022)\n\010metadata\030\005 \001(" +
+      "\0132\027.google.protobuf.Struct\022\022\n\nextensions" +
+      "\030\006 \003(\t\"\235\001\n\025TaskStatusUpdateEvent\022\024\n\007task" +
+      "_id\030\001 \001(\tB\003\340A\002\022\027\n\ncontext_id\030\002 \001(\tB\003\340A\002\022" +
+      "*\n\006status\030\003 \001(\0132\025.lf.a2a.v1.TaskStatusB\003" +
+      "\340A\002\022)\n\010metadata\030\004 \001(\0132\027.google.protobuf." +
+      "Struct\"\303\001\n\027TaskArtifactUpdateEvent\022\024\n\007ta" +
+      "sk_id\030\001 \001(\tB\003\340A\002\022\027\n\ncontext_id\030\002 \001(\tB\003\340A" +
+      "\002\022*\n\010artifact\030\003 \001(\0132\023.lf.a2a.v1.Artifact" +
+      "B\003\340A\002\022\016\n\006append\030\004 \001(\010\022\022\n\nlast_chunk\030\005 \001(" +
+      "\010\022)\n\010metadata\030\006 \001(\0132\027.google.protobuf.St" +
+      "ruct\">\n\022AuthenticationInfo\022\023\n\006scheme\030\001 \001" +
+      "(\tB\003\340A\002\022\023\n\013credentials\030\002 \001(\t\"p\n\016AgentInt" +
+      "erface\022\020\n\003url\030\001 \001(\tB\003\340A\002\022\035\n\020protocol_bin" +
+      "ding\030\002 \001(\tB\003\340A\002\022\016\n\006tenant\030\003 \001(\t\022\035\n\020proto" +
+      "col_version\030\004 \001(\tB\003\340A\002\"\306\005\n\tAgentCard\022\021\n\004" +
+      "name\030\001 \001(\tB\003\340A\002\022\030\n\013description\030\002 \001(\tB\003\340A" +
+      "\002\022<\n\024supported_interfaces\030\003 \003(\0132\031.lf.a2a" +
+      ".v1.AgentInterfaceB\003\340A\002\022*\n\010provider\030\004 \001(" +
+      "\0132\030.lf.a2a.v1.AgentProvider\022\024\n\007version\030\005" +
+      " \001(\tB\003\340A\002\022\036\n\021documentation_url\030\006 \001(\tH\000\210\001" +
+      "\001\0227\n\014capabilities\030\007 \001(\0132\034.lf.a2a.v1.Agen" +
+      "tCapabilitiesB\003\340A\002\022C\n\020security_schemes\030\010" +
+      " \003(\0132).lf.a2a.v1.AgentCard.SecuritySchem" +
+      "esEntry\022=\n\025security_requirements\030\t \003(\0132\036" +
+      ".lf.a2a.v1.SecurityRequirement\022 \n\023defaul" +
+      "t_input_modes\030\n \003(\tB\003\340A\002\022!\n\024default_outp" +
+      "ut_modes\030\013 \003(\tB\003\340A\002\022*\n\006skills\030\014 \003(\0132\025.lf" +
+      ".a2a.v1.AgentSkillB\003\340A\002\0221\n\nsignatures\030\r " +
+      "\003(\0132\035.lf.a2a.v1.AgentCardSignature\022\025\n\010ic" +
+      "on_url\030\016 \001(\tH\001\210\001\001\032Q\n\024SecuritySchemesEntr" +
+      "y\022\013\n\003key\030\001 \001(\t\022(\n\005value\030\002 \001(\0132\031.lf.a2a.v" +
+      "1.SecurityScheme:\0028\001B\024\n\022_documentation_u" +
+      "rlB\013\n\t_icon_url\"<\n\rAgentProvider\022\020\n\003url\030" +
+      "\001 \001(\tB\003\340A\002\022\031\n\014organization\030\002 \001(\tB\003\340A\002\"\332\001" +
+      "\n\021AgentCapabilities\022\026\n\tstreaming\030\001 \001(\010H\000" +
+      "\210\001\001\022\037\n\022push_notifications\030\002 \001(\010H\001\210\001\001\022-\n\n" +
+      "extensions\030\003 \003(\0132\031.lf.a2a.v1.AgentExtens" +
+      "ion\022 \n\023extended_agent_card\030\004 \001(\010H\002\210\001\001B\014\n" +
+      "\n_streamingB\025\n\023_push_notificationsB\026\n\024_e" +
+      "xtended_agent_card\"m\n\016AgentExtension\022\013\n\003" +
+      "uri\030\001 \001(\t\022\023\n\013description\030\002 \001(\t\022\020\n\010requir" +
+      "ed\030\003 \001(\010\022\'\n\006params\030\004 \001(\0132\027.google.protob" +
+      "uf.Struct\"\331\001\n\nAgentSkill\022\017\n\002id\030\001 \001(\tB\003\340A" +
+      "\002\022\021\n\004name\030\002 \001(\tB\003\340A\002\022\030\n\013description\030\003 \001(" +
+      "\tB\003\340A\002\022\021\n\004tags\030\004 \003(\tB\003\340A\002\022\020\n\010examples\030\005 " +
+      "\003(\t\022\023\n\013input_modes\030\006 \003(\t\022\024\n\014output_modes" +
+      "\030\007 \003(\t\022=\n\025security_requirements\030\010 \003(\0132\036." +
+      "lf.a2a.v1.SecurityRequirement\"m\n\022AgentCa" +
+      "rdSignature\022\026\n\tprotected\030\001 \001(\tB\003\340A\002\022\026\n\ts" +
+      "ignature\030\002 \001(\tB\003\340A\002\022\'\n\006header\030\003 \001(\0132\027.go" +
+      "ogle.protobuf.Struct\"\241\001\n\032TaskPushNotific" +
+      "ationConfig\022\016\n\006tenant\030\001 \001(\t\022\n\n\002id\030\002 \001(\t\022" +
+      "\017\n\007task_id\030\003 \001(\t\022\020\n\003url\030\004 \001(\tB\003\340A\002\022\r\n\005to" +
+      "ken\030\005 \001(\t\0225\n\016authentication\030\006 \001(\0132\035.lf.a" +
+      "2a.v1.AuthenticationInfo\"\032\n\nStringList\022\014" +
+      "\n\004list\030\001 \003(\t\"\232\001\n\023SecurityRequirement\022<\n\007" +
+      "schemes\030\001 \003(\0132+.lf.a2a.v1.SecurityRequir" +
+      "ement.SchemesEntry\032E\n\014SchemesEntry\022\013\n\003ke" +
+      "y\030\001 \001(\t\022$\n\005value\030\002 \001(\0132\025.lf.a2a.v1.Strin" +
+      "gList:\0028\001\"\200\003\n\016SecurityScheme\022B\n\027api_key_" +
+      "security_scheme\030\001 \001(\0132\037.lf.a2a.v1.APIKey" +
+      "SecuritySchemeH\000\022F\n\031http_auth_security_s" +
+      "cheme\030\002 \001(\0132!.lf.a2a.v1.HTTPAuthSecurity" +
+      "SchemeH\000\022A\n\026oauth2_security_scheme\030\003 \001(\013" +
+      "2\037.lf.a2a.v1.OAuth2SecuritySchemeH\000\022Q\n\037o" +
+      "pen_id_connect_security_scheme\030\004 \001(\0132&.l" +
+      "f.a2a.v1.OpenIdConnectSecuritySchemeH\000\022B" +
+      "\n\024mtls_security_scheme\030\005 \001(\0132\".lf.a2a.v1" +
+      ".MutualTlsSecuritySchemeH\000B\010\n\006scheme\"U\n\024" +
+      "APIKeySecurityScheme\022\023\n\013description\030\001 \001(" +
+      "\t\022\025\n\010location\030\002 \001(\tB\003\340A\002\022\021\n\004name\030\003 \001(\tB\003" +
+      "\340A\002\"Y\n\026HTTPAuthSecurityScheme\022\023\n\013descrip" +
+      "tion\030\001 \001(\t\022\023\n\006scheme\030\002 \001(\tB\003\340A\002\022\025\n\rbeare" +
+      "r_format\030\003 \001(\t\"s\n\024OAuth2SecurityScheme\022\023" +
+      "\n\013description\030\001 \001(\t\022)\n\005flows\030\002 \001(\0132\025.lf." +
+      "a2a.v1.OAuthFlowsB\003\340A\002\022\033\n\023oauth2_metadat" +
+      "a_url\030\003 \001(\t\"T\n\033OpenIdConnectSecuritySche" +
+      "me\022\023\n\013description\030\001 \001(\t\022 \n\023open_id_conne" +
+      "ct_url\030\002 \001(\tB\003\340A\002\".\n\027MutualTlsSecuritySc" +
+      "heme\022\023\n\013description\030\001 \001(\t\"\301\002\n\nOAuthFlows" +
+      "\022C\n\022authorization_code\030\001 \001(\0132%.lf.a2a.v1" +
+      ".AuthorizationCodeOAuthFlowH\000\022C\n\022client_" +
+      "credentials\030\002 \001(\0132%.lf.a2a.v1.ClientCred" +
+      "entialsOAuthFlowH\000\0224\n\010implicit\030\003 \001(\0132\034.l" +
+      "f.a2a.v1.ImplicitOAuthFlowB\002\030\001H\000\0224\n\010pass" +
+      "word\030\004 \001(\0132\034.lf.a2a.v1.PasswordOAuthFlow" +
+      "B\002\030\001H\000\0225\n\013device_code\030\005 \001(\0132\036.lf.a2a.v1." +
+      "DeviceCodeOAuthFlowH\000B\006\n\004flow\"\367\001\n\032Author" +
+      "izationCodeOAuthFlow\022\036\n\021authorization_ur" +
+      "l\030\001 \001(\tB\003\340A\002\022\026\n\ttoken_url\030\002 \001(\tB\003\340A\002\022\023\n\013" +
+      "refresh_url\030\003 \001(\t\022F\n\006scopes\030\004 \003(\01321.lf.a" +
+      "2a.v1.AuthorizationCodeOAuthFlow.ScopesE" +
+      "ntryB\003\340A\002\022\025\n\rpkce_required\030\005 \001(\010\032-\n\013Scop" +
       "esEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"" +
-      "\244\001\n\021PasswordOAuthFlow\022\021\n\ttoken_url\030\001 \001(\t" +
-      "\022\023\n\013refresh_url\030\002 \001(\t\0228\n\006scopes\030\003 \003(\0132(." +
-      "lf.a2a.v1.PasswordOAuthFlow.ScopesEntry\032" +
-      "-\n\013ScopesEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001" +
-      "(\t:\0028\001\"\331\001\n\023DeviceCodeOAuthFlow\022%\n\030device" +
-      "_authorization_url\030\001 \001(\tB\003\340A\002\022\026\n\ttoken_u" +
-      "rl\030\002 \001(\tB\003\340A\002\022\023\n\013refresh_url\030\003 \001(\t\022?\n\006sc" +
-      "opes\030\004 \003(\0132*.lf.a2a.v1.DeviceCodeOAuthFl" +
-      "ow.ScopesEntryB\003\340A\002\032-\n\013ScopesEntry\022\013\n\003ke" +
-      "y\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\265\001\n\022SendMessa" +
-      "geRequest\022\016\n\006tenant\030\001 \001(\t\022(\n\007message\030\002 \001" +
-      "(\0132\022.lf.a2a.v1.MessageB\003\340A\002\022:\n\rconfigura" +
-      "tion\030\003 \001(\0132#.lf.a2a.v1.SendMessageConfig" +
-      "uration\022)\n\010metadata\030\004 \001(\0132\027.google.proto" +
-      "buf.Struct\"a\n\016GetTaskRequest\022\016\n\006tenant\030\001" +
-      " \001(\t\022\017\n\002id\030\002 \001(\tB\003\340A\002\022\033\n\016history_length\030" +
-      "\003 \001(\005H\000\210\001\001B\021\n\017_history_length\"\270\002\n\020ListTa" +
-      "sksRequest\022\016\n\006tenant\030\001 \001(\t\022\022\n\ncontext_id" +
-      "\030\002 \001(\t\022$\n\006status\030\003 \001(\0162\024.lf.a2a.v1.TaskS" +
-      "tate\022\026\n\tpage_size\030\004 \001(\005H\000\210\001\001\022\022\n\npage_tok" +
-      "en\030\005 \001(\t\022\033\n\016history_length\030\006 \001(\005H\001\210\001\001\022:\n" +
-      "\026status_timestamp_after\030\007 \001(\0132\032.google.p" +
-      "rotobuf.Timestamp\022\036\n\021include_artifacts\030\010" +
-      " \001(\010H\002\210\001\001B\014\n\n_page_sizeB\021\n\017_history_leng" +
-      "thB\024\n\022_include_artifacts\"\207\001\n\021ListTasksRe" +
-      "sponse\022#\n\005tasks\030\001 \003(\0132\017.lf.a2a.v1.TaskB\003" +
-      "\340A\002\022\034\n\017next_page_token\030\002 \001(\tB\003\340A\002\022\026\n\tpag" +
-      "e_size\030\003 \001(\005B\003\340A\002\022\027\n\ntotal_size\030\004 \001(\005B\003\340" +
-      "A\002\"_\n\021CancelTaskRequest\022\016\n\006tenant\030\001 \001(\t\022" +
-      "\017\n\002id\030\002 \001(\tB\003\340A\002\022)\n\010metadata\030\003 \001(\0132\027.goo" +
-      "gle.protobuf.Struct\"]\n$GetTaskPushNotifi" +
-      "cationConfigRequest\022\016\n\006tenant\030\001 \001(\t\022\024\n\007t" +
-      "ask_id\030\002 \001(\tB\003\340A\002\022\017\n\002id\030\003 \001(\tB\003\340A\002\"`\n\'De" +
-      "leteTaskPushNotificationConfigRequest\022\016\n" +
-      "\006tenant\030\001 \001(\t\022\024\n\007task_id\030\002 \001(\tB\003\340A\002\022\017\n\002i" +
-      "d\030\003 \001(\tB\003\340A\002\"9\n\026SubscribeToTaskRequest\022\016" +
-      "\n\006tenant\030\001 \001(\t\022\017\n\002id\030\002 \001(\tB\003\340A\002\"u\n&ListT" +
-      "askPushNotificationConfigsRequest\022\016\n\006ten" +
-      "ant\030\004 \001(\t\022\024\n\007task_id\030\001 \001(\tB\003\340A\002\022\021\n\tpage_" +
-      "size\030\002 \001(\005\022\022\n\npage_token\030\003 \001(\t\"-\n\033GetExt" +
-      "endedAgentCardRequest\022\016\n\006tenant\030\001 \001(\t\"h\n" +
-      "\023SendMessageResponse\022\037\n\004task\030\001 \001(\0132\017.lf." +
-      "a2a.v1.TaskH\000\022%\n\007message\030\002 \001(\0132\022.lf.a2a." +
-      "v1.MessageH\000B\t\n\007payload\"\335\001\n\016StreamRespon" +
-      "se\022\037\n\004task\030\001 \001(\0132\017.lf.a2a.v1.TaskH\000\022%\n\007m" +
-      "essage\030\002 \001(\0132\022.lf.a2a.v1.MessageH\000\0229\n\rst" +
-      "atus_update\030\003 \001(\0132 .lf.a2a.v1.TaskStatus" +
-      "UpdateEventH\000\022=\n\017artifact_update\030\004 \001(\0132\"" +
-      ".lf.a2a.v1.TaskArtifactUpdateEventH\000B\t\n\007" +
-      "payload\"z\n\'ListTaskPushNotificationConfi" +
-      "gsResponse\0226\n\007configs\030\001 \003(\0132%.lf.a2a.v1." +
-      "TaskPushNotificationConfig\022\027\n\017next_page_" +
-      "token\030\002 \001(\t*\371\001\n\tTaskState\022\032\n\026TASK_STATE_" +
-      "UNSPECIFIED\020\000\022\030\n\024TASK_STATE_SUBMITTED\020\001\022" +
-      "\026\n\022TASK_STATE_WORKING\020\002\022\030\n\024TASK_STATE_CO" +
-      "MPLETED\020\003\022\025\n\021TASK_STATE_FAILED\020\004\022\027\n\023TASK" +
-      "_STATE_CANCELED\020\005\022\035\n\031TASK_STATE_INPUT_RE" +
-      "QUIRED\020\006\022\027\n\023TASK_STATE_REJECTED\020\007\022\034\n\030TAS" +
-      "K_STATE_AUTH_REQUIRED\020\010*;\n\004Role\022\024\n\020ROLE_" +
-      "UNSPECIFIED\020\000\022\r\n\tROLE_USER\020\001\022\016\n\nROLE_AGE" +
-      "NT\020\0022\227\017\n\nA2AService\022\203\001\n\013SendMessage\022\035.lf" +
-      ".a2a.v1.SendMessageRequest\032\036.lf.a2a.v1.S" +
-      "endMessageResponse\"5\202\323\344\223\002/\"\r/message:sen" +
-      "d:\001*Z\033\"\026/{tenant}/message:send:\001*\022\215\001\n\024Se" +
-      "ndStreamingMessage\022\035.lf.a2a.v1.SendMessa" +
-      "geRequest\032\031.lf.a2a.v1.StreamResponse\"9\202\323" +
-      "\344\223\0023\"\017/message:stream:\001*Z\035\"\030/{tenant}/me" +
-      "ssage:stream:\001*0\001\022k\n\007GetTask\022\031.lf.a2a.v1" +
-      ".GetTaskRequest\032\017.lf.a2a.v1.Task\"4\332A\002id\202" +
-      "\323\344\223\002)\022\r/tasks/{id=*}Z\030\022\026/{tenant}/tasks/" +
-      "{id=*}\022i\n\tListTasks\022\033.lf.a2a.v1.ListTask" +
-      "sRequest\032\034.lf.a2a.v1.ListTasksResponse\"!" +
-      "\202\323\344\223\002\033\022\006/tasksZ\021\022\017/{tenant}/tasks\022\200\001\n\nCa" +
-      "ncelTask\022\034.lf.a2a.v1.CancelTaskRequest\032\017" +
-      ".lf.a2a.v1.Task\"C\202\323\344\223\002=\"\024/tasks/{id=*}:c" +
-      "ancel:\001*Z\"\"\035/{tenant}/tasks/{id=*}:cance" +
-      "l:\001*\022\226\001\n\017SubscribeToTask\022!.lf.a2a.v1.Sub" +
-      "scribeToTaskRequest\032\031.lf.a2a.v1.StreamRe" +
-      "sponse\"C\202\323\344\223\002=\022\027/tasks/{id=*}:subscribeZ" +
-      "\"\022 /{tenant}/tasks/{id=*}:subscribe0\001\022\363\001" +
-      "\n CreateTaskPushNotificationConfig\022%.lf." +
-      "a2a.v1.TaskPushNotificationConfig\032%.lf.a" +
-      "2a.v1.TaskPushNotificationConfig\"\200\001\332A\016ta" +
-      "sk_id,config\202\323\344\223\002i\"*/tasks/{task_id=*}/p" +
-      "ushNotificationConfigs:\001*Z8\"3/{tenant}/t" +
-      "asks/{task_id=*}/pushNotificationConfigs" +
-      ":\001*\022\376\001\n\035GetTaskPushNotificationConfig\022/." +
-      "lf.a2a.v1.GetTaskPushNotificationConfigR" +
-      "equest\032%.lf.a2a.v1.TaskPushNotificationC" +
-      "onfig\"\204\001\332A\ntask_id,id\202\323\344\223\002q\0221/tasks/{tas" +
-      "k_id=*}/pushNotificationConfigs/{id=*}Z<" +
-      "\022:/{tenant}/tasks/{task_id=*}/pushNotifi" +
-      "cationConfigs/{id=*}\022\375\001\n\037ListTaskPushNot" +
-      "ificationConfigs\0221.lf.a2a.v1.ListTaskPus" +
-      "hNotificationConfigsRequest\0322.lf.a2a.v1." +
-      "ListTaskPushNotificationConfigsResponse\"" +
-      "s\332A\007task_id\202\323\344\223\002c\022*/tasks/{task_id=*}/pu" +
-      "shNotificationConfigsZ5\0223/{tenant}/tasks" +
-      "/{task_id=*}/pushNotificationConfigs\022\217\001\n" +
-      "\024GetExtendedAgentCard\022&.lf.a2a.v1.GetExt" +
-      "endedAgentCardRequest\032\024.lf.a2a.v1.AgentC" +
-      "ard\"9\202\323\344\223\0023\022\022/extendedAgentCardZ\035\022\033/{ten" +
-      "ant}/extendedAgentCard\022\365\001\n DeleteTaskPus" +
-      "hNotificationConfig\0222.lf.a2a.v1.DeleteTa" +
-      "skPushNotificationConfigRequest\032\026.google" +
-      ".protobuf.Empty\"\204\001\332A\ntask_id,id\202\323\344\223\002q*1/" +
+      "\300\001\n\032ClientCredentialsOAuthFlow\022\026\n\ttoken_" +
+      "url\030\001 \001(\tB\003\340A\002\022\023\n\013refresh_url\030\002 \001(\t\022F\n\006s" +
+      "copes\030\003 \003(\01321.lf.a2a.v1.ClientCredential" +
+      "sOAuthFlow.ScopesEntryB\003\340A\002\032-\n\013ScopesEnt" +
+      "ry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\254\001\n\021I" +
+      "mplicitOAuthFlow\022\031\n\021authorization_url\030\001 " +
+      "\001(\t\022\023\n\013refresh_url\030\002 \001(\t\0228\n\006scopes\030\003 \003(\013" +
+      "2(.lf.a2a.v1.ImplicitOAuthFlow.ScopesEnt" +
+      "ry\032-\n\013ScopesEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030" +
+      "\002 \001(\t:\0028\001\"\244\001\n\021PasswordOAuthFlow\022\021\n\ttoken" +
+      "_url\030\001 \001(\t\022\023\n\013refresh_url\030\002 \001(\t\0228\n\006scope" +
+      "s\030\003 \003(\0132(.lf.a2a.v1.PasswordOAuthFlow.Sc" +
+      "opesEntry\032-\n\013ScopesEntry\022\013\n\003key\030\001 \001(\t\022\r\n" +
+      "\005value\030\002 \001(\t:\0028\001\"\331\001\n\023DeviceCodeOAuthFlow" +
+      "\022%\n\030device_authorization_url\030\001 \001(\tB\003\340A\002\022" +
+      "\026\n\ttoken_url\030\002 \001(\tB\003\340A\002\022\023\n\013refresh_url\030\003" +
+      " \001(\t\022?\n\006scopes\030\004 \003(\0132*.lf.a2a.v1.DeviceC" +
+      "odeOAuthFlow.ScopesEntryB\003\340A\002\032-\n\013ScopesE" +
+      "ntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\265\001\n" +
+      "\022SendMessageRequest\022\016\n\006tenant\030\001 \001(\t\022(\n\007m" +
+      "essage\030\002 \001(\0132\022.lf.a2a.v1.MessageB\003\340A\002\022:\n" +
+      "\rconfiguration\030\003 \001(\0132#.lf.a2a.v1.SendMes" +
+      "sageConfiguration\022)\n\010metadata\030\004 \001(\0132\027.go" +
+      "ogle.protobuf.Struct\"a\n\016GetTaskRequest\022\016" +
+      "\n\006tenant\030\001 \001(\t\022\017\n\002id\030\002 \001(\tB\003\340A\002\022\033\n\016histo" +
+      "ry_length\030\003 \001(\005H\000\210\001\001B\021\n\017_history_length\"" +
+      "\270\002\n\020ListTasksRequest\022\016\n\006tenant\030\001 \001(\t\022\022\n\n" +
+      "context_id\030\002 \001(\t\022$\n\006status\030\003 \001(\0162\024.lf.a2" +
+      "a.v1.TaskState\022\026\n\tpage_size\030\004 \001(\005H\000\210\001\001\022\022" +
+      "\n\npage_token\030\005 \001(\t\022\033\n\016history_length\030\006 \001" +
+      "(\005H\001\210\001\001\022:\n\026status_timestamp_after\030\007 \001(\0132" +
+      "\032.google.protobuf.Timestamp\022\036\n\021include_a" +
+      "rtifacts\030\010 \001(\010H\002\210\001\001B\014\n\n_page_sizeB\021\n\017_hi" +
+      "story_lengthB\024\n\022_include_artifacts\"\207\001\n\021L" +
+      "istTasksResponse\022#\n\005tasks\030\001 \003(\0132\017.lf.a2a" +
+      ".v1.TaskB\003\340A\002\022\034\n\017next_page_token\030\002 \001(\tB\003" +
+      "\340A\002\022\026\n\tpage_size\030\003 \001(\005B\003\340A\002\022\027\n\ntotal_siz" +
+      "e\030\004 \001(\005B\003\340A\002\"_\n\021CancelTaskRequest\022\016\n\006ten" +
+      "ant\030\001 \001(\t\022\017\n\002id\030\002 \001(\tB\003\340A\002\022)\n\010metadata\030\003" +
+      " \001(\0132\027.google.protobuf.Struct\"]\n$GetTask" +
+      "PushNotificationConfigRequest\022\016\n\006tenant\030" +
+      "\001 \001(\t\022\024\n\007task_id\030\002 \001(\tB\003\340A\002\022\017\n\002id\030\003 \001(\tB" +
+      "\003\340A\002\"`\n\'DeleteTaskPushNotificationConfig" +
+      "Request\022\016\n\006tenant\030\001 \001(\t\022\024\n\007task_id\030\002 \001(\t" +
+      "B\003\340A\002\022\017\n\002id\030\003 \001(\tB\003\340A\002\"9\n\026SubscribeToTas" +
+      "kRequest\022\016\n\006tenant\030\001 \001(\t\022\017\n\002id\030\002 \001(\tB\003\340A" +
+      "\002\"u\n&ListTaskPushNotificationConfigsRequ" +
+      "est\022\016\n\006tenant\030\004 \001(\t\022\024\n\007task_id\030\001 \001(\tB\003\340A" +
+      "\002\022\021\n\tpage_size\030\002 \001(\005\022\022\n\npage_token\030\003 \001(\t" +
+      "\"-\n\033GetExtendedAgentCardRequest\022\016\n\006tenan" +
+      "t\030\001 \001(\t\"h\n\023SendMessageResponse\022\037\n\004task\030\001" +
+      " \001(\0132\017.lf.a2a.v1.TaskH\000\022%\n\007message\030\002 \001(\013" +
+      "2\022.lf.a2a.v1.MessageH\000B\t\n\007payload\"\335\001\n\016St" +
+      "reamResponse\022\037\n\004task\030\001 \001(\0132\017.lf.a2a.v1.T" +
+      "askH\000\022%\n\007message\030\002 \001(\0132\022.lf.a2a.v1.Messa" +
+      "geH\000\0229\n\rstatus_update\030\003 \001(\0132 .lf.a2a.v1." +
+      "TaskStatusUpdateEventH\000\022=\n\017artifact_upda" +
+      "te\030\004 \001(\0132\".lf.a2a.v1.TaskArtifactUpdateE" +
+      "ventH\000B\t\n\007payload\"z\n\'ListTaskPushNotific" +
+      "ationConfigsResponse\0226\n\007configs\030\001 \003(\0132%." +
+      "lf.a2a.v1.TaskPushNotificationConfig\022\027\n\017" +
+      "next_page_token\030\002 \001(\t*\371\001\n\tTaskState\022\032\n\026T" +
+      "ASK_STATE_UNSPECIFIED\020\000\022\030\n\024TASK_STATE_SU" +
+      "BMITTED\020\001\022\026\n\022TASK_STATE_WORKING\020\002\022\030\n\024TAS" +
+      "K_STATE_COMPLETED\020\003\022\025\n\021TASK_STATE_FAILED" +
+      "\020\004\022\027\n\023TASK_STATE_CANCELED\020\005\022\035\n\031TASK_STAT" +
+      "E_INPUT_REQUIRED\020\006\022\027\n\023TASK_STATE_REJECTE" +
+      "D\020\007\022\034\n\030TASK_STATE_AUTH_REQUIRED\020\010*;\n\004Rol" +
+      "e\022\024\n\020ROLE_UNSPECIFIED\020\000\022\r\n\tROLE_USER\020\001\022\016" +
+      "\n\nROLE_AGENT\020\0022\227\017\n\nA2AService\022\203\001\n\013SendMe" +
+      "ssage\022\035.lf.a2a.v1.SendMessageRequest\032\036.l" +
+      "f.a2a.v1.SendMessageResponse\"5\202\323\344\223\002/\"\r/m" +
+      "essage:send:\001*Z\033\"\026/{tenant}/message:send" +
+      ":\001*\022\215\001\n\024SendStreamingMessage\022\035.lf.a2a.v1" +
+      ".SendMessageRequest\032\031.lf.a2a.v1.StreamRe" +
+      "sponse\"9\202\323\344\223\0023\"\017/message:stream:\001*Z\035\"\030/{" +
+      "tenant}/message:stream:\001*0\001\022k\n\007GetTask\022\031" +
+      ".lf.a2a.v1.GetTaskRequest\032\017.lf.a2a.v1.Ta" +
+      "sk\"4\332A\002id\202\323\344\223\002)\022\r/tasks/{id=*}Z\030\022\026/{tena" +
+      "nt}/tasks/{id=*}\022i\n\tListTasks\022\033.lf.a2a.v" +
+      "1.ListTasksRequest\032\034.lf.a2a.v1.ListTasks" +
+      "Response\"!\202\323\344\223\002\033\022\006/tasksZ\021\022\017/{tenant}/ta" +
+      "sks\022\200\001\n\nCancelTask\022\034.lf.a2a.v1.CancelTas" +
+      "kRequest\032\017.lf.a2a.v1.Task\"C\202\323\344\223\002=\"\024/task" +
+      "s/{id=*}:cancel:\001*Z\"\"\035/{tenant}/tasks/{i" +
+      "d=*}:cancel:\001*\022\226\001\n\017SubscribeToTask\022!.lf." +
+      "a2a.v1.SubscribeToTaskRequest\032\031.lf.a2a.v" +
+      "1.StreamResponse\"C\202\323\344\223\002=\022\027/tasks/{id=*}:" +
+      "subscribeZ\"\022 /{tenant}/tasks/{id=*}:subs" +
+      "cribe0\001\022\363\001\n CreateTaskPushNotificationCo" +
+      "nfig\022%.lf.a2a.v1.TaskPushNotificationCon" +
+      "fig\032%.lf.a2a.v1.TaskPushNotificationConf" +
+      "ig\"\200\001\332A\016task_id,config\202\323\344\223\002i\"*/tasks/{ta" +
+      "sk_id=*}/pushNotificationConfigs:\001*Z8\"3/" +
+      "{tenant}/tasks/{task_id=*}/pushNotificat" +
+      "ionConfigs:\001*\022\376\001\n\035GetTaskPushNotificatio" +
+      "nConfig\022/.lf.a2a.v1.GetTaskPushNotificat" +
+      "ionConfigRequest\032%.lf.a2a.v1.TaskPushNot" +
+      "ificationConfig\"\204\001\332A\ntask_id,id\202\323\344\223\002q\0221/" +
       "tasks/{task_id=*}/pushNotificationConfig" +
-      "s/{id=*}Z<*:/{tenant}/tasks/{task_id=*}/" +
-      "pushNotificationConfigs/{id=*}B=\n\013io.a2a" +
-      ".grpcB\003A2AP\001Z\033google.golang.org/lf/a2a/v" +
-      "1\252\002\tLf.A2a.V1b\006proto3"
+      "s/{id=*}Z<\022:/{tenant}/tasks/{task_id=*}/" +
+      "pushNotificationConfigs/{id=*}\022\375\001\n\037ListT" +
+      "askPushNotificationConfigs\0221.lf.a2a.v1.L" +
+      "istTaskPushNotificationConfigsRequest\0322." +
+      "lf.a2a.v1.ListTaskPushNotificationConfig" +
+      "sResponse\"s\332A\007task_id\202\323\344\223\002c\022*/tasks/{tas" +
+      "k_id=*}/pushNotificationConfigsZ5\0223/{ten" +
+      "ant}/tasks/{task_id=*}/pushNotificationC" +
+      "onfigs\022\217\001\n\024GetExtendedAgentCard\022&.lf.a2a" +
+      ".v1.GetExtendedAgentCardRequest\032\024.lf.a2a" +
+      ".v1.AgentCard\"9\202\323\344\223\0023\022\022/extendedAgentCar" +
+      "dZ\035\022\033/{tenant}/extendedAgentCard\022\365\001\n Del" +
+      "eteTaskPushNotificationConfig\0222.lf.a2a.v" +
+      "1.DeleteTaskPushNotificationConfigReques" +
+      "t\032\026.google.protobuf.Empty\"\204\001\332A\ntask_id,i" +
+      "d\202\323\344\223\002q*1/tasks/{task_id=*}/pushNotifica" +
+      "tionConfigs/{id=*}Z<*:/{tenant}/tasks/{t" +
+      "ask_id=*}/pushNotificationConfigs/{id=*}" +
+      "B=\n\013io.a2a.grpcB\003A2AP\001Z\033google.golang.or" +
+      "g/lf/a2a/v1\252\002\tLf.A2a.V1b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -553,7 +553,7 @@ public final class A2A extends com.google.protobuf.GeneratedFile {
     internal_static_lf_a2a_v1_SendMessageConfiguration_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_lf_a2a_v1_SendMessageConfiguration_descriptor,
-        new java.lang.String[] { "AcceptedOutputModes", "TaskPushNotificationConfig", "HistoryLength", "Blocking", });
+        new java.lang.String[] { "AcceptedOutputModes", "TaskPushNotificationConfig", "HistoryLength", "ReturnImmediately", });
     internal_static_lf_a2a_v1_Task_descriptor =
       getDescriptor().getMessageType(1);
     internal_static_lf_a2a_v1_Task_fieldAccessorTable = new

--- a/spec-grpc/src/main/java/io/a2a/grpc/OAuthFlows.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/OAuthFlows.java
@@ -189,7 +189,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.lf.a2a.v1.ImplicitOAuthFlow implicit = 3 [deprecated = true];</code>
    * @deprecated lf.a2a.v1.OAuthFlows.implicit is deprecated.
-   *     See a2a.proto;l=567
+   *     See a2a.proto;l=569
    * @return Whether the implicit field is set.
    */
   @java.lang.Override
@@ -203,7 +203,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.lf.a2a.v1.ImplicitOAuthFlow implicit = 3 [deprecated = true];</code>
    * @deprecated lf.a2a.v1.OAuthFlows.implicit is deprecated.
-   *     See a2a.proto;l=567
+   *     See a2a.proto;l=569
    * @return The implicit.
    */
   @java.lang.Override
@@ -236,7 +236,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.lf.a2a.v1.PasswordOAuthFlow password = 4 [deprecated = true];</code>
    * @deprecated lf.a2a.v1.OAuthFlows.password is deprecated.
-   *     See a2a.proto;l=569
+   *     See a2a.proto;l=571
    * @return Whether the password field is set.
    */
   @java.lang.Override
@@ -250,7 +250,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.lf.a2a.v1.PasswordOAuthFlow password = 4 [deprecated = true];</code>
    * @deprecated lf.a2a.v1.OAuthFlows.password is deprecated.
-   *     See a2a.proto;l=569
+   *     See a2a.proto;l=571
    * @return The password.
    */
   @java.lang.Override
@@ -1159,7 +1159,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.lf.a2a.v1.ImplicitOAuthFlow implicit = 3 [deprecated = true];</code>
      * @deprecated lf.a2a.v1.OAuthFlows.implicit is deprecated.
-     *     See a2a.proto;l=567
+     *     See a2a.proto;l=569
      * @return Whether the implicit field is set.
      */
     @java.lang.Override
@@ -1173,7 +1173,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.lf.a2a.v1.ImplicitOAuthFlow implicit = 3 [deprecated = true];</code>
      * @deprecated lf.a2a.v1.OAuthFlows.implicit is deprecated.
-     *     See a2a.proto;l=567
+     *     See a2a.proto;l=569
      * @return The implicit.
      */
     @java.lang.Override
@@ -1341,7 +1341,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.lf.a2a.v1.PasswordOAuthFlow password = 4 [deprecated = true];</code>
      * @deprecated lf.a2a.v1.OAuthFlows.password is deprecated.
-     *     See a2a.proto;l=569
+     *     See a2a.proto;l=571
      * @return Whether the password field is set.
      */
     @java.lang.Override
@@ -1355,7 +1355,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.lf.a2a.v1.PasswordOAuthFlow password = 4 [deprecated = true];</code>
      * @deprecated lf.a2a.v1.OAuthFlows.password is deprecated.
-     *     See a2a.proto;l=569
+     *     See a2a.proto;l=571
      * @return The password.
      */
     @java.lang.Override

--- a/spec-grpc/src/main/java/io/a2a/grpc/OAuthFlowsOrBuilder.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/OAuthFlowsOrBuilder.java
@@ -71,7 +71,7 @@ public interface OAuthFlowsOrBuilder extends
    *
    * <code>.lf.a2a.v1.ImplicitOAuthFlow implicit = 3 [deprecated = true];</code>
    * @deprecated lf.a2a.v1.OAuthFlows.implicit is deprecated.
-   *     See a2a.proto;l=567
+   *     See a2a.proto;l=569
    * @return Whether the implicit field is set.
    */
   @java.lang.Deprecated boolean hasImplicit();
@@ -82,7 +82,7 @@ public interface OAuthFlowsOrBuilder extends
    *
    * <code>.lf.a2a.v1.ImplicitOAuthFlow implicit = 3 [deprecated = true];</code>
    * @deprecated lf.a2a.v1.OAuthFlows.implicit is deprecated.
-   *     See a2a.proto;l=567
+   *     See a2a.proto;l=569
    * @return The implicit.
    */
   @java.lang.Deprecated io.a2a.grpc.ImplicitOAuthFlow getImplicit();
@@ -102,7 +102,7 @@ public interface OAuthFlowsOrBuilder extends
    *
    * <code>.lf.a2a.v1.PasswordOAuthFlow password = 4 [deprecated = true];</code>
    * @deprecated lf.a2a.v1.OAuthFlows.password is deprecated.
-   *     See a2a.proto;l=569
+   *     See a2a.proto;l=571
    * @return Whether the password field is set.
    */
   @java.lang.Deprecated boolean hasPassword();
@@ -113,7 +113,7 @@ public interface OAuthFlowsOrBuilder extends
    *
    * <code>.lf.a2a.v1.PasswordOAuthFlow password = 4 [deprecated = true];</code>
    * @deprecated lf.a2a.v1.OAuthFlows.password is deprecated.
-   *     See a2a.proto;l=569
+   *     See a2a.proto;l=571
    * @return The password.
    */
   @java.lang.Deprecated io.a2a.grpc.PasswordOAuthFlow getPassword();

--- a/spec-grpc/src/main/java/io/a2a/grpc/SendMessageConfiguration.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/SendMessageConfiguration.java
@@ -181,21 +181,23 @@ private static final long serialVersionUID = 0L;
     return historyLength_;
   }
 
-  public static final int BLOCKING_FIELD_NUMBER = 4;
-  private boolean blocking_ = false;
+  public static final int RETURN_IMMEDIATELY_FIELD_NUMBER = 4;
+  private boolean returnImmediately_ = false;
   /**
    * <pre>
-   * If `true`, the operation MUST wait until the task reaches a terminal state
-   * (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or an interrupted state
-   * (`INPUT_REQUIRED`, `AUTH_REQUIRED`) before returning. Default is `false`.
+   * If `true`, the operation returns immediately after creating the task,
+   * even if processing is still in progress.
+   * If `false` (default), the operation MUST wait until the task reaches a
+   * terminal (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or interrupted
+   * (`INPUT_REQUIRED`, `AUTH_REQUIRED`) state before returning.
    * </pre>
    *
-   * <code>bool blocking = 4;</code>
-   * @return The blocking.
+   * <code>bool return_immediately = 4;</code>
+   * @return The returnImmediately.
    */
   @java.lang.Override
-  public boolean getBlocking() {
-    return blocking_;
+  public boolean getReturnImmediately() {
+    return returnImmediately_;
   }
 
   private byte memoizedIsInitialized = -1;
@@ -221,8 +223,8 @@ private static final long serialVersionUID = 0L;
     if (((bitField0_ & 0x00000002) != 0)) {
       output.writeInt32(3, historyLength_);
     }
-    if (blocking_ != false) {
-      output.writeBool(4, blocking_);
+    if (returnImmediately_ != false) {
+      output.writeBool(4, returnImmediately_);
     }
     getUnknownFields().writeTo(output);
   }
@@ -249,9 +251,9 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
         .computeInt32Size(3, historyLength_);
     }
-    if (blocking_ != false) {
+    if (returnImmediately_ != false) {
       size += com.google.protobuf.CodedOutputStream
-        .computeBoolSize(4, blocking_);
+        .computeBoolSize(4, returnImmediately_);
     }
     size += getUnknownFields().getSerializedSize();
     memoizedSize = size;
@@ -280,8 +282,8 @@ private static final long serialVersionUID = 0L;
       if (getHistoryLength()
           != other.getHistoryLength()) return false;
     }
-    if (getBlocking()
-        != other.getBlocking()) return false;
+    if (getReturnImmediately()
+        != other.getReturnImmediately()) return false;
     if (!getUnknownFields().equals(other.getUnknownFields())) return false;
     return true;
   }
@@ -305,9 +307,9 @@ private static final long serialVersionUID = 0L;
       hash = (37 * hash) + HISTORY_LENGTH_FIELD_NUMBER;
       hash = (53 * hash) + getHistoryLength();
     }
-    hash = (37 * hash) + BLOCKING_FIELD_NUMBER;
+    hash = (37 * hash) + RETURN_IMMEDIATELY_FIELD_NUMBER;
     hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
-        getBlocking());
+        getReturnImmediately());
     hash = (29 * hash) + getUnknownFields().hashCode();
     memoizedHashCode = hash;
     return hash;
@@ -457,7 +459,7 @@ private static final long serialVersionUID = 0L;
         taskPushNotificationConfigBuilder_ = null;
       }
       historyLength_ = 0;
-      blocking_ = false;
+      returnImmediately_ = false;
       return this;
     }
 
@@ -507,7 +509,7 @@ private static final long serialVersionUID = 0L;
         to_bitField0_ |= 0x00000002;
       }
       if (((from_bitField0_ & 0x00000008) != 0)) {
-        result.blocking_ = blocking_;
+        result.returnImmediately_ = returnImmediately_;
       }
       result.bitField0_ |= to_bitField0_;
     }
@@ -540,8 +542,8 @@ private static final long serialVersionUID = 0L;
       if (other.hasHistoryLength()) {
         setHistoryLength(other.getHistoryLength());
       }
-      if (other.getBlocking() != false) {
-        setBlocking(other.getBlocking());
+      if (other.getReturnImmediately() != false) {
+        setReturnImmediately(other.getReturnImmediately());
       }
       this.mergeUnknownFields(other.getUnknownFields());
       onChanged();
@@ -588,7 +590,7 @@ private static final long serialVersionUID = 0L;
               break;
             } // case 24
             case 32: {
-              blocking_ = input.readBool();
+              returnImmediately_ = input.readBool();
               bitField0_ |= 0x00000008;
               break;
             } // case 32
@@ -999,52 +1001,58 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-    private boolean blocking_ ;
+    private boolean returnImmediately_ ;
     /**
      * <pre>
-     * If `true`, the operation MUST wait until the task reaches a terminal state
-     * (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or an interrupted state
-     * (`INPUT_REQUIRED`, `AUTH_REQUIRED`) before returning. Default is `false`.
+     * If `true`, the operation returns immediately after creating the task,
+     * even if processing is still in progress.
+     * If `false` (default), the operation MUST wait until the task reaches a
+     * terminal (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or interrupted
+     * (`INPUT_REQUIRED`, `AUTH_REQUIRED`) state before returning.
      * </pre>
      *
-     * <code>bool blocking = 4;</code>
-     * @return The blocking.
+     * <code>bool return_immediately = 4;</code>
+     * @return The returnImmediately.
      */
     @java.lang.Override
-    public boolean getBlocking() {
-      return blocking_;
+    public boolean getReturnImmediately() {
+      return returnImmediately_;
     }
     /**
      * <pre>
-     * If `true`, the operation MUST wait until the task reaches a terminal state
-     * (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or an interrupted state
-     * (`INPUT_REQUIRED`, `AUTH_REQUIRED`) before returning. Default is `false`.
+     * If `true`, the operation returns immediately after creating the task,
+     * even if processing is still in progress.
+     * If `false` (default), the operation MUST wait until the task reaches a
+     * terminal (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or interrupted
+     * (`INPUT_REQUIRED`, `AUTH_REQUIRED`) state before returning.
      * </pre>
      *
-     * <code>bool blocking = 4;</code>
-     * @param value The blocking to set.
+     * <code>bool return_immediately = 4;</code>
+     * @param value The returnImmediately to set.
      * @return This builder for chaining.
      */
-    public Builder setBlocking(boolean value) {
+    public Builder setReturnImmediately(boolean value) {
 
-      blocking_ = value;
+      returnImmediately_ = value;
       bitField0_ |= 0x00000008;
       onChanged();
       return this;
     }
     /**
      * <pre>
-     * If `true`, the operation MUST wait until the task reaches a terminal state
-     * (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or an interrupted state
-     * (`INPUT_REQUIRED`, `AUTH_REQUIRED`) before returning. Default is `false`.
+     * If `true`, the operation returns immediately after creating the task,
+     * even if processing is still in progress.
+     * If `false` (default), the operation MUST wait until the task reaches a
+     * terminal (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or interrupted
+     * (`INPUT_REQUIRED`, `AUTH_REQUIRED`) state before returning.
      * </pre>
      *
-     * <code>bool blocking = 4;</code>
+     * <code>bool return_immediately = 4;</code>
      * @return This builder for chaining.
      */
-    public Builder clearBlocking() {
+    public Builder clearReturnImmediately() {
       bitField0_ = (bitField0_ & ~0x00000008);
-      blocking_ = false;
+      returnImmediately_ = false;
       onChanged();
       return this;
     }

--- a/spec-grpc/src/main/java/io/a2a/grpc/SendMessageConfigurationOrBuilder.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/SendMessageConfigurationOrBuilder.java
@@ -112,13 +112,15 @@ public interface SendMessageConfigurationOrBuilder extends
 
   /**
    * <pre>
-   * If `true`, the operation MUST wait until the task reaches a terminal state
-   * (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or an interrupted state
-   * (`INPUT_REQUIRED`, `AUTH_REQUIRED`) before returning. Default is `false`.
+   * If `true`, the operation returns immediately after creating the task,
+   * even if processing is still in progress.
+   * If `false` (default), the operation MUST wait until the task reaches a
+   * terminal (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or interrupted
+   * (`INPUT_REQUIRED`, `AUTH_REQUIRED`) state before returning.
    * </pre>
    *
-   * <code>bool blocking = 4;</code>
-   * @return The blocking.
+   * <code>bool return_immediately = 4;</code>
+   * @return The returnImmediately.
    */
-  boolean getBlocking();
+  boolean getReturnImmediately();
 }

--- a/spec-grpc/src/main/proto/a2a.proto
+++ b/spec-grpc/src/main/proto/a2a.proto
@@ -9,7 +9,7 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
-// From commit dec790a
+// From commit 601c408
 
 option csharp_namespace = "Lf.A2a.V1";
 option go_package = "google.golang.org/lf/a2a/v1";
@@ -154,10 +154,12 @@ message SendMessageConfiguration {
   // value of zero is a request to not include any messages. The server MUST NOT
   // return more messages than the provided value, but MAY apply a lower limit.
   optional int32 history_length = 3;
-  // If `true`, the operation MUST wait until the task reaches a terminal state
-  // (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or an interrupted state
-  // (`INPUT_REQUIRED`, `AUTH_REQUIRED`) before returning. Default is `false`.
-  bool blocking = 4;
+  // If `true`, the operation returns immediately after creating the task,
+  // even if processing is still in progress.
+  // If `false` (default), the operation MUST wait until the task reaches a
+  // terminal (`COMPLETED`, `FAILED`, `CANCELED`, `REJECTED`) or interrupted
+  // (`INPUT_REQUIRED`, `AUTH_REQUIRED`) state before returning.
+  bool return_immediately = 4;
 }
 
 // `Task` is the core unit of action for A2A. It has a current status

--- a/spec-grpc/src/test/java/io/a2a/grpc/mapper/A2ACommonFieldMapperTest.java
+++ b/spec-grpc/src/test/java/io/a2a/grpc/mapper/A2ACommonFieldMapperTest.java
@@ -57,7 +57,7 @@ public class A2ACommonFieldMapperTest {
                 "    }\n" +
                 "  },\n" +
                 "  \"configuration\": {\n" +
-                "    \"blocking\": true\n" +
+                "    \"returnImmediately\": false\n" +
                 "  },\n" +
                 "  \"metadata\": {\n" +
                 "  }\n" +

--- a/spec-grpc/src/test/java/io/a2a/grpc/utils/ToProtoTest.java
+++ b/spec-grpc/src/test/java/io/a2a/grpc/utils/ToProtoTest.java
@@ -278,7 +278,7 @@ public class ToProtoTest {
                 .acceptedOutputModes(List.of("text"))
                 .build();
         SendMessageConfiguration result = ProtoUtils.ToProto.messageSendConfiguration(configuration);
-        assertFalse(result.getBlocking());
+        assertFalse(result.getReturnImmediately());
         assertEquals(1, result.getAcceptedOutputModesCount());
         assertEquals("text", result.getAcceptedOutputModesBytes(0).toStringUtf8());
     }

--- a/spec/src/main/java/io/a2a/spec/MessageSendConfiguration.java
+++ b/spec/src/main/java/io/a2a/spec/MessageSendConfiguration.java
@@ -9,7 +9,7 @@ import org.jspecify.annotations.Nullable;
  * Configuration options for {@code message/send} and {@code message/stream} requests.
  * <p>
  * This record defines how the agent should process a message request, including output format
- * preferences, conversation history context, push notification settings, and blocking behavior.
+ * preferences, conversation history context, push notification settings, and return behavior.
  * <p>
  * All fields are optional and have sensible defaults when not specified.
  *
@@ -17,13 +17,13 @@ import org.jspecify.annotations.Nullable;
  * @param historyLength number of previous messages to include in conversation context (must be non-negative)
  * @param taskPushNotificationConfig configuration for asynchronous push notifications when task state changes.
  *        Task id should be empty when sending this configuration in a SendMessage request.
- * @param blocking whether the request should block until task completion (defaults to false)
+ * @param returnImmediately whether the operation should return immediately after creating the task (defaults to false)
  * @see MessageSendParams for the parameters that use this configuration
  * @see TaskPushNotificationConfig for push notification options
  * @see <a href="https://a2a-protocol.org/latest/">A2A Protocol Specification</a>
  */
 public record MessageSendConfiguration(@Nullable List<String> acceptedOutputModes, @Nullable Integer historyLength,
-        @Nullable TaskPushNotificationConfig taskPushNotificationConfig, Boolean blocking) {
+        @Nullable TaskPushNotificationConfig taskPushNotificationConfig, Boolean returnImmediately) {
 
     /**
      * Compact constructor for validation.
@@ -32,7 +32,7 @@ public record MessageSendConfiguration(@Nullable List<String> acceptedOutputMode
      * @param acceptedOutputModes list of accepted output modes
      * @param historyLength maximum number of history items
      * @param taskPushNotificationConfig push notification configuration
-     * @param blocking whether the request should block
+     * @param returnImmediately whether to return immediately
      * @throws IllegalArgumentException if historyLength is negative
      */
     public MessageSendConfiguration {
@@ -60,7 +60,7 @@ public record MessageSendConfiguration(@Nullable List<String> acceptedOutputMode
         @Nullable List<String> acceptedOutputModes;
         @Nullable Integer historyLength;
         @Nullable TaskPushNotificationConfig taskPushNotificationConfig;
-        Boolean blocking = false;
+        Boolean returnImmediately = false;
 
         /**
          * Creates a new Builder with all fields unset.
@@ -107,13 +107,13 @@ public record MessageSendConfiguration(@Nullable List<String> acceptedOutputMode
         }
 
         /**
-         * Sets whether the request should block until completion.
+         * Sets whether the operation should return immediately after creating the task.
          *
-         * @param blocking true to block until task completes, false for fire-and-forget
+         * @param returnImmediately true to return immediately, false to wait for task completion
          * @return this builder
          */
-        public Builder blocking(@NonNull Boolean blocking) {
-            this.blocking = blocking;
+        public Builder returnImmediately(@NonNull Boolean returnImmediately) {
+            this.returnImmediately = returnImmediately;
             return this;
         }
 
@@ -127,7 +127,7 @@ public record MessageSendConfiguration(@Nullable List<String> acceptedOutputMode
                     acceptedOutputModes,
                     historyLength,
                     taskPushNotificationConfig,
-                    blocking);
+                    returnImmediately);
         }
     }
 }

--- a/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
@@ -2348,7 +2348,7 @@ public abstract class AbstractA2AServerTest {
         AgentCard agentCard = createTestAgentCard();
         ClientConfig clientConfig = new ClientConfig.Builder()
                 .setStreaming(false) // Non-streaming
-                .setPolling(true) // Polling mode (translates to blocking=false on server)
+                .setPolling(true) // Polling mode (translates to returnImmediately=true on server)
                 .build();
 
         ClientBuilder clientBuilder = Client

--- a/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -96,7 +96,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
     private static MessageSendConfiguration defaultConfiguration() {
         return MessageSendConfiguration.builder()
                 .acceptedOutputModes(List.of())
-                .blocking(false)
+                .returnImmediately(true)
                 .build();
     }
 

--- a/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
+++ b/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
@@ -104,7 +104,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
               },
               "configuration":
                 {
-                  "blocking": true
+                  "returnImmediately": false
               }
             }""";
 
@@ -557,7 +557,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
                 "metadata": {}
               },
               "configuration": {
-                "blocking": true
+                "returnImmediately": false
               }
             }""";
 
@@ -706,7 +706,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
                 "metadata": {}
               },
               "configuration": {
-                "blocking": true
+                "returnImmediately": false
               }
             }""";
 
@@ -757,7 +757,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
                 "metadata": {}
               },
               "configuration": {
-                "blocking": true
+                "returnImmediately": false
               }
             }""";
 
@@ -900,7 +900,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
                 "metadata": {}
               },
               "configuration": {
-                "blocking": true
+                "returnImmediately": false
               }
             }""";
 
@@ -948,7 +948,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
                 "metadata": {}
               },
               "configuration": {
-                "blocking": true
+                "returnImmediately": false
               }
             }""";
 


### PR DESCRIPTION
Sync a2a.proto with upstream (dec790a -> 601c408).

The `blocking` field in `SendMessageConfiguration` has been renamed to `return_immediately` with inverted semantics:
- `blocking=true` (wait) -> `returnImmediately=false`
- `blocking=false` (return immediately) -> `returnImmediately=true`

The default behavior changed: `false` now means "wait for completion" instead of "return immediately".

BREAKING CHANGE: `MessageSendConfiguration.blocking()` renamed to `returnImmediately()`. Builder method `.blocking(boolean)` renamed to `.returnImmediately(boolean)` with inverted value. JSON wire format field changed from `"blocking"` to `"returnImmediately"`.