### PR TITLE
fix: Include google.rpc.ErrorInfo in gRPC error status details

### DIFF
--- a/transport/grpc/src/main/java/io/a2a/transport/grpc/handler/GrpcHandler.java
+++ b/transport/grpc/src/main/java/io/a2a/transport/grpc/handler/GrpcHandler.java
@@ -158,6 +158,10 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
 
     private static final Logger LOGGER = Logger.getLogger(GrpcHandler.class.getName());
 
+    private static final io.grpc.Metadata.Key<com.google.rpc.Status> GRPC_STATUS_DETAILS_KEY =
+            io.grpc.Metadata.Key.of("grpc-status-details-bin",
+                    io.grpc.protobuf.ProtoUtils.metadataMarshaller(com.google.rpc.Status.getDefaultInstance()));
+
     /**
      * Constructs a new GrpcHandler.
      */
@@ -769,7 +773,7 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
             errorReason = "INVALID_AGENT_RESPONSE";
         } else if (error instanceof ExtendedAgentCardNotConfiguredError) {
             status = Status.FAILED_PRECONDITION;
-            description = "ExtendedCardNotConfiguredError: " + error.getMessage();
+            description = "ExtendedAgentCardNotConfiguredError: " + error.getMessage();
             errorReason = "EXTENDED_AGENT_CARD_NOT_CONFIGURED";
         } else if (error instanceof ExtensionSupportRequiredError) {
             status = Status.FAILED_PRECONDITION;
@@ -800,10 +804,7 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
 
         // Create metadata with grpc-status-details-bin
         io.grpc.Metadata trailers = new io.grpc.Metadata();
-        io.grpc.Metadata.Key<com.google.rpc.Status> statusKey =
-                io.grpc.Metadata.Key.of("grpc-status-details-bin",
-                        io.grpc.protobuf.ProtoUtils.metadataMarshaller(com.google.rpc.Status.getDefaultInstance()));
-        trailers.put(statusKey, rpcStatus);
+        trailers.put(GRPC_STATUS_DETAILS_KEY, rpcStatus);
 
         // Send error with ErrorInfo in metadata
         responseObserver.onError(status.withDescription(description).asRuntimeException(trailers));


### PR DESCRIPTION
Per specification requirement GRPC-ERR-001 (section 10.6), A2A-specific errors must include a google.rpc.ErrorInfo message in the status.details array with:
- reason: A2A error type in UPPER_SNAKE_CASE without "Error" suffix
- domain: "a2a-protocol.org"
- metadata: Optional map of additional error context

Modified GrpcHandler.handleError() to:
1. Create google.rpc.ErrorInfo with appropriate reason and domain
2. Build google.rpc.Status containing the ErrorInfo in details
3. Include Status in grpc-status-details-bin trailing metadata
4. Rename ExtendedCardNotConfiguredError to ExtendedAgentCardNotConfiguredError. This wasn't part of the original work done in this PR, but was picked up by the Gemini review, so I included it

This ensures gRPC error responses comply with the A2A specification by providing structured error information that clients can programmatically inspect and handle.

Fixes #731 