### PR TITLE
feat!: New permanent groupId: org.a2aproject.sdk

### DIFF
--- a/.enforcer-scripts/validate-jbang-versions.groovy
+++ b/.enforcer-scripts/validate-jbang-versions.groovy
@@ -14,7 +14,7 @@ if (!jbangFile.exists()) {
 }
 
 def expectedVersion = project.version
-def groupPrefix = "//DEPS io.github.a2asdk:"
+def groupPrefix = "//DEPS org.a2aproject.sdk:"
 def success = true
 
 jbangFile.eachLine { line ->

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -60,19 +60,19 @@ jobs:
             // Add Maven Central installation instructions
             releaseNotes += `### Installation\n\n`;
             releaseNotes += `**Maven**:\n\`\`\`xml\n<dependency>\n`;
-            releaseNotes += `    <groupId>io.github.a2asdk</groupId>\n`;
+            releaseNotes += `    <groupId>org.a2aproject.sdk</groupId>\n`;
             releaseNotes += `    <artifactId>a2a-java-sdk-client</artifactId>\n`;
             releaseNotes += `    <version>${version}</version>\n`;
             releaseNotes += `</dependency>\n\`\`\`\n\n`;
 
             releaseNotes += `**Gradle**:\n\`\`\`gradle\n`;
-            releaseNotes += `implementation 'io.github.a2asdk:a2a-java-sdk-client:${version}'\n`;
+            releaseNotes += `implementation 'org.a2aproject.sdk:a2a-java-sdk-client:${version}'\n`;
             releaseNotes += `\`\`\`\n\n`;
 
             // Add links
             releaseNotes += `### Links\n\n`;
-            releaseNotes += `- [Maven Central](https://central.sonatype.com/artifact/io.github.a2asdk/a2a-java-sdk-parent/${version})\n`;
-            releaseNotes += `- [JavaDoc](https://javadoc.io/doc/io.github.a2asdk/a2a-java-sdk-parent/${version})\n`;
+            releaseNotes += `- [Maven Central](https://central.sonatype.com/artifact/org.a2aproject.sdk/a2a-java-sdk-parent/${version})\n`;
+            releaseNotes += `- [JavaDoc](https://javadoc.io/doc/org.a2aproject.sdk/a2a-java-sdk-parent/${version})\n`;
             releaseNotes += `- [GitHub](https://github.com/a2aproject/a2a-java/tree/v${version})\n\n`;
 
             // Add changelog header
@@ -115,7 +115,7 @@ jobs:
               core.summary
                 .addHeading(`Release v${version} Created`)
                 .addLink('View Release', release.html_url)
-                .addLink('Maven Central', `https://central.sonatype.com/artifact/io.github.a2asdk/a2a-java-sdk-parent/${version}`)
+                .addLink('Maven Central', `https://central.sonatype.com/artifact/org.a2aproject.sdk/a2a-java-sdk-parent/${version}`)
                 .write();
 
             } catch (error) {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Java SDK for the [Agent2Agent (A2A) Protocol](https://a2a-protocol.org/). Multi-module Maven project (`io.github.a2asdk` group) providing client and server libraries for A2A agent communication over JSON-RPC, gRPC, and REST transports.
+Java SDK for the [Agent2Agent (A2A) Protocol](https://a2a-protocol.org/). Multi-module Maven project (`org.a2aproject.sdk` group) providing client and server libraries for A2A agent communication over JSON-RPC, gRPC, and REST transports.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,9 @@ The A2A Java SDK Reference Server implementations support the following transpor
 
 To use the reference implementation with the JSON-RPC protocol, add the following dependency to your project:
 
-> *⚠️ The `io.github.a2asdk` `groupId` below is temporary and will likely change for future releases.*
-
 ```xml
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
     <!-- Use a released version from https://github.com/a2aproject/a2a-java/releases --> 
     <version>${io.a2a.sdk.version}</version>
@@ -71,11 +69,9 @@ To use the reference implementation with the JSON-RPC protocol, add the followin
 
 To use the reference implementation with the gRPC protocol, add the following dependency to your project:
 
-> *⚠️ The `io.github.a2asdk` `groupId` below is temporary and will likely change for future releases.*
-
 ```xml
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-sdk-reference-grpc</artifactId>
     <!-- Use a released version from https://github.com/a2aproject/a2a-java/releases --> 
     <version>${io.a2a.sdk.version}</version>
@@ -84,11 +80,9 @@ To use the reference implementation with the gRPC protocol, add the following de
 
 To use the reference implementation with the HTTP+JSON/REST protocol, add the following dependency to your project:
 
-> *⚠️ The `io.github.a2asdk` `groupId` below is temporary and will likely change for future releases.*
-
 ```xml
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-sdk-reference-rest</artifactId>
     <!-- Use a released version from https://github.com/a2aproject/a2a-java/releases --> 
     <version>${io.a2a.sdk.version}</version>
@@ -291,13 +285,9 @@ To make use of the Java `Client`:
 Adding a dependency on `a2a-java-sdk-client` will provide access to a `ClientBuilder`
 that you can use to create your A2A `Client`.
 
-----
-> *⚠️ The `io.github.a2asdk` `groupId` below is temporary and will likely change for future releases.*
-----
-
 ```xml
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-sdk-client</artifactId>
     <!-- Use a released version from https://github.com/a2aproject/a2a-java/releases -->
     <version>${io.a2a.sdk.version}</version>
@@ -311,13 +301,9 @@ By default, the `sdk-client` artifact includes the JSONRPC transport dependency.
 
 If you want to use the gRPC transport, you'll need to add a relevant dependency:
 
-----
-> *⚠️ The `io.github.a2asdk` `groupId` below is temporary and will likely change for future releases.*
-----
-
 ```xml
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-sdk-client-transport-grpc</artifactId>
     <!-- Use a released version from https://github.com/a2aproject/a2a-java/releases -->
     <version>${io.a2a.sdk.version}</version>
@@ -327,13 +313,10 @@ If you want to use the gRPC transport, you'll need to add a relevant dependency:
 
 If you want to use the HTTP+JSON/REST transport, you'll need to add a relevant dependency:
 
-----
-> *⚠️ The `io.github.a2asdk` `groupId` below is temporary and will likely change for future releases.*
-----
 
 ```xml
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-sdk-client-transport-rest</artifactId>
     <!-- Use a released version from https://github.com/a2aproject/a2a-java/releases -->
     <version>${io.a2a.sdk.version}</version>

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ The release process involves:
 
 ### Required Accounts & Access
 - GitHub repository write access to `a2aproject/a2a-java`
-- Maven Central account: namespace: `io.github.a2asdk`
+- Maven Central account: namespace: `org.a2aproject.sdk`
 
 ### Required Secrets (Repository Maintainers)
 The following secrets must be configured in GitHub repository settings:
@@ -140,7 +140,7 @@ Check that artifacts are available:
 
 **Maven Central**:
 ```
-https://central.sonatype.com/artifact/io.github.a2asdk/a2a-java-sdk-parent/0.4.0.Alpha1
+https://central.sonatype.com/artifact/org.a2aproject.sdk/a2a-java-sdk-parent/0.4.0.Alpha1
 ```
 
 **GitHub Release**:
@@ -184,7 +184,7 @@ Open PR, wait for CI, and merge.
 ./update-version.sh OLD_VERSION NEW_VERSION
 
 # Or manually check:
-grep -r "//DEPS io.github.a2asdk:" examples/
+grep -r "//DEPS org.a2aproject.sdk:" examples/
 ```
 
 ### GPG signing fails in workflow

--- a/boms/README.md
+++ b/boms/README.md
@@ -14,7 +14,7 @@ The A2A Java SDK provides three BOMs for different use cases:
 
 ### SDK BOM (`boms/sdk`)
 
-**Artifact:** `io.github.a2asdk:a2a-java-sdk-bom`
+**Artifact:** `org.a2aproject.sdk:a2a-java-sdk-bom`
 
 The SDK BOM includes:
 - All A2A SDK core modules (spec, server, client, transport)
@@ -26,7 +26,7 @@ The SDK BOM includes:
 
 ### Extras BOM (`boms/extras`)
 
-**Artifact:** `io.github.a2asdk:a2a-java-sdk-extras-bom`
+**Artifact:** `org.a2aproject.sdk:a2a-java-sdk-extras-bom`
 
 The Extras BOM includes:
 - Everything from `a2a-java-sdk-bom` (via import)
@@ -36,7 +36,7 @@ The Extras BOM includes:
 
 ### Reference BOM (`boms/reference`)
 
-**Artifact:** `io.github.a2asdk:a2a-java-sdk-reference-bom`
+**Artifact:** `org.a2aproject.sdk:a2a-java-sdk-reference-bom`
 
 The Reference BOM includes:
 - Everything from `a2a-java-sdk-bom` (via import)
@@ -56,7 +56,7 @@ Add to your project's `pom.xml`:
 <dependencyManagement>
     <dependencies>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-bom</artifactId>
             <version>${io.a2a.sdk.version}</version>
             <type>pom</type>
@@ -68,11 +68,11 @@ Add to your project's `pom.xml`:
 <dependencies>
     <!-- No version needed - managed by BOM -->
     <dependency>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-server-common</artifactId>
     </dependency>
     <dependency>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-transport-jsonrpc</artifactId>
     </dependency>
 </dependencies>
@@ -86,7 +86,7 @@ Add to your project's `pom.xml`:
 <dependencyManagement>
     <dependencies>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-extras-bom</artifactId>
             <version>${io.a2a.sdk.version}</version>
             <type>pom</type>
@@ -98,11 +98,11 @@ Add to your project's `pom.xml`:
 <dependencies>
     <!-- No version needed - managed by BOM -->
     <dependency>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-server-common</artifactId>
     </dependency>
     <dependency>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-extras-task-store-database-jpa</artifactId>
     </dependency>
 </dependencies>
@@ -116,7 +116,7 @@ Add to your project's `pom.xml`:
 <dependencyManagement>
     <dependencies>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-bom</artifactId>
             <version>${io.a2a.sdk.version}</version>
             <type>pom</type>
@@ -128,7 +128,7 @@ Add to your project's `pom.xml`:
 <dependencies>
     <!-- A2A SDK and Quarkus versions both managed -->
     <dependency>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
     </dependency>
     <dependency>

--- a/boms/extras/pom.xml
+++ b/boms/extras/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
@@ -111,7 +111,7 @@
                     <invokerPropertiesFile>invoker.properties</invokerPropertiesFile>
                     <!-- Install test-utils module before running integration tests -->
                     <extraArtifacts>
-                        <extraArtifact>io.github.a2asdk:a2a-java-bom-test-utils:${project.version}:jar</extraArtifact>
+                        <extraArtifact>org.a2aproject.sdk:a2a-java-bom-test-utils:${project.version}:jar</extraArtifact>
                     </extraArtifacts>
                 </configuration>
                 <executions>

--- a/boms/extras/src/it/extras-usage-test/pom.xml
+++ b/boms/extras/src/it/extras-usage-test/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.github.a2asdk.it</groupId>
+    <groupId>org.a2aproject.sdk.it</groupId>
     <artifactId>extras-bom-usage-test</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -22,7 +22,7 @@
         <dependencies>
             <!-- Import the Extras BOM - this is what we're testing -->
             <dependency>
-                <groupId>io.github.a2asdk</groupId>
+                <groupId>org.a2aproject.sdk</groupId>
                 <artifactId>a2a-java-sdk-extras-bom</artifactId>
                 <version>@project.version@</version>
                 <type>pom</type>
@@ -34,96 +34,96 @@
     <dependencies>
         <!-- BOM Test Utilities -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-bom-test-utils</artifactId>
             <version>@project.version@</version>
         </dependency>
 
         <!-- Extras modules -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-extras-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-http-client-vertx</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-opentelemetry-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-opentelemetry-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-opentelemetry-client-propagation</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-opentelemetry-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-extras-task-store-database-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-extras-push-notification-config-store-database-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-queue-manager-replicated-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-queue-manager-replication-mp-reactive</artifactId>
         </dependency>
 
         <!-- Core SDK modules (inherited from SDK BOM via Extras BOM) -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-spec</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-spec-grpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-server-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-microprofile-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client-transport-grpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client-transport-jsonrpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client-transport-rest</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-transport-jsonrpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-transport-grpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-transport-rest</artifactId>
         </dependency>
 

--- a/boms/reference/pom.xml
+++ b/boms/reference/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
@@ -97,7 +97,7 @@
                     <invokerPropertiesFile>invoker.properties</invokerPropertiesFile>
                     <!-- Install test-utils module before running integration tests -->
                     <extraArtifacts>
-                        <extraArtifact>io.github.a2asdk:a2a-java-bom-test-utils:${project.version}:jar</extraArtifact>
+                        <extraArtifact>org.a2aproject.sdk:a2a-java-bom-test-utils:${project.version}:jar</extraArtifact>
                     </extraArtifacts>
                 </configuration>
                 <executions>

--- a/boms/reference/src/it/reference-usage-test/pom.xml
+++ b/boms/reference/src/it/reference-usage-test/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.github.a2asdk.it</groupId>
+    <groupId>org.a2aproject.sdk.it</groupId>
     <artifactId>reference-bom-usage-test</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -21,7 +21,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.github.a2asdk</groupId>
+                <groupId>org.a2aproject.sdk</groupId>
                 <artifactId>a2a-java-sdk-reference-bom</artifactId>
                 <version>@project.version@</version>
                 <type>pom</type>
@@ -33,60 +33,60 @@
     <dependencies>
         <!-- BOM Test Utilities -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-bom-test-utils</artifactId>
             <version>@project.version@</version>
         </dependency>
 
         <!-- All reference implementation modules -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-grpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-rest</artifactId>
         </dependency>
 
         <!-- Core SDK modules (inherited from SDK BOM via Reference BOM) -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-spec</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-spec-grpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-server-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-microprofile-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client-transport-grpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client-transport-rest</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-transport-jsonrpc</artifactId>
         </dependency>
 

--- a/boms/sdk/pom.xml
+++ b/boms/sdk/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
@@ -249,7 +249,7 @@
                     <invokerPropertiesFile>invoker.properties</invokerPropertiesFile>
                     <!-- Install test-utils module before running integration tests -->
                     <extraArtifacts>
-                        <extraArtifact>io.github.a2asdk:a2a-java-bom-test-utils:${project.version}:jar</extraArtifact>
+                        <extraArtifact>org.a2aproject.sdk:a2a-java-bom-test-utils:${project.version}:jar</extraArtifact>
                     </extraArtifacts>
                 </configuration>
                 <executions>

--- a/boms/sdk/src/it/sdk-usage-test/pom.xml
+++ b/boms/sdk/src/it/sdk-usage-test/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.github.a2asdk.it</groupId>
+    <groupId>org.a2aproject.sdk.it</groupId>
     <artifactId>sdk-bom-usage-test</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -22,7 +22,7 @@
         <dependencies>
             <!-- Import the SDK BOM - this is what we're testing -->
             <dependency>
-                <groupId>io.github.a2asdk</groupId>
+                <groupId>org.a2aproject.sdk</groupId>
                 <artifactId>a2a-java-sdk-bom</artifactId>
                 <version>@project.version@</version>
                 <type>pom</type>
@@ -34,72 +34,72 @@
     <dependencies>
         <!-- BOM Test Utilities -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-bom-test-utils</artifactId>
             <version>@project.version@</version>
         </dependency>
 
         <!-- Spec modules -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-spec</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-spec-grpc</artifactId>
         </dependency>
 
         <!-- Common modules -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-common</artifactId>
         </dependency>
 
         <!-- Server modules -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-server-common</artifactId>
         </dependency>
 
         <!-- Integration modules -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-microprofile-config</artifactId>
         </dependency>
 
         <!-- Client modules -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client-transport-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client-transport-jsonrpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client-transport-grpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client-transport-rest</artifactId>
         </dependency>
 
         <!-- Transport modules -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-transport-jsonrpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-transport-grpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-transport-rest</artifactId>
         </dependency>
 

--- a/boms/test-utils/pom.xml
+++ b/boms/test-utils/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/client/base/pom.xml
+++ b/client/base/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/client/transport/grpc/pom.xml
+++ b/client/transport/grpc/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>

--- a/client/transport/jsonrpc/pom.xml
+++ b/client/transport/jsonrpc/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>

--- a/client/transport/rest/pom.xml
+++ b/client/transport/rest/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
@@ -39,7 +39,7 @@
             <artifactId>a2a-java-sdk-client-transport-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-http-client</artifactId>
         </dependency>
         <dependency>

--- a/client/transport/spi/pom.xml
+++ b/client/transport/spi/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
@@ -18,7 +18,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-spec</artifactId>
         </dependency>
         <dependency>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
     </parent>

--- a/examples/cloud-deployment/README.md
+++ b/examples/cloud-deployment/README.md
@@ -545,23 +545,23 @@ From `pom.xml`:
 ```xml
 <!-- A2A SDK with JSON-RPC transport -->
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
 </dependency>
 
 <!-- Database task storage -->
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-extras-task-store-database-jpa</artifactId>
 </dependency>
 
 <!-- Replicated event queue manager -->
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-queue-manager-replicated-core</artifactId>
 </dependency>
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-queue-manager-replication-mp-reactive</artifactId>
 </dependency>
 

--- a/examples/cloud-deployment/server/pom.xml
+++ b/examples/cloud-deployment/server/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
@@ -19,35 +19,35 @@
     <dependencies>
         <!-- Core A2A SDK with JSON-RPC transport. This pulls in the rest of the needed a2a-java dependencies -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <!-- Database-backed task store -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-extras-task-store-database-jpa</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <!-- Database-backed push notification config store -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-extras-push-notification-config-store-database-jpa</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <!-- Replicated queue manager core -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-queue-manager-replicated-core</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <!-- Provides the MicroProfile Reactive Messaging ReplicationStrategy for the replicated queue manager-->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-queue-manager-replication-mp-reactive</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -80,7 +80,7 @@
         </dependency>
 
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client</artifactId>
             <scope>test</scope>
         </dependency>

--- a/examples/helloworld/client/pom.xml
+++ b/examples/helloworld/client/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-examples-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
     </parent>
@@ -21,27 +21,27 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-jsonrpc-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client-transport-grpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client-transport-rest</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-opentelemetry-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-opentelemetry-client-propagation</artifactId>
         </dependency>
         <dependency>

--- a/examples/helloworld/client/src/main/java/io/a2a/examples/helloworld/HelloWorldRunner.java
+++ b/examples/helloworld/client/src/main/java/io/a2a/examples/helloworld/HelloWorldRunner.java
@@ -1,12 +1,12 @@
 
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 
-//DEPS io.github.a2asdk:a2a-java-sdk-client:1.0.0.Alpha4-SNAPSHOT
-//DEPS io.github.a2asdk:a2a-java-sdk-client-transport-jsonrpc:1.0.0.Alpha4-SNAPSHOT
-//DEPS io.github.a2asdk:a2a-java-sdk-client-transport-grpc:1.0.0.Alpha4-SNAPSHOT
-//DEPS io.github.a2asdk:a2a-java-sdk-client-transport-rest:1.0.0.Alpha4-SNAPSHOT
-//DEPS io.github.a2asdk:a2a-java-sdk-opentelemetry-client:1.0.0.Alpha4-SNAPSHOT
-//DEPS io.github.a2asdk:a2a-java-sdk-opentelemetry-client-propagation:1.0.0.Alpha4-SNAPSHOT
+//DEPS org.a2aproject.sdk:a2a-java-sdk-client:1.0.0.Alpha4-SNAPSHOT
+//DEPS org.a2aproject.sdk:a2a-java-sdk-client-transport-jsonrpc:1.0.0.Alpha4-SNAPSHOT
+//DEPS org.a2aproject.sdk:a2a-java-sdk-client-transport-grpc:1.0.0.Alpha4-SNAPSHOT
+//DEPS org.a2aproject.sdk:a2a-java-sdk-client-transport-rest:1.0.0.Alpha4-SNAPSHOT
+//DEPS org.a2aproject.sdk:a2a-java-sdk-opentelemetry-client:1.0.0.Alpha4-SNAPSHOT
+//DEPS org.a2aproject.sdk:a2a-java-sdk-opentelemetry-client-propagation:1.0.0.Alpha4-SNAPSHOT
 //DEPS io.opentelemetry:opentelemetry-sdk:1.55.0
 //DEPS io.opentelemetry:opentelemetry-exporter-otlp:1.55.0
 //DEPS io.opentelemetry:opentelemetry-exporter-logging:1.55.0

--- a/examples/helloworld/pom.xml
+++ b/examples/helloworld/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
@@ -27,7 +27,7 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>io.github.a2asdk</groupId>
+                <groupId>org.a2aproject.sdk</groupId>
                 <artifactId>a2a-java-sdk-client</artifactId>
             </dependency>
         </dependencies>

--- a/examples/helloworld/server/pom.xml
+++ b/examples/helloworld/server/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-examples-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
     </parent>
@@ -17,11 +17,11 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
         </dependency>
         <dependency>
@@ -30,11 +30,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-grpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-rest</artifactId>
         </dependency>
         <dependency>
@@ -75,7 +75,7 @@
             <id>opentelemetry</id>
             <dependencies>
                 <dependency>
-                    <groupId>io.github.a2asdk</groupId>
+                    <groupId>org.a2aproject.sdk</groupId>
                     <artifactId>a2a-java-sdk-opentelemetry-server</artifactId>
                 </dependency>
                 <dependency>

--- a/extras/common/pom.xml
+++ b/extras/common/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/extras/http-client-vertx/README.md
+++ b/extras/http-client-vertx/README.md
@@ -62,7 +62,7 @@ Add this module to your project's `pom.xml`:
 
 ```xml
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-sdk-http-client-vertx</artifactId>
     <version>${a2a.version}</version>
 </dependency>

--- a/extras/http-client-vertx/pom.xml
+++ b/extras/http-client-vertx/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/extras/opentelemetry/client-propagation/pom.xml
+++ b/extras/opentelemetry/client-propagation/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-opentelemetry-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
     </parent>

--- a/extras/opentelemetry/client/pom.xml
+++ b/extras/opentelemetry/client/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-opentelemetry-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
     </parent>

--- a/extras/opentelemetry/common/pom.xml
+++ b/extras/opentelemetry/common/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-opentelemetry-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
     </parent>

--- a/extras/opentelemetry/integration-tests/pom.xml
+++ b/extras/opentelemetry/integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-opentelemetry-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
     </parent>

--- a/extras/opentelemetry/pom.xml
+++ b/extras/opentelemetry/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/extras/opentelemetry/server/pom.xml
+++ b/extras/opentelemetry/server/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-opentelemetry-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
     </parent>

--- a/extras/push-notification-config-store-database-jpa/README.md
+++ b/extras/push-notification-config-store-database-jpa/README.md
@@ -12,7 +12,7 @@ Add this module to your project's `pom.xml`:
 
 ```xml
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-extras-push-notification-config-store-database-jpa</artifactId>
     <version>${a2a.version}</version>
 </dependency>

--- a/extras/push-notification-config-store-database-jpa/pom.xml
+++ b/extras/push-notification-config-store-database-jpa/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/extras/queue-manager-replicated/README.md
+++ b/extras/queue-manager-replicated/README.md
@@ -25,7 +25,7 @@ Add the core replicated queue manager module to your project's `pom.xml`:
 
 ```xml
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-queue-manager-replicated-core</artifactId>
     <version>${a2a.version}</version>
 </dependency>
@@ -39,7 +39,7 @@ You must also include a replication strategy implementation. Currently, we provi
 
 ```xml
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-queue-manager-replication-mp-reactive</artifactId>
     <version>${a2a.version}</version>
 </dependency>

--- a/extras/queue-manager-replicated/core/pom.xml
+++ b/extras/queue-manager-replicated/core/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-queue-manager-replicated-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -16,17 +16,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-server-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-jsonrpc-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-extras-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/extras/queue-manager-replicated/pom.xml
+++ b/extras/queue-manager-replicated/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/extras/queue-manager-replicated/replication-mp-reactive/pom.xml
+++ b/extras/queue-manager-replicated/replication-mp-reactive/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-queue-manager-replicated-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -16,12 +16,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-queue-manager-replicated-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-jsonrpc-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/extras/queue-manager-replicated/tests-multi-instance/pom.xml
+++ b/extras/queue-manager-replicated/tests-multi-instance/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-queue-manager-replicated-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-1/pom.xml
+++ b/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-1/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-queue-manager-replicated-tests-multi-instance-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -17,32 +17,32 @@
     <dependencies>
         <!-- Common test code -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-queue-manager-replicated-tests-multi-instance-common</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <!-- Replicated Queue Manager -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-queue-manager-replicated-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-queue-manager-replication-mp-reactive</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <!-- A2A Reference Implementation -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
         </dependency>
 
         <!-- JPA TaskStore for shared database -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-extras-task-store-database-jpa</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-2/pom.xml
+++ b/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-2/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-queue-manager-replicated-tests-multi-instance-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -17,32 +17,32 @@
     <dependencies>
         <!-- Common test code -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-queue-manager-replicated-tests-multi-instance-common</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <!-- Replicated Queue Manager -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-queue-manager-replicated-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-queue-manager-replication-mp-reactive</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <!-- A2A Reference Implementation -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
         </dependency>
 
         <!-- JPA TaskStore for shared database -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-extras-task-store-database-jpa</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/extras/queue-manager-replicated/tests-multi-instance/quarkus-common/pom.xml
+++ b/extras/queue-manager-replicated/tests-multi-instance/quarkus-common/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-queue-manager-replicated-tests-multi-instance-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -17,13 +17,13 @@
     <dependencies>
         <!-- A2A Spec -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-spec</artifactId>
         </dependency>
 
         <!-- A2A Server Common -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-server-common</artifactId>
         </dependency>
 

--- a/extras/queue-manager-replicated/tests-multi-instance/tests/pom.xml
+++ b/extras/queue-manager-replicated/tests-multi-instance/tests/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-queue-manager-replicated-tests-multi-instance-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -17,12 +17,12 @@
     <dependencies>
         <!-- A2A Client for testing -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-transport-jsonrpc</artifactId>
             <scope>test</scope>
         </dependency>
@@ -77,7 +77,7 @@
 
         <!-- Docker test utilities -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-test-utils-docker</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extras/queue-manager-replicated/tests-single-instance/pom.xml
+++ b/extras/queue-manager-replicated/tests-single-instance/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-queue-manager-replicated-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -16,30 +16,30 @@
     <dependencies>
         <!-- Project Modules -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-queue-manager-replicated-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-queue-manager-replication-mp-reactive</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-jsonrpc-common</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <!-- A2A Reference Impl for a runnable app -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
         </dependency>
 
         <!-- JPA TaskStore for testing poison pill generation -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-extras-task-store-database-jpa</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -57,12 +57,12 @@
 
         <!-- A2A Client for testing -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-transport-jsonrpc</artifactId>
             <scope>test</scope>
         </dependency>
@@ -86,7 +86,7 @@
 
         <!-- Docker test utilities -->
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-test-utils-docker</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extras/task-store-database-jpa/README.md
+++ b/extras/task-store-database-jpa/README.md
@@ -12,7 +12,7 @@ Add this module to your project's `pom.xml`:
 
 ```xml
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-extras-task-store-database-jpa</artifactId>
     <version>${a2a.version}</version>
 </dependency>

--- a/extras/task-store-database-jpa/pom.xml
+++ b/extras/task-store-database-jpa/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
     </parent>

--- a/integrations/microprofile-config/README.md
+++ b/integrations/microprofile-config/README.md
@@ -18,7 +18,7 @@ This module provides `MicroProfileConfigProvider`, which integrates with MicroPr
 
 ```xml
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-sdk-microprofile-config</artifactId>
     <version>${io.a2a.sdk.version}</version>
 </dependency>

--- a/integrations/microprofile-config/pom.xml
+++ b/integrations/microprofile-config/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/jsonrpc-common/pom.xml
+++ b/jsonrpc-common/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-sdk-parent</artifactId>
     <version>1.0.0.Alpha4-SNAPSHOT</version>
 
@@ -191,37 +191,37 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.github.a2asdk</groupId>
+                <groupId>org.a2aproject.sdk</groupId>
                 <artifactId>a2a-java-sdk-opentelemetry</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.github.a2asdk</groupId>
+                <groupId>org.a2aproject.sdk</groupId>
                 <artifactId>a2a-java-sdk-opentelemetry-spring</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.github.a2asdk</groupId>
+                <groupId>org.a2aproject.sdk</groupId>
                 <artifactId>a2a-java-sdk-opentelemetry-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.github.a2asdk</groupId>
+                <groupId>org.a2aproject.sdk</groupId>
                 <artifactId>a2a-java-sdk-opentelemetry-client</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.github.a2asdk</groupId>
+                <groupId>org.a2aproject.sdk</groupId>
                 <artifactId>a2a-java-sdk-opentelemetry-server</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.github.a2asdk</groupId>
+                <groupId>org.a2aproject.sdk</groupId>
                 <artifactId>a2a-java-sdk-opentelemetry-client-propagation</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.github.a2asdk</groupId>
+                <groupId>org.a2aproject.sdk</groupId>
                 <artifactId>a2a-java-test-utils-docker</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/reference/common/pom.xml
+++ b/reference/common/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/reference/grpc/pom.xml
+++ b/reference/grpc/pom.xml
@@ -4,7 +4,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/reference/grpc/src/main/java/io/a2a/server/grpc/quarkus/package-info.java
+++ b/reference/grpc/src/main/java/io/a2a/server/grpc/quarkus/package-info.java
@@ -71,7 +71,7 @@
  * <p><b>Add Dependency:</b>
  * <pre>{@code
  * <dependency>
- *   <groupId>io.github.a2asdk</groupId>
+ *   <groupId>org.a2aproject.sdk</groupId>
  *   <artifactId>a2a-java-sdk-reference-grpc</artifactId>
  *   <version>${a2a.version}</version>
  * </dependency>

--- a/reference/jsonrpc/pom.xml
+++ b/reference/jsonrpc/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/reference/rest/pom.xml
+++ b/reference/rest/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/reference/rest/src/main/java/io/a2a/server/rest/quarkus/package-info.java
+++ b/reference/rest/src/main/java/io/a2a/server/rest/quarkus/package-info.java
@@ -47,7 +47,7 @@
  * <p>Add this module as a dependency to your Quarkus project:
  * <pre>{@code
  * <dependency>
- *   <groupId>io.github.a2asdk</groupId>
+ *   <groupId>org.a2aproject.sdk</groupId>
  *   <artifactId>a2a-java-sdk-reference-rest</artifactId>
  *   <version>${a2a.version}</version>
  * </dependency>

--- a/server-common/pom.xml
+++ b/server-common/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
     </parent>

--- a/spec-grpc/pom.xml
+++ b/spec-grpc/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
     </parent>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
     </parent>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
     </parent>
@@ -21,11 +21,11 @@
             <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-grpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-rest</artifactId>
         </dependency>
         <dependency>

--- a/test-utils-docker/README.md
+++ b/test-utils-docker/README.md
@@ -12,7 +12,7 @@ Add the dependency to your test module:
 
 ```xml
 <dependency>
-    <groupId>io.github.a2asdk</groupId>
+    <groupId>org.a2aproject.sdk</groupId>
     <artifactId>a2a-java-test-utils-docker</artifactId>
     <scope>test</scope>
 </dependency>

--- a/test-utils-docker/pom.xml
+++ b/test-utils-docker/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/tests/server-common/pom.xml
+++ b/tests/server-common/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
@@ -56,17 +56,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client-transport-jsonrpc</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client-transport-grpc</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-client-transport-rest</artifactId>
             <scope>test</scope>
         </dependency>

--- a/transport/grpc/pom.xml
+++ b/transport/grpc/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
@@ -19,7 +19,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-server-common</artifactId>
         </dependency>
         <dependency>

--- a/transport/jsonrpc/pom.xml
+++ b/transport/jsonrpc/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
@@ -19,19 +19,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-server-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-spec-grpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-spec</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-jsonrpc-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/transport/rest/pom.xml
+++ b/transport/rest/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.a2asdk</groupId>
+        <groupId>org.a2aproject.sdk</groupId>
         <artifactId>a2a-java-sdk-parent</artifactId>
         <version>1.0.0.Alpha4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
@@ -19,19 +19,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-server-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-spec-grpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-spec</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.a2asdk</groupId>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-jsonrpc-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/update-version.sh
+++ b/update-version.sh
@@ -44,7 +44,7 @@ echo ""
 
 # Find all files to update
 POM_FILES=$(find . -type f -name "pom.xml" | sort)
-JBANG_FILES=$(find . -type f -name "*.java" -path "*/examples/*" -exec grep -l "//DEPS io.github.a2asdk:" {} \; | sort)
+JBANG_FILES=$(find . -type f -name "*.java" -path "*/examples/*" -exec grep -l "//DEPS org.a2aproject.sdk:" {} \; | sort)
 
 POM_COUNT=$(echo "$POM_FILES" | wc -l | tr -d ' ')
 JBANG_COUNT=$(echo "$JBANG_FILES" | wc -l | tr -d ' ')
@@ -69,9 +69,9 @@ if [ "$DRY_RUN" = true ]; then
 
     echo "=== JBang files with version $FROM_VERSION ==="
     for file in $JBANG_FILES; do
-        if grep -q "//DEPS io.github.a2asdk:.*:$FROM_VERSION" "$file"; then
+        if grep -q "//DEPS org.a2aproject.sdk:.*:$FROM_VERSION" "$file"; then
             echo "  📝 $file"
-            grep -n "//DEPS io.github.a2asdk:.*:$FROM_VERSION" "$file" | sed 's/^/      /'
+            grep -n "//DEPS org.a2aproject.sdk:.*:$FROM_VERSION" "$file" | sed 's/^/      /'
         fi
     done
     echo ""
@@ -107,13 +107,13 @@ echo ""
 # Update JBang files
 echo "Updating JBang script files..."
 for file in $JBANG_FILES; do
-    if grep -q "//DEPS io.github.a2asdk:.*:$FROM_VERSION" "$file"; then
+    if grep -q "//DEPS org.a2aproject.sdk:.*:$FROM_VERSION" "$file"; then
         if [[ "$OSTYPE" == "darwin"* ]]; then
             # macOS requires empty string after -i
-            sed -i "" -e "s/\(\/\/DEPS io.github.a2asdk:.*:\)$FROM_VERSION/\1$TO_VERSION/g" "$file"
+            sed -i "" -e "s/\(\/\/DEPS org.a2aproject.sdk:.*:\)$FROM_VERSION/\1$TO_VERSION/g" "$file"
         else
             # Linux doesn't need it
-            sed -i "s/\(\/\/DEPS io.github.a2asdk:.*:\)$FROM_VERSION/\1$TO_VERSION/g" "$file"
+            sed -i "s/\(\/\/DEPS org.a2aproject.sdk:.*:\)$FROM_VERSION/\1$TO_VERSION/g" "$file"
         fi
         echo "  ✅ $file"
         UPDATED_JBANGS=$((UPDATED_JBANGS + 1))


### PR DESCRIPTION
The old io.github.a2asdk was temporary. It was decided to not change the package names.

Breaking Change:
------------------
Going forward `org.a2aproject.sdk` will be used as the groupId instead of `io.github.a2asdk`