### PR TITLE
fix: Return UnsupportedOperationError when extendedAgentCard capabili…

### DIFF
--- a/transport/grpc/src/main/java/io/a2a/transport/grpc/handler/GrpcHandler.java
+++ b/transport/grpc/src/main/java/io/a2a/transport/grpc/handler/GrpcHandler.java
@@ -546,6 +546,10 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     public void getExtendedAgentCard(io.a2a.grpc.GetExtendedAgentCardRequest request,
                            StreamObserver<io.a2a.grpc.AgentCard> responseObserver) {
         try {
+            if (!getAgentCard().capabilities().extendedAgentCard()) {
+                handleError(responseObserver, new UnsupportedOperationError());
+                return;
+            }
             AgentCard extendedAgentCard = getExtendedAgentCard();
             if (extendedAgentCard != null) {
                 responseObserver.onNext(ToProto.agentCard(extendedAgentCard));

--- a/transport/jsonrpc/src/main/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandler.java
+++ b/transport/jsonrpc/src/main/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandler.java
@@ -47,6 +47,7 @@ import io.a2a.spec.ExtendedAgentCardNotConfiguredError;
 import io.a2a.spec.EventKind;
 import io.a2a.spec.InternalError;
 import io.a2a.spec.InvalidRequestError;
+import io.a2a.spec.UnsupportedOperationError;
 import io.a2a.spec.ListTaskPushNotificationConfigResult;
 import io.a2a.spec.PushNotificationNotSupportedError;
 import io.a2a.spec.StreamingEventKind;
@@ -667,7 +668,10 @@ public class JSONRPCHandler {
     // TODO: Add authentication (https://github.com/a2aproject/a2a-java/issues/77)
     public GetExtendedAgentCardResponse onGetExtendedCardRequest(
             GetExtendedAgentCardRequest request, ServerCallContext context) {
-        if (!agentCard.capabilities().extendedAgentCard() || extendedAgentCard == null || !extendedAgentCard.isResolvable()) {
+        if (!agentCard.capabilities().extendedAgentCard()) {
+            return new GetExtendedAgentCardResponse(request.getId(), new UnsupportedOperationError());
+        }
+        if (extendedAgentCard == null || !extendedAgentCard.isResolvable()) {
             return new GetExtendedAgentCardResponse(request.getId(),
                     new ExtendedAgentCardNotConfiguredError(null, "Extended Card not configured", null));
         }

--- a/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -1541,7 +1541,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
         GetExtendedAgentCardRequest request = new GetExtendedAgentCardRequest("1");
         GetExtendedAgentCardResponse response = handler.onGetExtendedCardRequest(request, callContext);
         assertEquals(request.getId(), response.getId());
-        assertInstanceOf(ExtendedAgentCardNotConfiguredError.class, response.getError());
+        assertInstanceOf(UnsupportedOperationError.class, response.getError());
         assertNull(response.getResult());
     }
 

--- a/transport/rest/src/main/java/io/a2a/transport/rest/handler/RestHandler.java
+++ b/transport/rest/src/main/java/io/a2a/transport/rest/handler/RestHandler.java
@@ -789,7 +789,10 @@ public class RestHandler {
      */
     public HTTPRestResponse getExtendedAgentCard(ServerCallContext context, String tenant) {
         try {
-            if (!agentCard.capabilities().extendedAgentCard() || extendedAgentCard == null || !extendedAgentCard.isResolvable()) {
+            if (!agentCard.capabilities().extendedAgentCard()) {
+                throw new UnsupportedOperationError();
+            }
+            if (extendedAgentCard == null || !extendedAgentCard.isResolvable()) {
                 throw new ExtendedAgentCardNotConfiguredError(null, "Extended Card not configured", null);
             }
             return new HTTPRestResponse(200, APPLICATION_JSON, JsonUtil.toJson(extendedAgentCard.get()));


### PR DESCRIPTION
…ty is disabled

GetExtendedAgentCard now checks if the capability is enabled before checking if the card is configured. When capability is false, returns 501/UNIMPLEMENTED with UnsupportedOperationError instead of 400/FAILED_PRECONDITION.

Applied to all three transports: HTTP+JSON, JSON-RPC, and gRPC.

Fixes #733