### PR TITLE
fix: Reject messages to tasks in terminal states

### DIFF
--- a/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
@@ -1034,6 +1034,13 @@ public class DefaultRequestHandler implements RequestHandler {
                         task.id(), task.contextId(), messageContextId));
             }
 
+            // Per spec CORE-SEND-002: Reject messages to tasks in terminal states
+            if (task.status().state().isFinal()) {
+                throw new UnsupportedOperationError(null, String.format(
+                        "Cannot send message to task %s: task is in terminal state %s and cannot accept further messages",
+                        task.id(), task.status().state()), null);
+            }
+
             LOGGER.debug("Found task updating with message {}", params.message());
             task = taskManager.updateWithMessage(params.message(), task);
 


### PR DESCRIPTION
Per A2A spec CORE-SEND-002, SendMessage must return UnsupportedOperationError when attempting to send messages to tasks in terminal states (completed, canceled, rejected, failed).

Added validation in DefaultRequestHandler.initMessageSend() to check if the existing task is in a terminal state (using TaskState.isFinal()) and throw UnsupportedOperationError before the message reaches the AgentExecutor.

This fixes the issue on all three transports (JSON-RPC, gRPC, HTTP+JSON) since they all use the same DefaultRequestHandler code path.

Fixes #741 🦕