### PR TITLE
fix: omit optional fields with default values from client JSON serialization

### DIFF
--- a/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JsonMessages.java
+++ b/client/transport/jsonrpc/src/test/java/io/a2a/client/transport/jsonrpc/JsonMessages.java
@@ -93,10 +93,7 @@ public class JsonMessages {
                     {
                       "text":"tell me a joke"
                     }
-                  ],
-                  "metadata":{
-                    
-                  }
+                  ]
                 }
               }
             }""";
@@ -143,18 +140,12 @@ public class JsonMessages {
                 {
                   "text":"tell me a joke"
                 }
-              ],
-              "metadata":{
-              }
+              ]
             },
             "configuration":{
               "acceptedOutputModes":[
                 "text"
-              ],
-              "returnImmediately":false
-            },
-            "metadata":{
-
+              ]
             }
           }
         }""";
@@ -192,19 +183,12 @@ public class JsonMessages {
                     {
                       "text":"tell me a joke"
                     }
-                  ],
-                  "metadata":{
-                    
-                  }
+                  ]
                 },
                 "configuration":{
                   "acceptedOutputModes":[
                     "text"
-                  ],
-                  "returnImmediately":false
-                },
-                "metadata":{
-                  
+                  ]
                 }
               }
             }""";
@@ -376,19 +360,12 @@ public class JsonMessages {
                        "url":"file:///path/to/image.jpg",
                        "mediaType":"image/jpeg"
                      }
-                   ],
-                   "metadata":{
-                     
-                   }
+                   ]
                  },
                  "configuration":{
                    "acceptedOutputModes":[
                      "text"
-                   ],
-                   "returnImmediately":false
-                 },
-                 "metadata":{
-                   
+                   ]
                  }
                }
              }""";
@@ -443,19 +420,12 @@ public class JsonMessages {
                         "timestamp":"2024-01-15T10:30:00Z"
                       }
                     }
-                  ],
-                  "metadata":{
-                    
-                  }
+                  ]
                 },
                 "configuration":{
                   "acceptedOutputModes":[
                     "text"
-                  ],
-                  "returnImmediately":false
-                },
-                "metadata":{
-                  
+                  ]
                 }
               }
             }""";
@@ -514,19 +484,12 @@ public class JsonMessages {
                         "labels":["Q1", "Q2", "Q3", "Q4"]
                       }
                     }
-                  ],
-                  "metadata":{
-                    
-                  }
+                  ]
                 },
                 "configuration":{
                   "acceptedOutputModes":[
                     "text"
-                  ],
-                  "returnImmediately":false
-                },
-                "metadata":{
-                  
+                  ]
                 }
               }
             }""";

--- a/spec-grpc/src/main/java/io/a2a/grpc/utils/JSONRPCUtils.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/utils/JSONRPCUtils.java
@@ -171,6 +171,9 @@ public class JSONRPCUtils {
     private static final Pattern EXTRACT_WRONG_TYPE = Pattern.compile("Expected (.*) but found \".*\"");
     static final String ERROR_MESSAGE = "Invalid request content: %s. Please verify the request matches the expected schema for this method.";
 
+    private static final JsonFormat.Printer REQUEST_PRINTER = JsonFormat.printer().omittingInsignificantWhitespace();
+    private static final JsonFormat.Printer RESPONSE_PRINTER = JsonFormat.printer().alwaysPrintFieldsWithNoPresence().omittingInsignificantWhitespace();
+
     public static A2ARequest<?> parseRequestBody(String body, @Nullable String tenant) throws JsonMappingException, JsonProcessingException {
         JsonElement jelement = JsonParser.parseString(body);
         JsonObject jsonRpc = jelement.getAsJsonObject();
@@ -556,7 +559,7 @@ public class JSONRPCUtils {
                 output.name("method").value(method);
             }
             if (payload != null) {
-                String resultValue = JsonFormat.printer().alwaysPrintFieldsWithNoPresence().omittingInsignificantWhitespace().print(payload);
+                String resultValue = REQUEST_PRINTER.print(payload);
                 output.name("params").jsonValue(resultValue);
             }
             output.endObject();
@@ -579,7 +582,7 @@ public class JSONRPCUtils {
                     output.name("id").value(number.longValue());
                 }
             }
-            String resultValue = JsonFormat.printer().alwaysPrintFieldsWithNoPresence().omittingInsignificantWhitespace().print(builder);
+            String resultValue = RESPONSE_PRINTER.print(builder);
             output.name("result").jsonValue(resultValue);
             output.endObject();
             return result.toString();


### PR DESCRIPTION
The JSON-RPC client serialization used alwaysPrintFieldsWithNoPresence() which caused proto3 implicit-presence fields (taskId, contextId, tenant, etc.) to be serialized as empty strings instead of being omitted.

Removed alwaysPrintFieldsWithNoPresence() from JsonFormat.printer() in JSONRPCUtils.toJsonRPCRequest() (client requests only), aligning with the REST client transport which already omitted it.

This fixes #770
