### PR TITLE
fix: update RestErrorMapper to handle RFC 7807 Problem Details error format

### DIFF
--- a/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestErrorMapper.java
+++ b/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestErrorMapper.java
@@ -36,11 +36,18 @@ public class RestErrorMapper {
         try {
             if (body != null && !body.isBlank()) {
                 JsonObject node = JsonUtil.fromJson(body, JsonObject.class);
+                // Support RFC 7807 Problem Details format (type, title, details, status)
+                if (node.has("type")) {
+                    String type = node.get("type").getAsString();
+                    String errorMessage = node.has("title") ? node.get("title").getAsString() : "";
+                    return mapRestErrorByType(type, errorMessage, code);
+                }
+                // Legacy format (error, message)
                 String className = node.has("error") ? node.get("error").getAsString() : "";
                 String errorMessage = node.has("message") ? node.get("message").getAsString() : "";
-                return mapRestError(className, errorMessage, code);
+                return mapRestErrorByClassName(className, errorMessage, code);
             }
-            return mapRestError("", "", code);
+            return mapRestErrorByClassName("", "", code);
         } catch (JsonProcessingException ex) {
             Logger.getLogger(RestErrorMapper.class.getName()).log(Level.SEVERE, null, ex);
             return new A2AClientException("Failed to parse error response: " + ex.getMessage());
@@ -48,6 +55,44 @@ public class RestErrorMapper {
     }
 
     public static A2AClientException mapRestError(String className, String errorMessage, int code) {
+        return mapRestErrorByClassName(className, errorMessage, code);
+    }
+
+    /**
+     * Maps RFC 7807 Problem Details error type URIs to A2A exceptions.
+     * <p>
+     * Note: Error constructors receive null for code and data parameters because:
+     * <ul>
+     *   <li>Error codes are defaulted by each error class (e.g., -32007 for ExtendedAgentCardNotConfiguredError)</li>
+     *   <li>The message comes from the RFC 7807 "title" field</li>
+     *   <li>The data field is optional and not included in basic RFC 7807 responses</li>
+     * </ul>
+     *
+     * @param type the RFC 7807 error type URI (e.g., "https://a2a-protocol.org/errors/task-not-found")
+     * @param errorMessage the error message from the "title" field
+     * @param code the HTTP status code (currently unused, kept for consistency)
+     * @return an A2AClientException wrapping the appropriate A2A error
+     */
+    private static A2AClientException mapRestErrorByType(String type, String errorMessage, int code) {
+        return switch (type) {
+            case "https://a2a-protocol.org/errors/task-not-found" -> new A2AClientException(errorMessage, new TaskNotFoundError());
+            case "https://a2a-protocol.org/errors/extended-agent-card-not-configured" -> new A2AClientException(errorMessage, new ExtendedAgentCardNotConfiguredError(null, errorMessage, null));
+            case "https://a2a-protocol.org/errors/content-type-not-supported" -> new A2AClientException(errorMessage, new ContentTypeNotSupportedError(null, errorMessage, null));
+            case "https://a2a-protocol.org/errors/internal-error" -> new A2AClientException(errorMessage, new InternalError(errorMessage));
+            case "https://a2a-protocol.org/errors/invalid-agent-response" -> new A2AClientException(errorMessage, new InvalidAgentResponseError(null, errorMessage, null));
+            case "https://a2a-protocol.org/errors/invalid-params" -> new A2AClientException(errorMessage, new InvalidParamsError());
+            case "https://a2a-protocol.org/errors/invalid-request" -> new A2AClientException(errorMessage, new InvalidRequestError());
+            case "https://a2a-protocol.org/errors/method-not-found" -> new A2AClientException(errorMessage, new MethodNotFoundError());
+            case "https://a2a-protocol.org/errors/push-notification-not-supported" -> new A2AClientException(errorMessage, new PushNotificationNotSupportedError());
+            case "https://a2a-protocol.org/errors/task-not-cancelable" -> new A2AClientException(errorMessage, new TaskNotCancelableError());
+            case "https://a2a-protocol.org/errors/unsupported-operation" -> new A2AClientException(errorMessage, new UnsupportedOperationError());
+            case "https://a2a-protocol.org/errors/extension-support-required" -> new A2AClientException(errorMessage, new ExtensionSupportRequiredError(null, errorMessage, null));
+            case "https://a2a-protocol.org/errors/version-not-supported" -> new A2AClientException(errorMessage, new VersionNotSupportedError(null, errorMessage, null));
+            default -> new A2AClientException(errorMessage);
+        };
+    }
+
+    private static A2AClientException mapRestErrorByClassName(String className, String errorMessage, int code) {
         return switch (className) {
             case "io.a2a.spec.TaskNotFoundError" -> new A2AClientException(errorMessage, new TaskNotFoundError());
             case "io.a2a.spec.ExtendedCardNotConfiguredError" -> new A2AClientException(errorMessage, new ExtendedAgentCardNotConfiguredError(null, errorMessage, null));

--- a/reference/rest/src/main/java/io/a2a/server/rest/quarkus/A2AServerRoutes.java
+++ b/reference/rest/src/main/java/io/a2a/server/rest/quarkus/A2AServerRoutes.java
@@ -31,6 +31,7 @@ import io.a2a.server.auth.User;
 import io.a2a.server.extensions.A2AExtensions;
 import io.a2a.server.util.async.Internal;
 import io.a2a.spec.A2AError;
+import io.a2a.spec.ContentTypeNotSupportedError;
 import io.a2a.spec.InternalError;
 import io.a2a.spec.InvalidParamsError;
 import io.a2a.spec.MethodNotFoundError;
@@ -165,8 +166,11 @@ public class A2AServerRoutes {
      * @param body the JSON request body
      * @param rc the Vert.x routing context
      */
-    @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)message:send$", order = 1, methods = {Route.HttpMethod.POST}, consumes = {APPLICATION_JSON}, type = Route.HandlerType.BLOCKING)
+    @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)message:send$", order = 1, methods = {Route.HttpMethod.POST}, type = Route.HandlerType.BLOCKING)
     public void sendMessage(@Body String body, RoutingContext rc) {
+        if(!validateContentType(rc)) {
+            return;
+        }
         ServerCallContext context = createCallContext(rc, SEND_MESSAGE_METHOD);
         HTTPRestResponse response = null;
         try {
@@ -198,8 +202,11 @@ public class A2AServerRoutes {
      * @param body the JSON request body
      * @param rc the Vert.x routing context
      */
-    @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)message:stream$", order = 1, methods = {Route.HttpMethod.POST}, consumes = {APPLICATION_JSON}, type = Route.HandlerType.BLOCKING)
+    @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)message:stream$", order = 1, methods = {Route.HttpMethod.POST}, type = Route.HandlerType.BLOCKING)
     public void sendMessageStreaming(@Body String body, RoutingContext rc) {
+        if(!validateContentType(rc)) {
+            return;
+        }
         ServerCallContext context = createCallContext(rc, SEND_STREAMING_MESSAGE_METHOD);
         HTTPRestStreamingResponse streamingResponse = null;
         HTTPRestResponse error = null;
@@ -339,6 +346,9 @@ public class A2AServerRoutes {
      */
     @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)tasks\\/(?<taskId>[^/]+):cancel$", order = 1, methods = {Route.HttpMethod.POST}, type = Route.HandlerType.BLOCKING)
     public void cancelTask(@Body String body, RoutingContext rc) {
+        if (!validateContentType(rc)) {
+            return;
+        }
         String taskId = rc.pathParam("taskId");
         ServerCallContext context = createCallContext(rc, CANCEL_TASK_METHOD);
         HTTPRestResponse response = null;
@@ -443,8 +453,11 @@ public class A2AServerRoutes {
      * @param body the JSON request body with notification configuration
      * @param rc the Vert.x routing context (taskId extracted from path)
      */
-    @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)tasks\\/(?<taskId>[^/]+)\\/pushNotificationConfigs$", order = 1, methods = {Route.HttpMethod.POST}, consumes = {APPLICATION_JSON}, type = Route.HandlerType.BLOCKING)
-    public void CreateTaskPushNotificationConfiguration(@Body String body, RoutingContext rc) {
+    @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)tasks\\/(?<taskId>[^/]+)\\/pushNotificationConfigs$", order = 1, methods = {Route.HttpMethod.POST}, type = Route.HandlerType.BLOCKING)
+    public void createTaskPushNotificationConfiguration(@Body String body, RoutingContext rc) {
+        if(!validateContentType(rc)) {
+            return;
+        }
         String taskId = rc.pathParam("taskId");
         ServerCallContext context = createCallContext(rc, SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
         HTTPRestResponse response = null;
@@ -595,6 +608,20 @@ public class A2AServerRoutes {
             tenantPath = tenantPath.substring(0, tenantPath.length() - 1);
         }
         return tenantPath;
+    }
+
+    /**
+     * Check if the request content type is application/json.
+     * @param rc
+     * @return true if the content type is application/json - false otherwise.
+     */
+    private boolean validateContentType(RoutingContext rc) {
+        String contentType = rc.request().getHeader(CONTENT_TYPE);
+        if (contentType == null || !contentType.trim().startsWith(APPLICATION_JSON)) {
+            sendResponse(rc, jsonRestHandler.createErrorResponse(new ContentTypeNotSupportedError(null, null, null)));
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/reference/rest/src/test/java/io/a2a/server/rest/quarkus/A2AServerRoutesTest.java
+++ b/reference/rest/src/test/java/io/a2a/server/rest/quarkus/A2AServerRoutesTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +27,7 @@ import java.util.concurrent.Executor;
 import jakarta.enterprise.inject.Instance;
 
 import io.a2a.server.ServerCallContext;
+import io.a2a.spec.ContentTypeNotSupportedError;
 import io.a2a.transport.rest.handler.RestHandler;
 import io.a2a.transport.rest.handler.RestHandler.HTTPRestResponse;
 import io.vertx.core.Future;
@@ -80,6 +82,7 @@ public class A2AServerRoutesTest {
         when(mockRoutingContext.user()).thenReturn(null);
         when(mockRequest.headers()).thenReturn(mockHeaders);
         when(mockRequest.params()).thenReturn(mockParams);
+        when(mockRequest.getHeader(any(CharSequence.class))).thenReturn("application/json");
         when(mockRoutingContext.body()).thenReturn(mockRequestBody);
         when(mockRequestBody.asString()).thenReturn("{}");
         when(mockResponse.setStatusCode(any(Integer.class))).thenReturn(mockResponse);
@@ -358,7 +361,7 @@ public class A2AServerRoutesTest {
         ArgumentCaptor<ServerCallContext> contextCaptor = ArgumentCaptor.forClass(ServerCallContext.class);
 
         // Act
-        routes.CreateTaskPushNotificationConfiguration("{}", mockRoutingContext);
+        routes.createTaskPushNotificationConfiguration("{}", mockRoutingContext);
 
         // Assert
         verify(mockRestHandler).createTaskPushNotificationConfiguration(contextCaptor.capture(), anyString(), eq("{}"), eq("task123"));
@@ -436,6 +439,61 @@ public class A2AServerRoutesTest {
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
         assertEquals(DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+    }
+
+    @Test
+    public void testSendMessage_UnsupportedContentType_ReturnsContentTypeNotSupportedError() {
+        // Arrange
+        HTTPRestResponse mockErrorResponse = mock(HTTPRestResponse.class);
+        when(mockErrorResponse.getStatusCode()).thenReturn(415);
+        when(mockErrorResponse.getContentType()).thenReturn("application/problem+json");
+        when(mockErrorResponse.getBody()).thenReturn("{\"type\":\"https://a2a-protocol.org/errors/content-type-not-supported\"}");
+        when(mockRestHandler.createErrorResponse(any(ContentTypeNotSupportedError.class))).thenReturn(mockErrorResponse);
+        when(mockRequest.getHeader(any(CharSequence.class))).thenReturn("text/plain");
+
+        // Act
+        routes.sendMessage("{}", mockRoutingContext);
+
+        // Assert: createErrorResponse called with ContentTypeNotSupportedError, sendMessage NOT called
+        verify(mockRestHandler).createErrorResponse(any(ContentTypeNotSupportedError.class));
+        verify(mockRestHandler, never()).sendMessage(any(ServerCallContext.class), anyString(), anyString());
+    }
+
+    @Test
+    public void testSendMessageStreaming_UnsupportedContentType_ReturnsContentTypeNotSupportedError() {
+        // Arrange
+        HTTPRestResponse mockErrorResponse = mock(HTTPRestResponse.class);
+        when(mockErrorResponse.getStatusCode()).thenReturn(415);
+        when(mockErrorResponse.getContentType()).thenReturn("application/problem+json");
+        when(mockErrorResponse.getBody()).thenReturn("{\"type\":\"https://a2a-protocol.org/errors/content-type-not-supported\"}");
+        when(mockRestHandler.createErrorResponse(any(ContentTypeNotSupportedError.class))).thenReturn(mockErrorResponse);
+        when(mockRequest.getHeader(any(CharSequence.class))).thenReturn("text/plain");
+
+        // Act
+        routes.sendMessageStreaming("{}", mockRoutingContext);
+
+        // Assert: createErrorResponse called with ContentTypeNotSupportedError, sendStreamingMessage NOT called
+        verify(mockRestHandler).createErrorResponse(any(ContentTypeNotSupportedError.class));
+        verify(mockRestHandler, never()).sendStreamingMessage(any(ServerCallContext.class), anyString(), anyString());
+    }
+
+    @Test
+    public void testSendMessage_UnsupportedProtocolVersion_ReturnsVersionNotSupportedError() {
+        // Arrange: content type is OK, but RestHandler returns a VersionNotSupportedError response
+        HTTPRestResponse mockErrorResponse = mock(HTTPRestResponse.class);
+        when(mockErrorResponse.getStatusCode()).thenReturn(400);
+        when(mockErrorResponse.getContentType()).thenReturn("application/problem+json");
+        when(mockErrorResponse.getBody()).thenReturn("{\"type\":\"https://a2a-protocol.org/errors/version-not-supported\"}");
+        when(mockRequest.getHeader(any(CharSequence.class))).thenReturn("application/json");
+        when(mockRestHandler.sendMessage(any(ServerCallContext.class), anyString(), anyString()))
+                .thenReturn(mockErrorResponse);
+
+        // Act
+        routes.sendMessage("{}", mockRoutingContext);
+
+        // Assert: sendMessage was called and error response forwarded
+        verify(mockRestHandler).sendMessage(any(ServerCallContext.class), anyString(), eq("{}"));
+        verify(mockResponse).setStatusCode(400);
     }
 
     /**

--- a/reference/rest/src/test/java/io/a2a/server/rest/quarkus/QuarkusA2ARestTest.java
+++ b/reference/rest/src/test/java/io/a2a/server/rest/quarkus/QuarkusA2ARestTest.java
@@ -31,6 +31,39 @@ public abstract class QuarkusA2ARestTest extends AbstractA2AServerTest {
     protected abstract void configureTransport(ClientBuilder builder);
 
     @Test
+    public void testSendMessageWithUnsupportedContentType() throws Exception {
+        HttpClient client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .build();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + serverPort + "/message:send"))
+                .POST(HttpRequest.BodyPublishers.ofString("test body"))
+                .header("Content-Type", "text/plain")
+                .build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        Assertions.assertEquals(415, response.statusCode());
+        Assertions.assertTrue(response.body().contains("content-type-not-supported"),
+                "Expected content-type-not-supported in response body: " + response.body());
+    }
+
+    @Test
+    public void testSendMessageWithUnsupportedProtocolVersion() throws Exception {
+        HttpClient client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .build();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + serverPort + "/message:send"))
+                .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                .header("Content-Type", APPLICATION_JSON)
+                .header("A2A-Version", "0.4.0")
+                .build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        Assertions.assertEquals(400, response.statusCode());
+        Assertions.assertTrue(response.body().contains("version-not-supported"),
+                "Expected version-not-supported in response body: " + response.body());
+    }
+
+    @Test
     public void testMethodNotFound() throws Exception {
         // Create the client
         HttpClient client = HttpClient.newBuilder()

--- a/spec/src/main/java/io/a2a/spec/ContentTypeNotSupportedError.java
+++ b/spec/src/main/java/io/a2a/spec/ContentTypeNotSupportedError.java
@@ -40,6 +40,9 @@ import org.jspecify.annotations.Nullable;
  */
 public class ContentTypeNotSupportedError extends A2AProtocolError {
 
+    public ContentTypeNotSupportedError() {
+        this(null, null, null);
+    }
     /**
      * Constructs a content type not supported error.
      *

--- a/transport/rest/README.md
+++ b/transport/rest/README.md
@@ -323,7 +323,7 @@ All error responses use [RFC 7807 Problem Details](https://tools.ietf.org/html/r
 | `https://a2a-protocol.org/errors/content-type-not-supported`   | 415         | The requested content type is not supported.               |
 | `https://a2a-protocol.org/errors/push-notification-not-supported` | 501      | Push notifications are not configured for this agent.      |
 | `https://a2a-protocol.org/errors/unsupported-operation`        | 501         | The operation is not implemented or not applicable (e.g., subscribing to a finalized task). |
-| `https://a2a-protocol.org/errors/version-not-supported`        | 501         | The requested protocol version is not supported.           |
+| `https://a2a-protocol.org/errors/version-not-supported`        | 400         | The requested protocol version is not supported.           |
 | `https://a2a-protocol.org/errors/invalid-agent-response`       | 502         | The agent produced an invalid response.                    |
 | `https://a2a-protocol.org/errors/extended-agent-card-not-configured` | 400   | The agent does not have an extended agent card configured. |
 | `https://a2a-protocol.org/errors/internal-error`               | 500         | An unexpected server-side error occurred.                  |

--- a/transport/rest/README.md
+++ b/transport/rest/README.md
@@ -1,0 +1,355 @@
+# A2A REST Transport
+
+REST transport implementation for the A2A Protocol, providing HTTP-based (`HTTP+JSON` protocol binding) communication between agents and clients.
+
+## Overview
+
+This module implements the REST transport layer for A2A protocol operations. All request and response bodies use [Protobuf JSON](https://protobuf.dev/programming-guides/proto3/#json) serialization (camelCase field names).
+
+## API Endpoints
+
+The `{tenant}` path prefix is optional on all endpoints. When omitted, the leading slash is also omitted (e.g., `/message:send` instead of `/{tenant}/message:send`).
+
+### Send Message
+
+Sends a message to the agent and blocks until the agent reaches a terminal or interrupted state, or returns immediately if `returnImmediately` is set.
+
+```
+POST /{tenant}/message:send
+Content-Type: application/json
+```
+
+**Request body** (`SendMessageRequest`):
+```json
+{
+  "message": {
+    "messageId": "msg-1",
+    "role": "ROLE_USER",
+    "parts": [
+      {"text": "Hello, what can you do?"}
+    ],
+    "contextId": "ctx-1"
+  },
+  "configuration": {
+    "historyLength": 10,
+    "returnImmediately": false,
+    "acceptedOutputModes": ["text/plain"]
+  }
+}
+```
+
+**Response** — one of:
+- `{"task": { ... }}` — a `Task` object when the agent creates/updates a task
+- `{"message": { ... }}` — a `Message` object when the agent replies without a task
+
+---
+
+### Send Streaming Message
+
+Sends a message and streams task updates as Server-Sent Events (SSE). Requires `capabilities.streaming = true` in the agent card.
+
+```
+POST /{tenant}/message:stream
+Content-Type: application/json
+Accept: text/event-stream
+```
+
+Request body is identical to `message:send`. Response is a stream of SSE events:
+
+```
+: SSE stream started
+
+id: 0
+data: {"statusUpdate":{"taskId":"task-1","contextId":"ctx-1","status":{"state":"TASK_STATE_WORKING"}}}
+
+id: 1
+data: {"artifactUpdate":{"taskId":"task-1","contextId":"ctx-1","artifact":{"artifactId":"a-1","parts":[{"text":"Hello!"}]}}}
+
+id: 2
+data: {"statusUpdate":{"taskId":"task-1","contextId":"ctx-1","status":{"state":"TASK_STATE_COMPLETED"}}}
+```
+
+Each `data` field contains a JSON-serialized `StreamResponse` with one of the following fields set:
+- `task` — full `Task` snapshot
+- `message` — a `Message` from the agent
+- `statusUpdate` — a `TaskStatusUpdateEvent`
+- `artifactUpdate` — a `TaskArtifactUpdateEvent`
+
+---
+
+### Get Task
+
+Retrieves the current state of a task by ID.
+
+```
+GET /{tenant}/tasks/{taskId}?historyLength=10
+```
+
+| Query parameter | Type    | Description                                                                 |
+|-----------------|---------|-----------------------------------------------------------------------------|
+| `historyLength` | integer | Maximum number of history messages to include. Omit for no limit; `0` for none. |
+
+**Response** — a `Task` object:
+```json
+{
+  "id": "task-1",
+  "contextId": "ctx-1",
+  "status": {
+    "state": "TASK_STATE_COMPLETED",
+    "timestamp": "2023-10-27T10:00:00Z"
+  },
+  "artifacts": [],
+  "history": []
+}
+```
+
+---
+
+### List Tasks
+
+Lists tasks with optional filtering and pagination.
+
+```
+GET /{tenant}/tasks
+```
+
+| Query parameter        | Type    | Description                                                                                |
+|------------------------|---------|--------------------------------------------------------------------------------------------|
+| `contextId`            | string  | Filter by context ID.                                                                      |
+| `status`               | string  | Filter by task state. One of the `TaskState` enum values (e.g. `TASK_STATE_COMPLETED`).    |
+| `pageSize`             | integer | Maximum number of tasks to return (server default: 50, max: 100).                          |
+| `pageToken`            | string  | Pagination token from a previous `ListTasks` response.                                     |
+| `historyLength`        | integer | Maximum history messages to include per task.                                               |
+| `statusTimestampAfter` | string  | ISO-8601 timestamp. Only return tasks whose status was updated at or after this time.      |
+| `includeArtifacts`     | boolean | Whether to include artifacts in results. Defaults to `false`.                               |
+
+**Response** (`ListTasksResponse`):
+```json
+{
+  "tasks": [ ... ],
+  "nextPageToken": "",
+  "pageSize": 50,
+  "totalSize": 3
+}
+```
+
+**`TaskState` values:**
+
+| Value                         | Description                                      |
+|-------------------------------|--------------------------------------------------|
+| `TASK_STATE_SUBMITTED`        | Task acknowledged, not yet processing.           |
+| `TASK_STATE_WORKING`          | Task is actively being processed.                |
+| `TASK_STATE_COMPLETED`        | Task finished successfully (terminal).           |
+| `TASK_STATE_FAILED`           | Task finished with an error (terminal).          |
+| `TASK_STATE_CANCELED`         | Task was canceled (terminal).                    |
+| `TASK_STATE_REJECTED`         | Agent declined to perform the task (terminal).   |
+| `TASK_STATE_INPUT_REQUIRED`   | Agent needs additional input (interrupted).      |
+| `TASK_STATE_AUTH_REQUIRED`    | Authentication is required to proceed (interrupted). |
+
+---
+
+### Cancel Task
+
+Requests cancellation of a running task. The agent should transition the task to `TASK_STATE_CANCELED`.
+
+```
+POST /{tenant}/tasks/{taskId}:cancel
+Content-Type: application/json
+```
+
+Request body is optional (may be empty or contain a `metadata` field).
+
+**Response** — the updated `Task` object on success.
+
+---
+
+### Subscribe to Task
+
+Opens an SSE stream to receive real-time updates for an existing task. Requires `capabilities.streaming = true`. Returns `UnsupportedOperationError` if the task is already in a terminal state.
+
+```
+POST /{tenant}/tasks/{taskId}:subscribe
+Accept: text/event-stream
+```
+
+Response is an SSE stream with the same event format as `message:stream`.
+
+---
+
+### Create Push Notification Config
+
+Creates a webhook configuration for push notifications on a task.
+
+```
+POST /{tenant}/tasks/{taskId}/pushNotificationConfigs
+Content-Type: application/json
+```
+
+**Request body** (`TaskPushNotificationConfig`):
+```json
+{
+  "url": "https://example.com/webhook",
+  "token": "optional-token",
+  "authentication": {
+    "scheme": "Bearer",
+    "credentials": "my-token"
+  }
+}
+```
+
+**Response** — the created `TaskPushNotificationConfig` with its generated `id`. HTTP 201.
+
+---
+
+### Get Push Notification Config
+
+```
+GET /{tenant}/tasks/{taskId}/pushNotificationConfigs/{configId}
+```
+
+**Response** — the `TaskPushNotificationConfig` object.
+
+---
+
+### List Push Notification Configs
+
+```
+GET /{tenant}/tasks/{taskId}/pushNotificationConfigs
+```
+
+| Query parameter | Type    | Description                        |
+|-----------------|---------|------------------------------------|
+| `pageSize`      | integer | Maximum configurations to return.  |
+| `pageToken`     | string  | Pagination token.                  |
+
+**Response** (`ListTaskPushNotificationConfigsResponse`):
+```json
+{
+  "configs": [ ... ],
+  "nextPageToken": ""
+}
+```
+
+---
+
+### Delete Push Notification Config
+
+```
+DELETE /{tenant}/tasks/{taskId}/pushNotificationConfigs/{configId}
+```
+
+**Response** — HTTP 204 No Content on success.
+
+---
+
+### Get Agent Card
+
+Public discovery endpoint. Returns the agent's self-describing manifest. No authentication required.
+
+```
+GET /.well-known/agent-card.json
+```
+
+**Response** — an `AgentCard` object:
+```json
+{
+  "name": "My Agent",
+  "description": "An example agent",
+  "version": "1.0.0",
+  "supportedInterfaces": [ ... ],
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false
+  },
+  "skills": [ ... ],
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/plain"]
+}
+```
+
+---
+
+### Get Extended Agent Card
+
+Returns additional agent metadata for authenticated clients. Requires `capabilities.extendedAgentCard = true` in the public agent card.
+
+```
+GET /{tenant}/extendedAgentCard
+```
+
+**Response** — an `AgentCard` object (same structure as the public card, potentially with additional fields).
+
+---
+
+## Request Headers
+
+| Header             | Description                                                                                     |
+|--------------------|-------------------------------------------------------------------------------------------------|
+| `X-A2A-Version`    | Requested A2A protocol version (e.g., `1.0`). Validated against the agent's supported versions. |
+| `X-A2A-Extensions` | Comma-separated list of extension URIs the client supports. Required when the agent declares required extensions. |
+
+---
+
+## Error Handling
+
+All error responses use [RFC 7807 Problem Details](https://tools.ietf.org/html/rfc7807) with `Content-Type: application/problem+json`.
+
+```json
+{
+  "type": "https://a2a-protocol.org/errors/task-not-found",
+  "title": "Task not found",
+  "status": 404,
+  "details": ""
+}
+```
+
+| Field     | Type    | Description                                 |
+|-----------|---------|---------------------------------------------|
+| `type`    | string  | URI identifying the error type.             |
+| `title`   | string  | Human-readable summary of the error.        |
+| `status`  | integer | HTTP status code.                           |
+| `details` | string  | Additional error context (may be empty).    |
+
+### Error Types
+
+| `type` URI                                                     | HTTP Status | Description                                                |
+|----------------------------------------------------------------|-------------|------------------------------------------------------------|
+| `https://a2a-protocol.org/errors/task-not-found`               | 404         | The requested task does not exist.                         |
+| `https://a2a-protocol.org/errors/method-not-found`             | 404         | The endpoint does not exist.                               |
+| `https://a2a-protocol.org/errors/invalid-request`              | 400         | Malformed request, missing required fields, or JSON parse error. |
+| `https://a2a-protocol.org/errors/invalid-params`               | 422         | Invalid parameter values (e.g., negative `historyLength`). |
+| `https://a2a-protocol.org/errors/extension-support-required`   | 400         | The agent requires an extension the client did not declare.|
+| `https://a2a-protocol.org/errors/task-not-cancelable`          | 409         | The task cannot be canceled in its current state.          |
+| `https://a2a-protocol.org/errors/content-type-not-supported`   | 415         | The requested content type is not supported.               |
+| `https://a2a-protocol.org/errors/push-notification-not-supported` | 501      | Push notifications are not configured for this agent.      |
+| `https://a2a-protocol.org/errors/unsupported-operation`        | 501         | The operation is not implemented or not applicable (e.g., subscribing to a finalized task). |
+| `https://a2a-protocol.org/errors/version-not-supported`        | 501         | The requested protocol version is not supported.           |
+| `https://a2a-protocol.org/errors/invalid-agent-response`       | 502         | The agent produced an invalid response.                    |
+| `https://a2a-protocol.org/errors/extended-agent-card-not-configured` | 400   | The agent does not have an extended agent card configured. |
+| `https://a2a-protocol.org/errors/internal-error`               | 500         | An unexpected server-side error occurred.                  |
+
+---
+
+## Client Integration
+
+The REST client (`client/transport/rest`) automatically maps error responses to typed A2A exceptions. It supports both the current RFC 7807 format and the legacy `{"error": "...", "message": "..."}` format for backward compatibility.
+
+```java
+try {
+    Task task = client.getTask(new TaskQueryParams("task-123"));
+} catch (A2AClientException e) {
+    if (e.getCause() instanceof TaskNotFoundError) {
+        // Handle task not found
+    } else if (e.getCause() instanceof UnsupportedOperationError) {
+        // Handle unsupported operation
+    }
+}
+```
+
+---
+
+## See Also
+
+- [A2A Protocol Specification](https://a2a-protocol.org/)
+- [RFC 7807 Problem Details](https://tools.ietf.org/html/rfc7807)
+- [Protobuf JSON Encoding](https://protobuf.dev/programming-guides/proto3/#json)

--- a/transport/rest/src/main/java/io/a2a/transport/rest/handler/RestHandler.java
+++ b/transport/rest/src/main/java/io/a2a/transport/rest/handler/RestHandler.java
@@ -26,6 +26,7 @@ import com.google.gson.JsonSyntaxException;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import io.a2a.grpc.utils.ProtoUtils;
+import io.a2a.jsonrpc.common.json.JsonProcessingException;
 import io.a2a.jsonrpc.common.json.JsonUtil;
 import io.a2a.jsonrpc.common.wrappers.ListTasksResult;
 import io.a2a.server.AgentCardValidator;
@@ -71,12 +72,14 @@ import org.jspecify.annotations.Nullable;
 /**
  * REST transport handler for processing A2A protocol requests over HTTP.
  *
- * <p>This handler converts HTTP REST requests into A2A protocol operations and
+ * <p>
+ * This handler converts HTTP REST requests into A2A protocol operations and
  * manages the lifecycle of agent interactions including message sending, task
  * management, and push notification configurations.
  *
  * <h2>Request Flow</h2>
- * <p>HTTP REST requests flow through this handler to the underlying {@link RequestHandler},
+ * <p>
+ * HTTP REST requests flow through this handler to the underlying {@link RequestHandler},
  * which coordinates with the agent executor and event queue system:
  * <pre>
  * HTTP Request → RestHandler → RequestHandler → AgentExecutor
@@ -86,24 +89,26 @@ import org.jspecify.annotations.Nullable;
  *
  * <h2>Supported Operations</h2>
  * <ul>
- *   <li>Message sending (blocking and streaming)</li>
- *   <li>Task management (get, list, cancel, subscribe)</li>
- *   <li>Push notification configurations (create, get, list, delete)</li>
- *   <li>Agent card retrieval (public and extended)</li>
+ * <li>Message sending (blocking and streaming)</li>
+ * <li>Task management (get, list, cancel, subscribe)</li>
+ * <li>Push notification configurations (create, get, list, delete)</li>
+ * <li>Agent card retrieval (public and extended)</li>
  * </ul>
  *
  * <h2>Error Handling</h2>
- * <p>All A2A protocol errors are caught and converted to appropriate HTTP status codes
+ * <p>
+ * All A2A protocol errors are caught and converted to appropriate HTTP status codes
  * via {@link #mapErrorToHttpStatus(A2AError)}. Protocol version and required extensions
  * are validated before processing requests.
  *
  * <h2>CDI Integration</h2>
- * <p>This handler is an {@code @ApplicationScoped} CDI bean that requires:
+ * <p>
+ * This handler is an {@code @ApplicationScoped} CDI bean that requires:
  * <ul>
- *   <li>{@link AgentCard} qualified with {@code @PublicAgentCard}</li>
- *   <li>{@link RequestHandler} for processing A2A operations</li>
- *   <li>{@link Executor} qualified with {@code @Internal} for async operations</li>
- *   <li>Optional {@link AgentCard} qualified with {@code @ExtendedAgentCard}</li>
+ * <li>{@link AgentCard} qualified with {@code @PublicAgentCard}</li>
+ * <li>{@link RequestHandler} for processing A2A operations</li>
+ * <li>{@link Executor} qualified with {@code @Internal} for async operations</li>
+ * <li>Optional {@link AgentCard} qualified with {@code @ExtendedAgentCard}</li>
  * </ul>
  *
  * @see RequestHandler
@@ -116,7 +121,6 @@ public class RestHandler {
 
     private static final Logger log = Logger.getLogger(RestHandler.class.getName());
     private static final String TASK_STATE_PREFIX = "TASK_STATE_";
-
 
     // Fields set by constructor injection cannot be final. We need a noargs constructor for
     // Jakarta compatibility, and it seems that making fields set by constructor injection
@@ -173,12 +177,14 @@ public class RestHandler {
     /**
      * Handles a blocking message send request.
      *
-     * <p>This method processes an HTTP POST request containing a message to be sent to the agent.
+     * <p>
+     * This method processes an HTTP POST request containing a message to be sent to the agent.
      * The request is validated for protocol version and required extensions before being forwarded
      * to the {@link RequestHandler}. The method blocks until the agent produces a terminal event
      * or requires authentication/input.
      *
-     * <p><b>Example Request:</b></p>
+     * <p>
+     * <b>Example Request:</b></p>
      * <pre>{@code
      * POST /v1/tenants/{tenant}/messages
      * Content-Type: application/json
@@ -192,7 +198,8 @@ public class RestHandler {
      * }
      * }</pre>
      *
-     * <p><b>Example Response:</b></p>
+     * <p>
+     * <b>Example Response:</b></p>
      * <pre>{@code
      * HTTP/1.1 200 OK
      * Content-Type: application/json
@@ -233,13 +240,16 @@ public class RestHandler {
     /**
      * Handles a streaming message send request.
      *
-     * <p>This method processes an HTTP POST request for streaming responses from the agent.
+     * <p>
+     * This method processes an HTTP POST request for streaming responses from the agent.
      * The response is returned as Server-Sent Events (SSE) via {@link HTTPRestStreamingResponse},
      * allowing clients to receive task updates and artifacts as they are produced by the agent.
      *
-     * <p>This method requires the agent card to have {@code capabilities.streaming = true}.
+     * <p>
+     * This method requires the agent card to have {@code capabilities.streaming = true}.
      *
-     * <p><b>Example Request:</b></p>
+     * <p>
+     * <b>Example Request:</b></p>
      * <pre>{@code
      * POST /v1/tenants/{tenant}/messages/stream
      * Content-Type: application/json
@@ -253,7 +263,8 @@ public class RestHandler {
      * }
      * }</pre>
      *
-     * <p><b>Example Streaming Response:</b></p>
+     * <p>
+     * <b>Example Streaming Response:</b></p>
      * <pre>{@code
      * HTTP/1.1 200 OK
      * Content-Type: text/event-stream
@@ -297,11 +308,13 @@ public class RestHandler {
     /**
      * Handles a task cancellation request.
      *
-     * <p>Attempts to cancel a running task identified by the task ID. The cancellation
+     * <p>
+     * Attempts to cancel a running task identified by the task ID. The cancellation
      * request is forwarded to the {@link RequestHandler}, which signals the agent executor
      * to stop processing. The agent should transition the task to {@code CANCELED} state.
      *
-     * <p><b>Example Request:</b></p>
+     * <p>
+     * <b>Example Request:</b></p>
      * <pre>{@code
      * POST /v1/tenants/{tenant}/tasks/{taskId}/cancel
      * }</pre>
@@ -312,7 +325,7 @@ public class RestHandler {
      * @param taskId the ID of the task to cancel
      * @return the HTTP response containing the cancelled task
      * @throws InvalidParamsError if taskId is null or empty
-     * @see RequestHandler#onCancelTask(CancelTaskParams, ServerCallContext) 
+     * @see RequestHandler#onCancelTask(CancelTaskParams, ServerCallContext)
      * @see io.a2a.server.agentexecution.AgentExecutor#cancel
      */
     @SuppressWarnings("unchecked")
@@ -321,7 +334,7 @@ public class RestHandler {
             if (taskId == null || taskId.isEmpty()) {
                 throw new InvalidParamsError();
             }
-            Map<String, Object> metadata =JsonUtil.readMetadata(body);
+            Map<String, Object> metadata = JsonUtil.readMetadata(body);
             CancelTaskParams params = CancelTaskParams.builder().id(taskId).tenant(tenant).metadata(metadata).build();
             Task task = requestHandler.onCancelTask(params, context);
             if (task != null) {
@@ -364,22 +377,26 @@ public class RestHandler {
     /**
      * Subscribes to task updates via a streaming connection.
      *
-     * <p>Creates a Server-Sent Events (SSE) stream that delivers real-time updates for an
+     * <p>
+     * Creates a Server-Sent Events (SSE) stream that delivers real-time updates for an
      * existing task. This allows clients to reconnect to ongoing or completed tasks and
      * receive their event history and future updates.
      *
-     * <p>This method requires the agent card to have {@code capabilities.streaming = true}.
+     * <p>
+     * This method requires the agent card to have {@code capabilities.streaming = true}.
      *
-     * <p><b>Example Request:</b></p>
+     * <p>
+     * <b>Example Request:</b></p>
      * <pre>{@code
      * GET /v1/tenants/{tenant}/tasks/{taskId}/subscribe
      * }</pre>
      *
-     * <p><b>Use Cases:</b></p>
+     * <p>
+     * <b>Use Cases:</b></p>
      * <ul>
-     *   <li>Reconnecting to a task after network interruption</li>
-     *   <li>Monitoring long-running tasks from multiple clients</li>
-     *   <li>Viewing historical events for completed tasks</li>
+     * <li>Reconnecting to a task after network interruption</li>
+     * <li>Monitoring long-running tasks from multiple clients</li>
+     * <li>Viewing historical events for completed tasks</li>
      * </ul>
      *
      * @param context the server call context containing authentication and metadata
@@ -415,17 +432,14 @@ public class RestHandler {
      */
     public HTTPRestResponse getTask(ServerCallContext context, String tenant, String taskId, @Nullable Integer historyLength) {
         try {
-            TaskQueryParams params;
-            try {
-                params = new TaskQueryParams(taskId, historyLength, tenant);
-            } catch (IllegalArgumentException e) {
-                throw new InvalidParamsError(e.getMessage());
-            }
+            TaskQueryParams params = new TaskQueryParams(taskId, historyLength, tenant);
             Task task = requestHandler.onGetTask(params, context);
             if (task != null) {
                 return createSuccessResponse(200, io.a2a.grpc.Task.newBuilder(ProtoUtils.ToProto.task(task)));
             }
             throw new TaskNotFoundError();
+        } catch (IllegalArgumentException e) {
+            return createErrorResponse(new InvalidParamsError(e.getMessage()));
         } catch (A2AError e) {
             return createErrorResponse(e);
         } catch (Throwable throwable) {
@@ -436,24 +450,27 @@ public class RestHandler {
     /**
      * Lists tasks with optional filtering and pagination.
      *
-     * <p>Retrieves a list of tasks with support for filtering by context, status, and timestamp,
+     * <p>
+     * Retrieves a list of tasks with support for filtering by context, status, and timestamp,
      * along with pagination controls. This method is useful for task management dashboards,
      * monitoring systems, and task history retrieval.
      *
-     * <p><b>Example Request:</b></p>
+     * <p>
+     * <b>Example Request:</b></p>
      * <pre>{@code
      * GET /v1/tenants/{tenant}/tasks?status=COMPLETED&pageSize=10&includeArtifacts=true
      * }</pre>
      *
-     * <p><b>Query Parameters:</b></p>
+     * <p>
+     * <b>Query Parameters:</b></p>
      * <ul>
-     *   <li>{@code contextId} - Filter tasks by conversation context</li>
-     *   <li>{@code status} - Filter by task state (SUBMITTED, WORKING, COMPLETED, etc.)</li>
-     *   <li>{@code pageSize} - Maximum tasks to return (for pagination)</li>
-     *   <li>{@code pageToken} - Token for retrieving next page of results</li>
-     *   <li>{@code historyLength} - Maximum history entries to include per task</li>
-     *   <li>{@code statusTimestampAfter} - ISO-8601 timestamp for filtering recent tasks</li>
-     *   <li>{@code includeArtifacts} - Whether to include task artifacts in response</li>
+     * <li>{@code contextId} - Filter tasks by conversation context</li>
+     * <li>{@code status} - Filter by task state (SUBMITTED, WORKING, COMPLETED, etc.)</li>
+     * <li>{@code pageSize} - Maximum tasks to return (for pagination)</li>
+     * <li>{@code pageToken} - Token for retrieving next page of results</li>
+     * <li>{@code historyLength} - Maximum history entries to include per task</li>
+     * <li>{@code statusTimestampAfter} - ISO-8601 timestamp for filtering recent tasks</li>
+     * <li>{@code includeArtifacts} - Whether to include task artifacts in response</li>
      * </ul>
      *
      * @param context the server call context containing authentication and metadata
@@ -471,10 +488,10 @@ public class RestHandler {
      * @see TaskState
      */
     public HTTPRestResponse listTasks(ServerCallContext context, String tenant,
-                                       @Nullable String contextId, @Nullable String status,
-                                       @Nullable Integer pageSize, @Nullable String pageToken,
-                                       @Nullable Integer historyLength, @Nullable String statusTimestampAfter,
-                                       @Nullable Boolean includeArtifacts) {
+            @Nullable String contextId, @Nullable String status,
+            @Nullable Integer pageSize, @Nullable String pageToken,
+            @Nullable Integer historyLength, @Nullable String statusTimestampAfter,
+            @Nullable Boolean includeArtifacts) {
         try {
             // Build params
             ListTasksParams.Builder paramsBuilder = ListTasksParams.builder();
@@ -723,22 +740,23 @@ public class RestHandler {
     /**
      * Maps A2A protocol errors to HTTP status codes.
      *
-     * <p>This method ensures consistent HTTP status code mapping for all A2A errors:
+     * <p>
+     * This method ensures consistent HTTP status code mapping for all A2A errors:
      * <ul>
-     *   <li>400 - Invalid request, JSON parse errors, missing extensions</li>
-     *   <li>404 - Method not found, task not found</li>
-     *   <li>409 - Task not cancelable (conflict)</li>
-     *   <li>415 - Unsupported content type</li>
-     *   <li>422 - Invalid parameters (unprocessable entity)</li>
-     *   <li>500 - Internal errors</li>
-     *   <li>501 - Not implemented (unsupported operations, version)</li>
-     *   <li>502 - Bad gateway (invalid agent response)</li>
+     * <li>400 - Invalid request, JSON parse errors, missing extensions</li>
+     * <li>404 - Method not found, task not found</li>
+     * <li>409 - Task not cancelable (conflict)</li>
+     * <li>415 - Unsupported content type</li>
+     * <li>422 - Invalid parameters (unprocessable entity)</li>
+     * <li>500 - Internal errors</li>
+     * <li>501 - Not implemented (unsupported operations, version)</li>
+     * <li>502 - Bad gateway (invalid agent response)</li>
      * </ul>
      *
      * @param error the A2A error to map
      * @return the corresponding HTTP status code
      */
-    private int mapErrorToHttpStatus(A2AError error) {
+    private static int mapErrorToHttpStatus(A2AError error) {
         if (error instanceof InvalidRequestError || error instanceof JSONParseError) {
             return 400;
         }
@@ -773,14 +791,73 @@ public class RestHandler {
     }
 
     /**
+     * Maps A2A protocol errors to RFC 7807 Problem Details type URIs.
+     *
+     * <p>
+     * This method provides a unique URI for each A2A error type, which is used in the "type"
+     * field of RFC 7807 error responses. For example:
+     * <ul>
+     * <li>{@link InvalidRequestError} -> "https://a2a-protocol.org/errors/invalid-request"</li>
+     * <li>{@link TaskNotFoundError} -> "https://a2a-protocol.org/errors/task-not-found"</li>
+     * </ul>
+     *
+     * @param error the A2A error to map
+     * @return the corresponding RFC 7807 type URI
+     */
+    private static String mapErrorToURI(A2AError error) {
+        if (error instanceof InvalidRequestError || error instanceof JSONParseError) {
+            return "https://a2a-protocol.org/errors/invalid-request";
+        }
+        if (error instanceof InvalidParamsError) {
+            return "https://a2a-protocol.org/errors/invalid-params";
+        }
+        if (error instanceof MethodNotFoundError) {
+            return "https://a2a-protocol.org/errors/method-not-found";
+        }
+        if (error instanceof TaskNotFoundError) {
+            return "https://a2a-protocol.org/errors/task-not-found";
+        }
+        if (error instanceof TaskNotCancelableError) {
+            return "https://a2a-protocol.org/errors/task-not-cancelable";
+        }
+        if (error instanceof PushNotificationNotSupportedError) {
+            return "https://a2a-protocol.org/errors/push-notification-not-supported";
+        }
+        if (error instanceof UnsupportedOperationError) {
+            return "https://a2a-protocol.org/errors/unsupported-operation";
+        }
+        if (error instanceof VersionNotSupportedError) {
+            return "https://a2a-protocol.org/errors/version-not-supported";
+        }
+        if (error instanceof ContentTypeNotSupportedError) {
+            return "https://a2a-protocol.org/errors/content-type-not-supported";
+        }
+        if (error instanceof InvalidAgentResponseError) {
+            return "https://a2a-protocol.org/errors/invalid-agent-response";
+        }
+        if (error instanceof ExtendedAgentCardNotConfiguredError) {
+            return "https://a2a-protocol.org/errors/extended-agent-card-not-configured";
+        }
+        if (error instanceof ExtensionSupportRequiredError) {
+            return "https://a2a-protocol.org/errors/extension-support-required";
+        }
+        if (error instanceof InternalError) {
+            return "https://a2a-protocol.org/errors/internal-error";
+        }
+        return "https://a2a-protocol.org/errors/internal-error";
+    }
+
+    /**
      * Retrieves the extended agent card if configured.
      *
-     * <p>The extended agent card provides additional metadata beyond the public agent card,
+     * <p>
+     * The extended agent card provides additional metadata beyond the public agent card,
      * such as tenant-specific configurations or private capabilities. This endpoint requires
      * the agent card to have {@code capabilities.extendedAgentCard = true} and a CDI-produced
      * {@code @ExtendedAgentCard} instance.
      *
-     * <p><b>Example Request:</b></p>
+     * <p>
+     * <b>Example Request:</b></p>
      * <pre>{@code
      * GET /v1/tenants/{tenant}/extended-agent-card
      * }</pre>
@@ -811,17 +888,20 @@ public class RestHandler {
     /**
      * Retrieves the public agent card.
      *
-     * <p>The agent card is a self-describing manifest that provides essential metadata about
+     * <p>
+     * The agent card is a self-describing manifest that provides essential metadata about
      * the agent, including its capabilities, supported skills, communication methods, and
      * security requirements. This is the primary discovery endpoint for clients to understand
      * what the agent can do and how to interact with it.
      *
-     * <p><b>Example Request:</b></p>
+     * <p>
+     * <b>Example Request:</b></p>
      * <pre>{@code
      * GET /v1/agent-card
      * }</pre>
      *
-     * <p><b>Example Response:</b></p>
+     * <p>
+     * <b>Example Response:</b></p>
      * <pre>{@code
      * {
      *   "name": "Weather Agent",
@@ -935,9 +1015,11 @@ public class RestHandler {
      */
     private static class HTTPRestErrorResponse {
 
-        private final String error;
-        private final @Nullable
-        String message;
+        private final String title;
+        private final String details;
+        private final int status;
+        private final String type;
+
 
         /**
          * Creates an error response from an A2A error.
@@ -945,17 +1027,25 @@ public class RestHandler {
          * @param jsonRpcError the A2A error
          */
         private HTTPRestErrorResponse(A2AError jsonRpcError) {
-            this.error = jsonRpcError.getClass().getName();
-            this.message = jsonRpcError.getMessage();
+            this.title = jsonRpcError.getMessage() == null ? jsonRpcError.getClass().getName() : jsonRpcError.getMessage();
+            this.details = jsonRpcError.getData() == null ? "" : jsonRpcError.getData().toString();
+            this.type = mapErrorToURI(jsonRpcError);
+            this.status = mapErrorToHttpStatus(jsonRpcError);
         }
 
         private String toJson() {
-            return "{\"error\": \"" + error + "\", \"message\": \"" + message + "\"}";
+            try {
+                return JsonUtil.toJson(this);
+            } catch (JsonProcessingException ex) {
+                log.log(Level.SEVERE, "Failed to serialize HTTPRestErrorResponse to JSON", ex);
+                return "{\"title\":\"Internal Server Error\",\"details\":\"Failed to serialize error response.\",\"status\":500,\"type\":\"https://a2a-protocol.org/errors/internal-error\"}";
+            }
         }
 
         @Override
         public String toString() {
-            return "HTTPRestErrorResponse{" + "error=" + error + ", message=" + message + '}';
+            return "HTTPRestErrorResponse{" + "title=" + title + ", details=" + details + ", status=" + status + ", type=" + type + '}';
         }
+
     }
 }

--- a/transport/rest/src/main/java/io/a2a/transport/rest/handler/RestHandler.java
+++ b/transport/rest/src/main/java/io/a2a/transport/rest/handler/RestHandler.java
@@ -770,8 +770,7 @@ public class RestHandler {
             return 409;
         }
         if (error instanceof PushNotificationNotSupportedError
-                || error instanceof UnsupportedOperationError
-                || error instanceof VersionNotSupportedError) {
+                || error instanceof UnsupportedOperationError) {
             return 501;
         }
         if (error instanceof ContentTypeNotSupportedError) {
@@ -781,7 +780,8 @@ public class RestHandler {
             return 502;
         }
         if (error instanceof ExtendedAgentCardNotConfiguredError
-                || error instanceof ExtensionSupportRequiredError) {
+                || error instanceof ExtensionSupportRequiredError
+                || error instanceof VersionNotSupportedError) {
             return 400;
         }
         if (error instanceof InternalError) {

--- a/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
+++ b/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
@@ -11,6 +11,8 @@ import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.a2a.server.ServerCallContext;
 import io.a2a.server.auth.UnauthenticatedUser;
@@ -53,9 +55,8 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
 
         RestHandler.HTTPRestResponse response = handler.getTask(callContext, "", "nonexistent", 0);
 
-        Assertions.assertEquals(404, response.getStatusCode());
-        Assertions.assertEquals("application/problem+json", response.getContentType());
-        Assertions.assertTrue(response.getBody().contains("TaskNotFoundError"));
+        assertProblemDetail(response, 404,
+                "https://a2a-protocol.org/errors/task-not-found", "Task not found");
     }
 
     @Test
@@ -64,9 +65,8 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
 
         RestHandler.HTTPRestResponse response = handler.getTask(callContext, "", MINIMAL_TASK.id(), -1);
 
-        Assertions.assertEquals(422, response.getStatusCode());
-        Assertions.assertEquals("application/problem+json", response.getContentType());
-        Assertions.assertTrue(response.getBody().contains("InvalidParamsError"));
+        assertProblemDetail(response, 422,
+                "https://a2a-protocol.org/errors/invalid-params", "Invalid history length");
     }
 
     @Test
@@ -89,9 +89,8 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         RestHandler.HTTPRestResponse response = handler.listTasks(callContext, "", null, "not-a-status", null, null,
                 null, null, null);
 
-        Assertions.assertEquals(422, response.getStatusCode());
-        Assertions.assertEquals("application/problem+json", response.getContentType());
-        Assertions.assertTrue(response.getBody().contains("InvalidParamsError"));
+        assertProblemDetail(response, 422,
+                "https://a2a-protocol.org/errors/invalid-params", "Invalid params");
     }
 
     @Test
@@ -132,9 +131,8 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         String invalidBody = "invalid json";
         RestHandler.HTTPRestResponse response = handler.sendMessage(callContext, "", invalidBody);
 
-        Assertions.assertEquals(400, response.getStatusCode());
-        Assertions.assertEquals("application/problem+json", response.getContentType());
-        Assertions.assertTrue(response.getBody().contains("JSONParseError"),response.getBody());
+        assertProblemDetail(response, 400,
+                "https://a2a-protocol.org/errors/invalid-request", "Failed to parse json");
     }
 
     @Test
@@ -158,7 +156,11 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
 
         Assertions.assertEquals(422, response.getStatusCode());
         Assertions.assertEquals("application/problem+json", response.getContentType());
-        Assertions.assertTrue(response.getBody().contains("InvalidParamsError"));
+        JsonObject body = JsonParser.parseString(response.getBody()).getAsJsonObject();
+        Assertions.assertEquals(422, body.get("status").getAsInt());
+        Assertions.assertEquals("https://a2a-protocol.org/errors/invalid-params", body.get("type").getAsString());
+        Assertions.assertTrue(body.get("title").getAsString().startsWith("Failed to parse request body:"),
+                "title should indicate parse failure: " + body.get("title").getAsString());
     }
 
     @Test
@@ -167,9 +169,8 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
 
         RestHandler.HTTPRestResponse response = handler.sendMessage(callContext, "", "");
 
-        Assertions.assertEquals(400, response.getStatusCode());
-        Assertions.assertEquals("application/problem+json", response.getContentType());
-        Assertions.assertTrue(response.getBody().contains("InvalidRequestError"));
+        assertProblemDetail(response, 400,
+                "https://a2a-protocol.org/errors/invalid-request", "Request body is required");
     }
 
     @Test
@@ -200,9 +201,8 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         String requestBody = "{\"id\":\"nonexistent\"}";
         RestHandler.HTTPRestResponse response = handler.cancelTask(callContext, "", requestBody, "nonexistent");
 
-        Assertions.assertEquals(404, response.getStatusCode());
-        Assertions.assertEquals("application/problem+json", response.getContentType());
-        Assertions.assertTrue(response.getBody().contains("TaskNotFoundError"));
+        assertProblemDetail(response, 404,
+                "https://a2a-protocol.org/errors/task-not-found", "Task not found");
     }
 
     @Test
@@ -346,8 +346,9 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
 
         RestHandler.HTTPRestResponse response = handler.sendStreamingMessage(callContext, "", requestBody);
 
-        Assertions.assertEquals(400, response.getStatusCode());
-        Assertions.assertTrue(response.getBody().contains("InvalidRequestError"));
+        assertProblemDetail(response, 400,
+                "https://a2a-protocol.org/errors/invalid-request",
+                "Streaming is not supported by the agent");
     }
 
     @Test
@@ -387,8 +388,9 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
 
         RestHandler.HTTPRestResponse response = handler.createTaskPushNotificationConfiguration(callContext, "", requestBody, MINIMAL_TASK.id());
 
-        Assertions.assertEquals(501, response.getStatusCode());
-        Assertions.assertTrue(response.getBody().contains("PushNotificationNotSupportedError"));
+        assertProblemDetail(response, 501,
+                "https://a2a-protocol.org/errors/push-notification-not-supported",
+                "Push Notification is not supported");
     }
 
     @Test
@@ -574,10 +576,9 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
 
         RestHandler.HTTPRestResponse response = handler.sendMessage(callContext, "", requestBody);
 
-        Assertions.assertEquals(400, response.getStatusCode());
-        Assertions.assertEquals("application/problem+json", response.getContentType());
-        Assertions.assertTrue(response.getBody().contains("ExtensionSupportRequiredError"));
-        Assertions.assertTrue(response.getBody().contains("https://example.com/test-extension"));
+        assertProblemDetail(response, 400,
+                "https://a2a-protocol.org/errors/extension-support-required",
+                "Required extension 'https://example.com/test-extension' was not requested by the client");
     }
 
     @Test
@@ -641,7 +642,9 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
 
             @Override
             public void onNext(String item) {
-                if (item.contains("ExtensionSupportRequiredError") && 
+                JsonObject error = JsonParser.parseString(item).getAsJsonObject();
+                if ("https://a2a-protocol.org/errors/extension-support-required".equals(
+                        error.has("type") ? error.get("type").getAsString() : null) &&
                     item.contains("https://example.com/streaming-extension")) {
                     errorFound.set(true);
                 }
@@ -774,10 +777,9 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
 
         RestHandler.HTTPRestResponse response = handler.sendMessage(contextWithVersion, "", requestBody);
 
-        Assertions.assertEquals(501, response.getStatusCode());
-        Assertions.assertEquals("application/problem+json", response.getContentType());
-        Assertions.assertTrue(response.getBody().contains("VersionNotSupportedError"));
-        Assertions.assertTrue(response.getBody().contains("2.0"));
+        assertProblemDetail(response, 501,
+                "https://a2a-protocol.org/errors/version-not-supported",
+                "Protocol version '2.0' is not supported. Supported versions: [1.0]");
     }
 
     @Test
@@ -843,8 +845,10 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
 
             @Override
             public void onNext(String item) {
-                if (item.contains("VersionNotSupportedError") &&
-                    item.contains("2.0")) {
+                JsonObject error = JsonParser.parseString(item).getAsJsonObject();
+                if ("https://a2a-protocol.org/errors/version-not-supported".equals(
+                        error.has("type") ? error.get("type").getAsString() : null) &&
+                    error.has("title") && error.get("title").getAsString().contains("2.0")) {
                     errorFound.set(true);
                 }
             }
@@ -979,9 +983,8 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         RestHandler.HTTPRestResponse response = handler.listTasks(callContext, "", null, null, null, null,
                 null, "-1", null);
 
-        Assertions.assertEquals(422, response.getStatusCode());
-        Assertions.assertEquals("application/problem+json", response.getContentType());
-        Assertions.assertTrue(response.getBody().contains("InvalidParamsError"));
+        assertProblemDetail(response, 422,
+                "https://a2a-protocol.org/errors/invalid-params", "Invalid params");
     }
 
     @Test
@@ -1041,5 +1044,16 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         // Verify empty array, not null
         Assertions.assertTrue(body.contains("\"tasks\":[]") || body.contains("\"tasks\": []"),
                 "tasks should be empty array");
+    }
+
+    private static void assertProblemDetail(RestHandler.HTTPRestResponse response,
+                                            int expectedStatus, String expectedType, String expectedTitle) {
+        Assertions.assertEquals(expectedStatus, response.getStatusCode());
+        Assertions.assertEquals("application/problem+json", response.getContentType());
+        JsonObject body = JsonParser.parseString(response.getBody()).getAsJsonObject();
+        Assertions.assertEquals(expectedStatus, body.get("status").getAsInt(), "status field mismatch");
+        Assertions.assertEquals(expectedType, body.get("type").getAsString(), "type field mismatch");
+        Assertions.assertEquals(expectedTitle, body.get("title").getAsString(), "title field mismatch");
+        Assertions.assertTrue(body.has("details"), "details field should be present");
     }
 }

--- a/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
+++ b/transport/rest/src/test/java/io/a2a/transport/rest/handler/RestHandlerTest.java
@@ -777,7 +777,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
 
         RestHandler.HTTPRestResponse response = handler.sendMessage(contextWithVersion, "", requestBody);
 
-        assertProblemDetail(response, 501,
+        assertProblemDetail(response, 400,
                 "https://a2a-protocol.org/errors/version-not-supported",
                 "Protocol version '2.0' is not supported. Supported versions: [1.0]");
     }


### PR DESCRIPTION
This covers the core fix: the client's RestErrorMapper now reads the type URI from Problem Details responses (introduced by the server-side changes on this branch) instead of the old error/message fields, with backward compatibility for the legacy format.


Fixes #727
Fixes #730  🦕