### PR TITLE
chore: update a2a.proto to v1.0.0 tag

### DIFF
--- a/spec-grpc/src/main/proto/a2a.proto
+++ b/spec-grpc/src/main/proto/a2a.proto
@@ -9,7 +9,7 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
-// From commit 601c408
+// From tag v1.0.0
 
 option csharp_namespace = "Lf.A2a.V1";
 option go_package = "google.golang.org/lf/a2a/v1";


### PR DESCRIPTION
The proto definitions did not change betwee the previous commit (601c408) and the v1.0.0 tag.

Update the tracking comment to reference the
official release tag.