### PR TITLE
fix: reject messages with mismatching contextId and taskId

### DIFF
--- a/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
@@ -1027,6 +1027,13 @@ public class DefaultRequestHandler implements RequestHandler {
         Task task = taskManager.getTask();
         if (task != null) {
             LOGGER.debug("Found task updating with message {}", params.message());
+            // Validate contextId matches the existing task's contextId
+            String messageContextId = params.message().contextId();
+            if (messageContextId != null && !messageContextId.isBlank() && !messageContextId.equals(task.contextId())) {
+                throw new InvalidParamsError(String.format(
+                        "Message has a mismatched context ID (Task %s has contextId %s but message has contextId %s)",
+                        task.id(), task.contextId(), messageContextId));
+            }
             task = taskManager.updateWithMessage(params.message(), task);
 
             if (pushConfigStore != null && params.configuration() != null && params.configuration().taskPushNotificationConfig() != null) {

--- a/server-common/src/test/java/io/a2a/server/requesthandlers/DefaultRequestHandlerTest.java
+++ b/server-common/src/test/java/io/a2a/server/requesthandlers/DefaultRequestHandlerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -30,6 +31,7 @@ import io.a2a.server.tasks.TaskStore;
 import io.a2a.spec.A2AError;
 import io.a2a.spec.Event;
 import io.a2a.spec.EventKind;
+import io.a2a.spec.InvalidParamsError;
 import io.a2a.spec.Message;
 import io.a2a.spec.MessageSendConfiguration;
 import io.a2a.spec.MessageSendParams;
@@ -508,5 +510,73 @@ public class DefaultRequestHandlerTest {
         assertEquals(TaskState.TASK_STATE_COMPLETED,
             ((TaskStatusUpdateEvent) completionEvent).status().state(),
             "Task should be completed");
+    }
+
+    /**
+     * Test: Mismatching contextId and taskId on non-streaming send is rejected.
+     * Verifies:
+     * - Sending a message with an existing taskId but a different contextId throws InvalidParamsError
+     */
+    @Test
+    void testContextIdMismatch_NonStreaming_ThrowsInvalidParamsError() throws Exception {
+        // Arrange: Save a task with a known contextId
+        Task existingTask = Task.builder()
+            .id("ctx-mismatch-task-1")
+            .contextId("correct-context-id")
+            .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
+            .build();
+        taskStore.save(existingTask, false);
+
+        // Act & Assert: Send message with correct taskId but wrong contextId
+        Message mismatchMessage = Message.builder()
+            .messageId("mismatch-001")
+            .role(Message.Role.ROLE_USER)
+            .parts(new TextPart("mismatched context test"))
+            .taskId(existingTask.id())
+            .contextId("wrong-context-does-not-exist")
+            .build();
+
+        MessageSendParams mismatchParams = MessageSendParams.builder()
+            .message(mismatchMessage)
+            .configuration(DEFAULT_CONFIG)
+            .build();
+
+        assertThrows(InvalidParamsError.class,
+            () -> requestHandler.onMessageSend(mismatchParams, NULL_CONTEXT),
+            "Should reject message with mismatching contextId and taskId");
+    }
+
+    /**
+     * Test: Mismatching contextId and taskId on streaming send is rejected.
+     * Verifies:
+     * - Sending a streaming message with an existing taskId but a different contextId throws InvalidParamsError
+     */
+    @Test
+    void testContextIdMismatch_Streaming_ThrowsInvalidParamsError() throws Exception {
+        // Arrange: Save a task with a known contextId
+        Task existingTask = Task.builder()
+            .id("ctx-mismatch-task-2")
+            .contextId("correct-context-id")
+            .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
+            .build();
+        taskStore.save(existingTask, false);
+
+        // Act & Assert: Send streaming message with correct taskId but wrong contextId
+        Message mismatchMessage = Message.builder()
+            .messageId("mismatch-002")
+            .role(Message.Role.ROLE_USER)
+            .parts(new TextPart("mismatched context test"))
+            .taskId(existingTask.id())
+            .contextId("wrong-context-does-not-exist")
+            .build();
+
+        MessageSendParams mismatchParams = MessageSendParams.builder()
+            .message(mismatchMessage)
+            .configuration(DEFAULT_CONFIG)
+            .build();
+
+        assertThrows(InvalidParamsError.class,
+            () -> requestHandler.onMessageSendStream(mismatchParams, NULL_CONTEXT),
+            "Should reject streaming message with mismatching contextId and taskId");
     }
 }

--- a/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
@@ -548,6 +548,77 @@ public abstract class AbstractA2AServerTest {
     }
 
     @Test
+    public void testSendMessageContextIdMismatch() throws Exception {
+        saveTaskInTaskStore(MINIMAL_TASK);
+        try {
+            // Send message with existing taskId but wrong contextId
+            Message mismatchMessage = Message.builder(MESSAGE)
+                    .taskId(MINIMAL_TASK.id())
+                    .contextId("wrong-context-does-not-exist")
+                    .build();
+
+            getNonStreamingClient().sendMessage(mismatchMessage);
+            fail("Expected A2AClientException for mismatching contextId and taskId");
+        } catch (A2AClientException e) {
+            assertInstanceOf(InvalidParamsError.class, e.getCause());
+        } finally {
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
+        }
+    }
+
+    @Test
+    public void testSendStreamingMessageContextIdMismatch() throws Exception {
+        saveTaskInTaskStore(MINIMAL_TASK);
+        try {
+            // Send streaming message with existing taskId but wrong contextId
+            Message mismatchMessage = Message.builder(MESSAGE)
+                    .taskId(MINIMAL_TASK.id())
+                    .contextId("wrong-context-does-not-exist")
+                    .build();
+
+            CountDownLatch latch = new CountDownLatch(1);
+            AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+            BiConsumer<ClientEvent, AgentCard> consumer = (event, agentCard) -> {
+                // Should not receive any successful events
+                fail("Should not receive a successful event for mismatching contextId");
+            };
+
+            Consumer<Throwable> errorHandler = error -> {
+                // Only capture non-null errors (null signals stream completion)
+                if (error != null && errorRef.compareAndSet(null, error)) {
+                    latch.countDown();
+                }
+            };
+
+            getClient().sendMessage(mismatchMessage, List.of(consumer), errorHandler);
+
+            assertTrue(latch.await(10, TimeUnit.SECONDS), "Should receive error response");
+
+            Throwable error = errorRef.get();
+            assertNotNull(error, "Should receive an error for mismatching contextId");
+
+            // Walk the cause chain to find InvalidParamsError
+            Throwable cause = error;
+            boolean foundInvalidParams = false;
+            while (cause != null && !foundInvalidParams) {
+                if (cause instanceof InvalidParamsError) {
+                    foundInvalidParams = true;
+                } else if (cause instanceof A2AClientException && cause.getCause() instanceof InvalidParamsError) {
+                    foundInvalidParams = true;
+                }
+                cause = cause.getCause();
+            }
+            assertTrue(foundInvalidParams,
+                    "Should receive InvalidParamsError for mismatching contextId and taskId");
+        } catch (A2AClientException e) {
+            assertInstanceOf(InvalidParamsError.class, e.getCause());
+        } finally {
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
+        }
+    }
+
+    @Test
     public void testSetPushNotificationSuccess() throws Exception {
         saveTaskInTaskStore(MINIMAL_TASK);
         try {

--- a/transport/grpc/src/test/java/io/a2a/transport/grpc/handler/GrpcHandlerTest.java
+++ b/transport/grpc/src/test/java/io/a2a/transport/grpc/handler/GrpcHandlerTest.java
@@ -1236,6 +1236,66 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
         Assertions.assertNotNull(response.getNextPageToken());
     }
 
+    @Test
+    public void testSendMessageContextIdMismatch() throws Exception {
+        GrpcHandler handler = new TestGrpcHandler(AbstractA2ARequestHandlerTest.CARD, requestHandler, internalExecutor);
+        taskStore.save(AbstractA2ARequestHandlerTest.MINIMAL_TASK, false);
+
+        agentExecutorExecute = (context, agentEmitter) -> {
+            agentEmitter.sendMessage(context.getMessage());
+        };
+
+        // Send message with existing taskId but wrong contextId
+        Message mismatchMessage = Message.newBuilder()
+                .setTaskId(AbstractA2ARequestHandlerTest.MINIMAL_TASK.id())
+                .setContextId("wrong-context-does-not-exist")
+                .setMessageId("mismatch-001")
+                .setRole(Role.ROLE_USER)
+                .addParts(Part.newBuilder()
+                        .setText("mismatched context test")
+                        .build())
+                .build();
+
+        SendMessageRequest request = SendMessageRequest.newBuilder()
+                .setMessage(mismatchMessage)
+                .build();
+        StreamRecorder<SendMessageResponse> streamRecorder = StreamRecorder.create();
+        handler.sendMessage(request, streamRecorder);
+        streamRecorder.awaitCompletion(5, TimeUnit.SECONDS);
+
+        assertGrpcError(streamRecorder, Status.Code.INVALID_ARGUMENT);
+    }
+
+    @Test
+    public void testSendStreamingMessageContextIdMismatch() throws Exception {
+        GrpcHandler handler = new TestGrpcHandler(AbstractA2ARequestHandlerTest.CARD, requestHandler, internalExecutor);
+        taskStore.save(AbstractA2ARequestHandlerTest.MINIMAL_TASK, false);
+
+        agentExecutorExecute = (context, agentEmitter) -> {
+            agentEmitter.sendMessage(context.getMessage());
+        };
+
+        // Send streaming message with existing taskId but wrong contextId
+        Message mismatchMessage = Message.newBuilder()
+                .setTaskId(AbstractA2ARequestHandlerTest.MINIMAL_TASK.id())
+                .setContextId("wrong-context-does-not-exist")
+                .setMessageId("mismatch-002")
+                .setRole(Role.ROLE_USER)
+                .addParts(Part.newBuilder()
+                        .setText("mismatched context test")
+                        .build())
+                .build();
+
+        SendMessageRequest request = SendMessageRequest.newBuilder()
+                .setMessage(mismatchMessage)
+                .build();
+        StreamRecorder<StreamResponse> streamRecorder = StreamRecorder.create();
+        handler.sendStreamingMessage(request, streamRecorder);
+        streamRecorder.awaitCompletion(5, TimeUnit.SECONDS);
+
+        assertGrpcError(streamRecorder, Status.Code.INVALID_ARGUMENT);
+    }
+
     private static class TestGrpcHandler extends GrpcHandler {
 
         private final AgentCard card;

--- a/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -60,6 +60,7 @@ import io.a2a.spec.ExtendedAgentCardNotConfiguredError;
 import io.a2a.spec.ExtensionSupportRequiredError;
 import io.a2a.spec.GetTaskPushNotificationConfigParams;
 import io.a2a.spec.InternalError;
+import io.a2a.spec.InvalidParamsError;
 import io.a2a.spec.InvalidRequestError;
 import io.a2a.spec.ListTaskPushNotificationConfigParams;
 import io.a2a.spec.ListTasksParams;
@@ -1349,6 +1350,84 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
         Assertions.assertNull(error.get());
         Assertions.assertEquals(1, results.size());
         Assertions.assertInstanceOf(InternalError.class, results.get(0).getError());
+    }
+
+    @Test
+    public void testOnMessageSendContextIdMismatch() {
+        JSONRPCHandler handler = new JSONRPCHandler(CARD, requestHandler, internalExecutor);
+        taskStore.save(MINIMAL_TASK, false);
+
+        agentExecutorExecute = (context, agentEmitter) -> {
+            agentEmitter.sendMessage(context.getMessage());
+        };
+
+        // Send message with existing taskId but wrong contextId
+        Message mismatchMessage = Message.builder(MESSAGE)
+                .taskId(MINIMAL_TASK.id())
+                .contextId("wrong-context-does-not-exist")
+                .build();
+        SendMessageRequest request = new SendMessageRequest("1",
+                new MessageSendParams(mismatchMessage, defaultConfiguration(), null));
+        SendMessageResponse response = handler.onMessageSend(request, callContext);
+        assertInstanceOf(InvalidParamsError.class, response.getError());
+    }
+
+    @Test
+    public void testOnMessageStreamContextIdMismatch() throws InterruptedException {
+        JSONRPCHandler handler = new JSONRPCHandler(CARD, requestHandler, internalExecutor);
+        taskStore.save(MINIMAL_TASK, false);
+
+        agentExecutorExecute = (context, agentEmitter) -> {
+            agentEmitter.sendMessage(context.getMessage());
+        };
+
+        // Send streaming message with existing taskId but wrong contextId
+        Message mismatchMessage = Message.builder(MESSAGE)
+                .taskId(MINIMAL_TASK.id())
+                .contextId("wrong-context-does-not-exist")
+                .build();
+        SendStreamingMessageRequest request = new SendStreamingMessageRequest("1",
+                new MessageSendParams(mismatchMessage, defaultConfiguration(), null));
+        Flow.Publisher<SendStreamingMessageResponse> response = handler.onMessageSendStream(request, callContext);
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        List<SendStreamingMessageResponse> results = new ArrayList<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        response.subscribe(new Flow.Subscriber<SendStreamingMessageResponse>() {
+            private Flow.Subscription subscription;
+
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                this.subscription = subscription;
+                subscription.request(1);
+            }
+
+            @Override
+            public void onNext(SendStreamingMessageResponse item) {
+                results.add(item);
+                subscription.request(1);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                error.set(throwable);
+                subscription.cancel();
+                future.completeExceptionally(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                subscription.cancel();
+                future.complete(null);
+            }
+        });
+
+        future.join();
+
+        Assertions.assertNull(error.get());
+        Assertions.assertEquals(1, results.size());
+        Assertions.assertInstanceOf(InvalidParamsError.class, results.get(0).getError());
     }
 
     @Test

--- a/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
+++ b/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
@@ -1031,4 +1031,101 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         Assertions.assertTrue(body.contains("\"tasks\":[]") || body.contains("\"tasks\": []"),
                 "tasks should be empty array");
     }
+
+    @Test
+    public void testSendMessageContextIdMismatch() {
+        RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
+        taskStore.save(MINIMAL_TASK, false);
+
+        agentExecutorExecute = (context, agentEmitter) -> {
+            agentEmitter.sendMessage(context.getMessage());
+        };
+
+        // Send message with existing taskId but wrong contextId
+        String mismatchBody = """
+            {
+              "message": {
+                "messageId": "mismatch-001",
+                "role": "ROLE_USER",
+                "parts": [{"text": "mismatched context test"}],
+                "taskId": "%s",
+                "contextId": "wrong-context-does-not-exist"
+              },
+              "configuration": {
+                "returnImmediately": false
+              }
+            }""".formatted(MINIMAL_TASK.id());
+        RestHandler.HTTPRestResponse mismatchResponse = handler.sendMessage(callContext, "", mismatchBody);
+
+        Assertions.assertEquals(422, mismatchResponse.getStatusCode());
+        Assertions.assertEquals("application/problem+json", mismatchResponse.getContentType());
+        Assertions.assertTrue(mismatchResponse.getBody().contains("InvalidParamsError"));
+    }
+
+    @Test
+    public void testSendStreamingMessageContextIdMismatch() {
+        RestHandler handler = new RestHandler(CARD, requestHandler, internalExecutor);
+        taskStore.save(MINIMAL_TASK, false);
+
+        agentExecutorExecute = (context, agentEmitter) -> {
+            agentEmitter.sendMessage(context.getMessage());
+        };
+
+        // Send streaming message with existing taskId but wrong contextId
+        String mismatchBody = """
+            {
+              "message": {
+                "messageId": "mismatch-002",
+                "role": "ROLE_USER",
+                "parts": [{"text": "mismatched context test"}],
+                "taskId": "%s",
+                "contextId": "wrong-context-does-not-exist"
+              },
+              "configuration": {
+                "acceptedOutputModes": ["text"]
+              }
+            }""".formatted(MINIMAL_TASK.id());
+        RestHandler.HTTPRestResponse mismatchResponse = handler.sendStreamingMessage(callContext, "", mismatchBody);
+
+        // Streaming responses embed errors in the stream with status 200
+        Assertions.assertEquals(200, mismatchResponse.getStatusCode());
+        Assertions.assertInstanceOf(RestHandler.HTTPRestStreamingResponse.class, mismatchResponse);
+
+        RestHandler.HTTPRestStreamingResponse streamingResponse = (RestHandler.HTTPRestStreamingResponse) mismatchResponse;
+        Flow.Publisher<String> publisher = streamingResponse.getPublisher();
+
+        AtomicBoolean errorFound = new AtomicBoolean(false);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        publisher.subscribe(new Flow.Subscriber<String>() {
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(String item) {
+                if (item.contains("InvalidParamsError")) {
+                    errorFound.set(true);
+                }
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onComplete() {
+                latch.countDown();
+            }
+        });
+
+        try {
+            Assertions.assertTrue(latch.await(5, TimeUnit.SECONDS));
+            Assertions.assertTrue(errorFound.get(), "Error should contain InvalidParamsError in streaming response");
+        } catch (InterruptedException e) {
+            Assertions.fail("Test interrupted");
+        }
+    }
 }


### PR DESCRIPTION
Validate that the contextId provided in a SendMessage request matches the contextId of the referenced task, returning InvalidParamsError when they differ. Previously, the mismatch was silently ignored and the request succeeded.

Add tests covering both streaming and non-streaming paths across all transports.

Fixes #723 🦕