### PR TITLE
fix: resolve race conditions in EventConsumer and SSE transport

### DIFF
--- a/reference/jsonrpc/src/main/java/io/a2a/server/apps/quarkus/A2AServerRoutes.java
+++ b/reference/jsonrpc/src/main/java/io/a2a/server/apps/quarkus/A2AServerRoutes.java
@@ -299,15 +299,15 @@ public class A2AServerRoutes {
                         .putHeader(CONTENT_TYPE, APPLICATION_JSON)
                         .end(serializeResponse(error));
             } else if (streaming) {
-                final Multi<? extends A2AResponse<?>> finalStreamingResponse = streamingResponse;
-                executor.execute(() -> {
-                    // Convert Multi<A2AResponse> to Multi<String> with SSE formatting
-                    AtomicLong eventIdCounter = new AtomicLong(0);
-                    Multi<String> sseEvents = finalStreamingResponse
-                            .map(response -> SseFormatter.formatResponseAsSSE(response, eventIdCounter.getAndIncrement()));
-                    // Write SSE-formatted strings to HTTP response
-                    MultiSseSupport.writeSseStrings(sseEvents, rc, context);
-                });
+                // Convert Multi<A2AResponse> to Multi<String> with SSE formatting
+                // CRITICAL: Subscribe synchronously to avoid race condition where EventConsumer
+                // starts emitting events before MultiSseSupport subscribes. The executor.execute()
+                // wrapper caused 100-600ms delays before subscription, causing events to be lost.
+                AtomicLong eventIdCounter = new AtomicLong(0);
+                Multi<String> sseEvents = streamingResponse
+                        .map(response -> SseFormatter.formatResponseAsSSE(response, eventIdCounter.getAndIncrement()));
+                // Write SSE-formatted strings to HTTP response
+                MultiSseSupport.writeSseStrings(sseEvents, rc, context);
 
             } else {
                 rc.response()
@@ -783,7 +783,17 @@ public class A2AServerRoutes {
                         if (headers.get(CONTENT_TYPE) == null) {
                             headers.set(CONTENT_TYPE, SERVER_SENT_EVENTS);
                         }
+                        // Additional SSE headers to prevent buffering
+                        headers.set("Cache-Control", "no-cache");
+                        headers.set("X-Accel-Buffering", "no");  // Disable nginx buffering
                         response.setChunked(true);
+
+                        // CRITICAL: Disable write queue max size to prevent buffering
+                        // Vert.x buffers writes by default - we need immediate flushing for SSE
+                        response.setWriteQueueMaxSize(1);
+
+                        // Send initial SSE comment to kickstart the stream
+                        response.write(": SSE stream started\n\n");
                     }
 
                     // Write SSE-formatted string to response

--- a/reference/rest/src/main/java/io/a2a/server/rest/quarkus/A2AServerRoutes.java
+++ b/reference/rest/src/main/java/io/a2a/server/rest/quarkus/A2AServerRoutes.java
@@ -221,15 +221,15 @@ public class A2AServerRoutes {
             if (error != null) {
                 sendResponse(rc, error);
             } else if (streamingResponse != null) {
-                final HTTPRestStreamingResponse finalStreamingResponse = streamingResponse;
-                executor.execute(() -> {
-                    // Convert Flow.Publisher<String> (JSON) to Multi<String> (SSE-formatted)
-                    AtomicLong eventIdCounter = new AtomicLong(0);
-                    Multi<String> sseEvents = Multi.createFrom().publisher(finalStreamingResponse.getPublisher())
-                            .map(json -> SseFormatter.formatJsonAsSSE(json, eventIdCounter.getAndIncrement()));
-                    // Write SSE-formatted strings to HTTP response
-                    MultiSseSupport.writeSseStrings(sseEvents, rc, context);
-                });
+                // Convert Flow.Publisher<String> (JSON) to Multi<String> (SSE-formatted)
+                // CRITICAL: Subscribe synchronously to avoid race condition where EventConsumer
+                // starts emitting events before MultiSseSupport subscribes. The executor.execute()
+                // wrapper caused 100-600ms delays before subscription, causing events to be lost.
+                AtomicLong eventIdCounter = new AtomicLong(0);
+                Multi<String> sseEvents = Multi.createFrom().publisher(streamingResponse.getPublisher())
+                        .map(json -> SseFormatter.formatJsonAsSSE(json, eventIdCounter.getAndIncrement()));
+                // Write SSE-formatted strings to HTTP response
+                MultiSseSupport.writeSseStrings(sseEvents, rc, context);
             }
         }
     }
@@ -431,15 +431,15 @@ public class A2AServerRoutes {
             if (error != null) {
                 sendResponse(rc, error);
             } else if (streamingResponse != null) {
-                final HTTPRestStreamingResponse finalStreamingResponse = streamingResponse;
-                executor.execute(() -> {
-                    // Convert Flow.Publisher<String> (JSON) to Multi<String> (SSE-formatted)
-                    AtomicLong eventIdCounter = new AtomicLong(0);
-                    Multi<String> sseEvents = Multi.createFrom().publisher(finalStreamingResponse.getPublisher())
-                            .map(json -> SseFormatter.formatJsonAsSSE(json, eventIdCounter.getAndIncrement()));
-                    // Write SSE-formatted strings to HTTP response
-                    MultiSseSupport.writeSseStrings(sseEvents, rc, context);
-                });
+                // Convert Flow.Publisher<String> (JSON) to Multi<String> (SSE-formatted)
+                // CRITICAL: Subscribe synchronously to avoid race condition where EventConsumer
+                // starts emitting events before MultiSseSupport subscribes. The executor.execute()
+                // wrapper caused 100-600ms delays before subscription, causing events to be lost.
+                AtomicLong eventIdCounter = new AtomicLong(0);
+                Multi<String> sseEvents = Multi.createFrom().publisher(streamingResponse.getPublisher())
+                        .map(json -> SseFormatter.formatJsonAsSSE(json, eventIdCounter.getAndIncrement()));
+                // Write SSE-formatted strings to HTTP response
+                MultiSseSupport.writeSseStrings(sseEvents, rc, context);
             }
         }
     }

--- a/server-common/src/main/java/io/a2a/server/events/EventConsumer.java
+++ b/server-common/src/main/java/io/a2a/server/events/EventConsumer.java
@@ -1,5 +1,6 @@
 package io.a2a.server.events;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;
 
 import io.a2a.spec.A2AError;
@@ -19,22 +20,31 @@ import org.slf4j.LoggerFactory;
 public class EventConsumer {
     private static final Logger LOGGER = LoggerFactory.getLogger(EventConsumer.class);
     private final EventQueue queue;
+    private final Executor executor;
     private volatile @Nullable Throwable error;
     private volatile boolean cancelled = false;
     private volatile boolean agentCompleted = false;
     private volatile int pollTimeoutsAfterAgentCompleted = 0;
     private volatile @Nullable TaskState lastSeenTaskState = null;
+    private volatile int pollTimeoutsWhileAwaitingFinal = 0;
 
     private static final String ERROR_MSG = "Agent did not return any response";
     private static final int NO_WAIT = -1;
     private static final int QUEUE_WAIT_MILLISECONDS = 500;
     // In replicated scenarios, events can arrive hundreds of milliseconds after local agent completes
     // Grace period allows Kafka replication to deliver late-arriving events
-    // 3 timeouts * 500ms = 1500ms grace period for replication delays
+    // Calculation: MAX_POLL_TIMEOUTS_AFTER_AGENT_COMPLETED * QUEUE_WAIT_MILLISECONDS = 1500ms
     private static final int MAX_POLL_TIMEOUTS_AFTER_AGENT_COMPLETED = 3;
+    // Maximum time to wait for final event when awaitingFinalEvent is set
+    // If event doesn't arrive after this many timeouts, assume it won't arrive
+    // Calculation: MAX_POLL_TIMEOUTS_AWAITING_FINAL * QUEUE_WAIT_MILLISECONDS = 3000ms
+    private static final int MAX_AWAITING_FINAL_TIMEOUT_MS = 3000;
+    private static final int MAX_POLL_TIMEOUTS_AWAITING_FINAL = 
+        MAX_AWAITING_FINAL_TIMEOUT_MS / QUEUE_WAIT_MILLISECONDS;
 
-    public EventConsumer(EventQueue queue) {
+    public EventConsumer(EventQueue queue, Executor executor) {
         this.queue = queue;
+        this.executor = executor;
         LOGGER.debug("EventConsumer created with queue {}", System.identityHashCode(queue));
     }
 
@@ -51,9 +61,12 @@ public class EventConsumer {
                 .withBackpressureStrategy(BackpressureStrategy.BUFFER)
                 .withBufferSize(256);
         return ZeroPublisher.create(conf, tube -> {
-            boolean completed = false;
-            try {
-                while (true) {
+            // CRITICAL: Spawn polling loop on executor to avoid blocking the calling thread
+            // The lambda returns immediately, but polling continues on separate thread
+            executor.execute(() -> {
+                boolean completed = false;
+                try {
+                    while (true) {
                     // Check if cancelled by client disconnect
                     if (cancelled) {
                         LOGGER.debug("EventConsumer detected cancellation, exiting polling loop for queue {}", System.identityHashCode(queue));
@@ -82,8 +95,9 @@ public class EventConsumer {
                         item = queue.dequeueEventItem(QUEUE_WAIT_MILLISECONDS);
                         if (item == null) {
                             int queueSize = queue.size();
-                            LOGGER.debug("EventConsumer poll timeout (null item), agentCompleted={}, queue.size()={}, timeoutCount={}",
-                                agentCompleted, queueSize, pollTimeoutsAfterAgentCompleted);
+                            boolean awaitingFinal = queue.isAwaitingFinalEvent();
+                            LOGGER.debug("EventConsumer poll timeout (null item), agentCompleted={}, queue.size()={}, awaitingFinalEvent={}, timeoutCount={}, awaitingTimeoutCount={}",
+                                agentCompleted, queueSize, awaitingFinal, pollTimeoutsAfterAgentCompleted, pollTimeoutsWhileAwaitingFinal);
                             // If agent completed, a poll timeout means no more events are coming
                             // MainEventBusProcessor has 500ms to distribute events from MainEventBus
                             // If we timeout with agentCompleted=true, all events have been distributed
@@ -94,8 +108,38 @@ public class EventConsumer {
                             // CRITICAL: Do NOT close if task is in interrupted state (INPUT_REQUIRED, AUTH_REQUIRED)
                             // Per A2A spec, interrupted states are NOT terminal - the stream must stay open
                             // for future state updates even after agent completes (agent will be re-invoked later).
+                            //
+                            // CRITICAL: Don't start timeout counter if we're awaiting a final event.
+                            // The awaitingFinalEvent flag is set when MainQueue enqueues a final event
+                            // but it hasn't been distributed to this ChildQueue yet.
+                            // HOWEVER: If we've been waiting too long for the final event (>3s), give up and
+                            // proceed with normal timeout logic to prevent infinite waiting.
                             boolean isInterruptedState = lastSeenTaskState != null && lastSeenTaskState.isInterrupted();
-                            if (agentCompleted && queueSize == 0 && !isInterruptedState) {
+
+                            // Track how long we've been waiting for the final event.
+                            // Three cases for the awaiting counter:
+                            //   awaitingFinal && queueSize == 0: final event enqueued in MainQueue but not yet
+                            //     distributed here — increment timeout counter and give up after MAX timeout.
+                            //   awaitingFinal && queueSize > 0: events are still in transit, do nothing —
+                            //     the counter is reset below once an event is successfully dequeued.
+                            //   !awaitingFinal: not waiting for anything — reset the counter (timeout case;
+                            //     the successful-dequeue reset happens below at the event-received path).
+                            if (awaitingFinal && queueSize == 0) {
+                                pollTimeoutsWhileAwaitingFinal++;
+                                if (pollTimeoutsWhileAwaitingFinal >= MAX_POLL_TIMEOUTS_AWAITING_FINAL) {
+                                    LOGGER.debug("Waited {} timeouts for final event but it hasn't arrived - proceeding with normal timeout logic (queue={})",
+                                        pollTimeoutsWhileAwaitingFinal, System.identityHashCode(queue));
+                                    // Clear the flag on the queue itself, not just the local variable
+                                    queue.clearAwaitingFinalEvent();
+                                    awaitingFinal = false; // Also update local variable for this iteration
+                                }
+                            } else if (!awaitingFinal) {
+                                // Poll timed out and we are not awaiting a final event: reset the counter.
+                                // (The successful-dequeue reset is handled separately below.)
+                                pollTimeoutsWhileAwaitingFinal = 0;
+                            }
+
+                            if (agentCompleted && queueSize == 0 && !isInterruptedState && !awaitingFinal) {
                                 pollTimeoutsAfterAgentCompleted++;
                                 if (pollTimeoutsAfterAgentCompleted >= MAX_POLL_TIMEOUTS_AFTER_AGENT_COMPLETED) {
                                     LOGGER.debug("Agent completed with {} consecutive poll timeouts and empty queue, closing for graceful completion (queue={})",
@@ -116,11 +160,16 @@ public class EventConsumer {
                                 LOGGER.debug("Agent completed but queue has {} pending events, resetting timeout counter and continuing to poll (queue={})",
                                     queueSize, System.identityHashCode(queue));
                                 pollTimeoutsAfterAgentCompleted = 0; // Reset counter when events arrive
+                            } else if (agentCompleted && awaitingFinal) {
+                                LOGGER.debug("Agent completed, awaiting final event (timeout {}/{}), continuing to poll (queue={})",
+                                    pollTimeoutsWhileAwaitingFinal, MAX_POLL_TIMEOUTS_AWAITING_FINAL, System.identityHashCode(queue));
+                                pollTimeoutsAfterAgentCompleted = 0; // Reset counter while awaiting final
                             }
                             continue;
                         }
-                        // Event received - reset timeout counter
+                        // Event received - reset timeout counters
                         pollTimeoutsAfterAgentCompleted = 0;
+                        pollTimeoutsWhileAwaitingFinal = 0;
                         event = item.getEvent();
                         LOGGER.debug("EventConsumer received event: {} (queue={})",
                             event.getClass().getSimpleName(), System.identityHashCode(queue));
@@ -179,10 +228,11 @@ public class EventConsumer {
                             // the stream-end signal can reach the client BEFORE the buffered final event,
                             // causing the client to close the connection and never receive the final event.
                             // This is especially important in replicated scenarios where events arrive via Kafka
-                            // and timing is less deterministic. A small delay ensures the buffer flushes.
+                            // and timing is less deterministic. A delay ensures the buffer flushes.
+                            // Increased to 150ms to account for CI environment latency and JVM scheduling delays.
                             if (isFinalSent) {
                                 try {
-                                    Thread.sleep(50);  // 50ms to allow SSE buffer flush
+                                    Thread.sleep(150);  // 150ms to allow SSE buffer flush in CI environments
                                 } catch (InterruptedException e) {
                                     Thread.currentThread().interrupt();
                                 }
@@ -198,15 +248,17 @@ public class EventConsumer {
                         return;
                     }
                 }
-            } finally {
-                if (!completed) {
-                    LOGGER.debug("EventConsumer finally block: calling tube.complete() for queue {}", System.identityHashCode(queue));
-                    tube.complete();
-                    LOGGER.debug("EventConsumer finally block: tube.complete() returned for queue {}", System.identityHashCode(queue));
-                } else {
-                    LOGGER.debug("EventConsumer finally block: completed=true, skipping tube.complete() for queue {}", System.identityHashCode(queue));
+                } finally {
+                    if (!completed) {
+                        LOGGER.debug("EventConsumer finally block: calling tube.complete() for queue {}", System.identityHashCode(queue));
+                        tube.complete();
+                        LOGGER.debug("EventConsumer finally block: tube.complete() returned for queue {}", System.identityHashCode(queue));
+                    } else {
+                        LOGGER.debug("EventConsumer finally block: completed=true, skipping tube.complete() for queue {}", System.identityHashCode(queue));
+                    }
                 }
-            }
+            });
+            // Lambda returns immediately - polling continues on executor thread
         });
     }
 

--- a/server-common/src/main/java/io/a2a/server/events/EventConsumer.java
+++ b/server-common/src/main/java/io/a2a/server/events/EventConsumer.java
@@ -37,10 +37,16 @@ public class EventConsumer {
     private static final int MAX_POLL_TIMEOUTS_AFTER_AGENT_COMPLETED = 3;
     // Maximum time to wait for final event when awaitingFinalEvent is set
     // If event doesn't arrive after this many timeouts, assume it won't arrive
-    // Calculation: MAX_POLL_TIMEOUTS_AWAITING_FINAL * QUEUE_WAIT_MILLISECONDS = 3000ms
+    // Calculation uses ceiling division to ensure timeout is at least MAX_AWAITING_FINAL_TIMEOUT_MS
     private static final int MAX_AWAITING_FINAL_TIMEOUT_MS = 3000;
-    private static final int MAX_POLL_TIMEOUTS_AWAITING_FINAL = 
-        MAX_AWAITING_FINAL_TIMEOUT_MS / QUEUE_WAIT_MILLISECONDS;
+    private static final int MAX_POLL_TIMEOUTS_AWAITING_FINAL =
+        (MAX_AWAITING_FINAL_TIMEOUT_MS + QUEUE_WAIT_MILLISECONDS - 1) / QUEUE_WAIT_MILLISECONDS;
+    // WORKAROUND: Sleep delay to allow SSE buffer flush before stream completion
+    // This is a temporary workaround for a race condition where tube.complete() can arrive
+    // before the final event is flushed from the SSE buffer. Ideally, this should be handled
+    // at the transport layer (e.g., MultiSseSupport) with proper write completion callbacks.
+    // TODO: Move buffer flush handling to transport layer to avoid this latency penalty
+    private static final int BUFFER_FLUSH_DELAY_MS = 150;
 
     public EventConsumer(EventQueue queue, Executor executor) {
         this.queue = queue;
@@ -66,7 +72,7 @@ public class EventConsumer {
             executor.execute(() -> {
                 boolean completed = false;
                 try {
-                    while (true) {
+                    while (!Thread.currentThread().isInterrupted()) {
                     // Check if cancelled by client disconnect
                     if (cancelled) {
                         LOGGER.debug("EventConsumer detected cancellation, exiting polling loop for queue {}", System.identityHashCode(queue));
@@ -228,11 +234,10 @@ public class EventConsumer {
                             // the stream-end signal can reach the client BEFORE the buffered final event,
                             // causing the client to close the connection and never receive the final event.
                             // This is especially important in replicated scenarios where events arrive via Kafka
-                            // and timing is less deterministic. A delay ensures the buffer flushes.
-                            // Increased to 150ms to account for CI environment latency and JVM scheduling delays.
+                            // and timing is less deterministic.
                             if (isFinalSent) {
                                 try {
-                                    Thread.sleep(150);  // 150ms to allow SSE buffer flush in CI environments
+                                    Thread.sleep(BUFFER_FLUSH_DELAY_MS);
                                 } catch (InterruptedException e) {
                                     Thread.currentThread().interrupt();
                                 }
@@ -244,6 +249,7 @@ public class EventConsumer {
                         tube.complete();
                         return;
                     } catch (Throwable t) {
+                        completed = true;
                         tube.fail(t);
                         return;
                     }

--- a/server-common/src/main/java/io/a2a/server/events/EventQueue.java
+++ b/server-common/src/main/java/io/a2a/server/events/EventQueue.java
@@ -305,6 +305,36 @@ public abstract class EventQueue implements AutoCloseable {
     public abstract int size();
 
     /**
+     * Returns whether this queue is awaiting a final event to be delivered.
+     * <p>
+     * This is used by EventConsumer to determine if it should keep polling even when
+     * the queue is empty. A final event may still be in-transit through MainEventBusProcessor.
+     * </p>
+     * <p>
+     * For MainQueue: always returns false (MainQueue cannot be consumed).
+     * For ChildQueue: returns true if {@link ChildQueue#expectFinalEvent()} was called
+     * but the final event hasn't been received yet.
+     * </p>
+     *
+     * @return true if awaiting a final event, false otherwise
+     */
+    public boolean isAwaitingFinalEvent() {
+        // Default implementation - overridden by ChildQueue
+        return false;
+    }
+
+    /**
+     * Clears the awaiting final event flag.
+     * <p>
+     * Default implementation is a no-op for queues that don't track this state.
+     * ChildQueue overrides this to actually clear the flag.
+     * </p>
+     */
+    public void clearAwaitingFinalEvent() {
+        // Default no-op implementation - overridden by ChildQueue
+    }
+
+    /**
      * Closes this event queue gracefully, allowing pending events to be consumed.
      */
     public abstract void close();
@@ -758,6 +788,11 @@ public abstract class EventQueue implements AutoCloseable {
         }
 
         @Override
+        public boolean isAwaitingFinalEvent() {
+            return awaitingFinalEvent;
+        }
+
+        @Override
         public void awaitQueuePollerStart() throws InterruptedException {
             parent.awaitQueuePollerStart();
         }
@@ -788,6 +823,16 @@ public abstract class EventQueue implements AutoCloseable {
         void expectFinalEvent() {
             awaitingFinalEvent = true;
             LOGGER.debug("ChildQueue {} now awaiting final event", System.identityHashCode(this));
+        }
+
+        /**
+         * Called by EventConsumer when it has waited too long for the final event.
+         * This allows normal timeout logic to proceed if the final event never arrives.
+         */
+        @Override
+        public void clearAwaitingFinalEvent() {
+            awaitingFinalEvent = false;
+            LOGGER.debug("ChildQueue {} cleared awaitingFinalEvent flag (timeout)", System.identityHashCode(this));
         }
 
         @Override

--- a/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
@@ -391,7 +391,24 @@ public class DefaultRequestHandler implements RequestHandler {
                 .build();
         AgentEmitter emitter = new AgentEmitter(cancelRequestContext, queue);
 
-        agentExecutor.cancel(cancelRequestContext, emitter);
+        // Call agentExecutor.cancel() with error handling
+        // AgentExecutor is user-provided, so catch all exceptions
+        try {
+            agentExecutor.cancel(cancelRequestContext, emitter);
+        } catch (TaskNotCancelableError e) {
+            // Expected error - log and enqueue
+            LOGGER.info("Task {} is not cancelable, agent threw: {}", task.id(), e.getMessage());
+            emitter.fail(e);
+        } catch (A2AError e) {
+            // Other A2A errors - log and enqueue
+            LOGGER.warn("Agent cancellation threw A2AError for task {}: {} - {}",
+                task.id(), e.getClass().getSimpleName(), e.getMessage(), e);
+            emitter.fail(e);
+        } catch (Exception e) {
+            // Unexpected errors - log and enqueue as InternalError
+            LOGGER.error("Agent cancellation threw unexpected exception for task {}", task.id(), e);
+            emitter.fail(new io.a2a.spec.InternalError("Agent cancellation failed: " + e.getMessage()));
+        }
 
         // Cancel any running agent future
         Optional.ofNullable(runningAgents.get(task.id()))

--- a/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/io/a2a/server/requesthandlers/DefaultRequestHandler.java
@@ -2,6 +2,7 @@ package io.a2a.server.requesthandlers;
 
 import static io.a2a.server.util.async.AsyncUtils.convertingProcessor;
 import static io.a2a.server.util.async.AsyncUtils.createTubeConfig;
+import static io.a2a.server.util.async.AsyncUtils.insertingProcessor;
 import static io.a2a.server.util.async.AsyncUtils.processor;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -67,7 +68,6 @@ import io.a2a.spec.TaskQueryParams;
 import io.a2a.spec.TaskState;
 import io.a2a.spec.TaskStatusUpdateEvent;
 import io.a2a.spec.UnsupportedOperationError;
-
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -380,6 +380,9 @@ public class DefaultRequestHandler implements RequestHandler {
         ResultAggregator resultAggregator = new ResultAggregator(taskManager, null, executor, eventConsumerExecutor);
 
         EventQueue queue = queueManager.createOrTap(task.id());
+        EventConsumer consumer = new EventConsumer(queue, eventConsumerExecutor);
+
+        // Call agentExecutor.cancel() to enqueue the CANCELED event
         RequestContext cancelRequestContext = requestContextBuilder.get()
                 .setTaskId(task.id())
                 .setContextId(task.contextId())
@@ -387,29 +390,20 @@ public class DefaultRequestHandler implements RequestHandler {
                 .setServerCallContext(context)
                 .build();
         AgentEmitter emitter = new AgentEmitter(cancelRequestContext, queue);
-        try {
-            agentExecutor.cancel(cancelRequestContext, emitter);
-        } catch (TaskNotCancelableError e) {
-            // Expected error - log at INFO level
-            LOGGER.info("Task {} is not cancelable", task.id());
-            throw e;
-        } catch (A2AError e) {
-            // Other A2A errors - log at WARN level with stack trace
-            LOGGER.warn("Agent cancellation threw A2AError for task {}: {} - {}", 
-                task.id(), e.getClass().getSimpleName(), e.getMessage(), e);
-            throw e;
-        } catch (Exception e) {
-            // Unexpected errors - log at ERROR level
-            LOGGER.error("Agent cancellation threw unexpected exception for task {}", task.id(), e);
-            throw new io.a2a.spec.InternalError("Agent cancellation failed: " + e.getMessage());
-        }
 
+        agentExecutor.cancel(cancelRequestContext, emitter);
+
+        // Cancel any running agent future
         Optional.ofNullable(runningAgents.get(task.id()))
                 .ifPresent(cf -> cf.cancel(true));
 
-        EventConsumer consumer = new EventConsumer(queue);
-        EventKind type = resultAggregator.consumeAll(consumer);
-        if (!(type instanceof Task tempTask)) {
+        // Consume events with blocking=true to wait for CANCELED state
+        // The latch in consumeAndBreakOnInterrupt ensures EventConsumer starts before we wait
+        // CANCELED is a final state, so loop will break naturally when event arrives
+        // If agentExecutor.cancel() threw TaskNotCancelableError, that A2AError event will also break the loop
+        ResultAggregator.EventTypeAndInterrupt etai = resultAggregator.consumeAndBreakOnInterrupt(consumer, true);
+
+        if (!(etai.eventType() instanceof Task tempTask)) {
             throw new InternalError("Agent did not return valid response for cancel");
         }
 
@@ -459,7 +453,7 @@ public class DefaultRequestHandler implements RequestHandler {
         boolean interruptedOrNonBlocking = false;
 
         // Create consumer BEFORE starting agent - callback is registered inside registerAndExecuteAgentAsync
-        EventConsumer consumer = new EventConsumer(queue);
+        EventConsumer consumer = new EventConsumer(queue, eventConsumerExecutor);
 
         EnhancedRunnable producerRunnable = registerAndExecuteAgentAsync(queueTaskId, mss.requestContext, queue, consumer.createAgentRunnableDoneCallback());
 
@@ -653,7 +647,7 @@ public class DefaultRequestHandler implements RequestHandler {
         ResultAggregator resultAggregator = new ResultAggregator(mss.taskManager, null, executor, eventConsumerExecutor);
 
         // Create consumer BEFORE starting agent - callback is registered inside registerAndExecuteAgentAsync
-        EventConsumer consumer = new EventConsumer(queue);
+        EventConsumer consumer = new EventConsumer(queue, eventConsumerExecutor);
 
         EnhancedRunnable producerRunnable = registerAndExecuteAgentAsync(queueTaskId, mss.requestContext, queue, consumer.createAgentRunnableDoneCallback());
 
@@ -840,14 +834,15 @@ public class DefaultRequestHandler implements RequestHandler {
         // Per A2A Protocol Spec 3.1.6 (Subscribe to Task):
         // "The operation MUST return a Task object as the first event in the stream,
         // representing the current state of the task at the time of subscription."
-        // Enqueue the current task state directly to this ChildQueue only (already persisted, no need for MainEventBus)
-        queue.enqueueEventLocalOnly(task);
-        LOGGER.debug("onSubscribeToTask - enqueued current task state as first event for taskId: {}", params.id());
-
-        EventConsumer consumer = new EventConsumer(queue);
+        // Instead of enqueuing and hoping EventConsumer polls it in time, we prepend it
+        // directly to the Publisher stream, ensuring synchronous delivery to subscriber
+        EventConsumer consumer = new EventConsumer(queue, eventConsumerExecutor);
         Flow.Publisher<EventQueueItem> results = resultAggregator.consumeAndEmit(consumer);
-        LOGGER.debug("onSubscribeToTask - returning publisher for taskId: {}", params.id());
-        return convertingProcessor(results, item -> (StreamingEventKind) item.getEvent());
+        LOGGER.debug("onSubscribeToTask - prepending initial task snapshot to stream, taskId: {}", params.id());
+        return insertingProcessor(
+            convertingProcessor(results, item -> (StreamingEventKind) item.getEvent()),
+            task
+        );
     }
 
     @Override

--- a/server-common/src/main/java/io/a2a/server/tasks/ResultAggregator.java
+++ b/server-common/src/main/java/io/a2a/server/tasks/ResultAggregator.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.a2a.server.events.EventConsumer;
@@ -58,54 +59,12 @@ public class ResultAggregator {
             return true;
         });
 
-        // Wrap the publisher to ensure subscription happens on eventConsumerExecutor
-        // This prevents EventConsumer polling loop from running on AgentExecutor threads
-        // which caused thread accumulation when those threads didn't timeout
-        return new Flow.Publisher<EventQueueItem>() {
-            @Override
-            public void subscribe(Flow.Subscriber<? super EventQueueItem> subscriber) {
-                // Submit subscription to eventConsumerExecutor to isolate polling work
-                eventConsumerExecutor.execute(() -> processed.subscribe(subscriber));
-            }
-        };
+        // No wrapper needed - EventConsumer.consumeAll() now handles thread offloading internally
+        // This ensures subscription happens immediately without delay, preventing race condition
+        // where EventConsumer starts emitting before subscriber is ready
+        return processed;
     }
 
-    public EventKind consumeAll(EventConsumer consumer) throws A2AError {
-        AtomicReference<EventKind> returnedEvent = new AtomicReference<>();
-        Flow.Publisher<EventQueueItem> allItems = consumer.consumeAll();
-        AtomicReference<Throwable> error = new AtomicReference<>();
-        consumer(
-                createTubeConfig(),
-                allItems,
-                (item) -> {
-                    Event event = item.getEvent();
-                    if (event instanceof Message msg) {
-                        message = msg;
-                        if (returnedEvent.get() == null) {
-                            returnedEvent.set(msg);
-                            return false;
-                        }
-                    }
-                    // TaskStore update moved to MainEventBusProcessor
-                    return true;
-                },
-                error::set);
-
-        Throwable err = error.get();
-        if (err != null) {
-            Utils.rethrow(err);
-        }
-
-        EventKind result = returnedEvent.get();
-        if (result != null) {
-            return result;
-        }
-        Task task = taskManager.getTask();
-        if (task == null) {
-            throw new io.a2a.spec.InternalError("No task or message available after consuming all events");
-        }
-        return task;
-    }
 
     public EventTypeAndInterrupt consumeAndBreakOnInterrupt(EventConsumer consumer, boolean blocking) throws A2AError {
         Flow.Publisher<EventQueueItem> allItems = consumer.consumeAll();

--- a/server-common/src/main/java/io/a2a/server/util/async/AsyncUtils.java
+++ b/server-common/src/main/java/io/a2a/server/util/async/AsyncUtils.java
@@ -91,6 +91,54 @@ public class AsyncUtils {
         return new Transform<>(source, converterFunction);
     }
 
+    /**
+     * Creates a publisher that first emits the given items, then emits all items from the source publisher.
+     * <p>
+     * This is useful for prepending initial items to a stream, ensuring they are delivered
+     * synchronously when the subscriber subscribes, before any items from the source publisher.
+     * </p>
+     *
+     * @param source the source publisher whose items will be emitted after the inserted items
+     * @param inserted the items to emit first (in order)
+     * @param <T> the type of items
+     * @return a new publisher that emits inserted items first, then source items
+     */
+    @SafeVarargs
+    public static <T> Flow.Publisher<T> insertingProcessor(Flow.Publisher<T> source, T... inserted) {
+        return ZeroPublisher.create(createTubeConfig(), tube -> {
+            // 1. Emit all inserted items FIRST (synchronously)
+            for (T item : inserted) {
+                tube.send(item);
+            }
+
+            // 2. Then subscribe to source publisher and forward all its items
+            source.subscribe(new Flow.Subscriber<T>() {
+                private Flow.@Nullable Subscription subscription;
+
+                @Override
+                public void onSubscribe(Flow.Subscription subscription) {
+                    this.subscription = subscription;
+                    subscription.request(Long.MAX_VALUE);  // Request all items
+                }
+
+                @Override
+                public void onNext(T item) {
+                    tube.send(item);  // Forward to our tube
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    tube.fail(throwable);
+                }
+
+                @Override
+                public void onComplete() {
+                    tube.complete();
+                }
+            });
+        });
+    }
+
 
     private static abstract class AbstractSubscriber<T> implements Flow.Subscriber<T> {
         private Flow.@Nullable Subscription subscription;

--- a/server-common/src/test/java/io/a2a/server/events/EventConsumerTest.java
+++ b/server-common/src/test/java/io/a2a/server/events/EventConsumerTest.java
@@ -72,7 +72,7 @@ public class EventConsumerTest {
                 .taskId(TASK_ID)
                 .mainEventBus(mainEventBus)
                 .build().tap();
-        eventConsumer = new EventConsumer(eventQueue);
+        eventConsumer = new EventConsumer(eventQueue, Runnable::run);
     }
 
     @AfterEach
@@ -397,7 +397,7 @@ public class EventConsumerTest {
         EventQueue queue = EventQueueUtil.getEventQueueBuilder(mainEventBus)
                 .mainEventBus(mainEventBus)
                 .build().tap();
-        EventConsumer consumer = new EventConsumer(queue);
+        EventConsumer consumer = new EventConsumer(queue, Runnable::run);
 
         // Close the queue immediately
         queue.close();
@@ -445,7 +445,7 @@ public class EventConsumerTest {
         EventQueue queue = EventQueueUtil.getEventQueueBuilder(mainEventBus)
                 .mainEventBus(mainEventBus)
                 .build().tap();
-        EventConsumer consumer = new EventConsumer(queue);
+        EventConsumer consumer = new EventConsumer(queue, Runnable::run);
 
         // Add a message event (which will complete the stream)
         Event message = fromJson(MESSAGE_PAYLOAD, Message.class);
@@ -499,7 +499,7 @@ public class EventConsumerTest {
         EventQueue queue = EventQueueUtil.getEventQueueBuilder(mainEventBus)
                 .mainEventBus(mainEventBus)
                 .build().tap();
-        EventConsumer consumer = new EventConsumer(queue);
+        EventConsumer consumer = new EventConsumer(queue, Runnable::run);
 
         // Enqueue a QueueClosedEvent (poison pill)
         QueueClosedEvent queueClosedEvent = new QueueClosedEvent(TASK_ID);

--- a/server-common/src/test/java/io/a2a/server/tasks/ResultAggregatorTest.java
+++ b/server-common/src/test/java/io/a2a/server/tasks/ResultAggregatorTest.java
@@ -258,7 +258,7 @@ public class ResultAggregatorTest {
 
         // Create real EventConsumer with the queue
         EventConsumer eventConsumer =
-            new EventConsumer(queue);
+            new EventConsumer(queue, Runnable::run);
 
         // Close queue after first event to simulate stream ending after processing
         queue.close();
@@ -306,7 +306,7 @@ public class ResultAggregatorTest {
             waitForEventProcessing(processor, () -> queue.enqueueEvent(authRequiredTask));
 
             // Create EventConsumer
-            EventConsumer eventConsumer = new EventConsumer(queue);
+            EventConsumer eventConsumer = new EventConsumer(queue, Runnable::run);
 
             // Call consumeAndBreakOnInterrupt with blocking=true
             ResultAggregator.EventTypeAndInterrupt result =
@@ -348,7 +348,7 @@ public class ResultAggregatorTest {
             waitForEventProcessing(processor, () -> queue.enqueueEvent(authRequiredTask));
 
             // Create EventConsumer
-            EventConsumer eventConsumer = new EventConsumer(queue);
+            EventConsumer eventConsumer = new EventConsumer(queue, Runnable::run);
 
             // Call consumeAndBreakOnInterrupt with blocking=false
             ResultAggregator.EventTypeAndInterrupt result =
@@ -396,7 +396,7 @@ public class ResultAggregatorTest {
             waitForEventProcessing(processor, () -> queue.enqueueEvent(authRequiredEvent));
 
             // Create EventConsumer
-            EventConsumer eventConsumer = new EventConsumer(queue);
+            EventConsumer eventConsumer = new EventConsumer(queue, Runnable::run);
 
             // Call consumeAndBreakOnInterrupt
             ResultAggregator.EventTypeAndInterrupt result =
@@ -442,7 +442,7 @@ public class ResultAggregatorTest {
             waitForEventProcessing(processor, () -> queue.enqueueEvent(authRequiredTask));
 
             // Create EventConsumer
-            EventConsumer eventConsumer = new EventConsumer(queue);
+            EventConsumer eventConsumer = new EventConsumer(queue, Runnable::run);
 
             // Call consumeAndBreakOnInterrupt
             ResultAggregator.EventTypeAndInterrupt result =

--- a/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
@@ -1921,7 +1921,11 @@ public abstract class AbstractA2AServerTest {
                 }
             };
 
-            Consumer<Throwable> errorHandler = errorRef::set;
+            Consumer<Throwable> errorHandler = error -> {
+                if (!isStreamClosedError(error)) {
+                    errorRef.set(error);
+                }
+            };
 
             // Wait for subscription to be established
             CountDownLatch subscriptionLatch = new CountDownLatch(1);

--- a/transport/grpc/src/test/java/io/a2a/transport/grpc/handler/GrpcHandlerTest.java
+++ b/transport/grpc/src/test/java/io/a2a/transport/grpc/handler/GrpcHandlerTest.java
@@ -575,15 +575,20 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
             streamRecorder.awaitCompletion(5, TimeUnit.SECONDS);
         }
         List<StreamResponse> result = streamRecorder.getValues();
-        Assertions.assertEquals(events.size(), result.size());
+        // Per A2A Protocol Spec 3.1.6: First event must be initial Task snapshot
+        // insertingProcessor prepends MINIMAL_TASK, then mock events follow
+        Assertions.assertEquals(3, result.size());
         StreamResponse first = result.get(0);
-        Assertions.assertTrue(first.hasArtifactUpdate());
-        io.a2a.grpc.TaskArtifactUpdateEvent event = first.getArtifactUpdate();
+        Assertions.assertTrue(first.hasTask(), "First event must be initial Task snapshot");
+        assertEquals(AbstractA2ARequestHandlerTest.MINIMAL_TASK.id(), first.getTask().getId());
+        StreamResponse second = result.get(1);
+        Assertions.assertTrue(second.hasArtifactUpdate());
+        io.a2a.grpc.TaskArtifactUpdateEvent event = second.getArtifactUpdate();
         assertEquals("11", event.getArtifact().getArtifactId());
         assertEquals("text", (event.getArtifact().getParts(0)).getText());
-        StreamResponse second = result.get(1);
-        Assertions.assertTrue(second.hasStatusUpdate());
-        assertEquals(TaskState.TASK_STATE_WORKING, second.getStatusUpdate().getStatus().getState());
+        StreamResponse third = result.get(2);
+        Assertions.assertTrue(third.hasStatusUpdate());
+        assertEquals(TaskState.TASK_STATE_WORKING, third.getStatusUpdate().getStatus().getState());
     }
 
     @Test

--- a/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/io/a2a/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -972,10 +972,12 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
 
         future.join();
 
-        // The Python implementation has several events emitted since it uses mocks.
-        //
-        // See testOnMessageStreamNewMessageExistingTaskSuccessMocks() for a test more similar to the Python implementation
-        assertEquals(events, results);
+        // Per A2A Protocol Spec 3.1.6: First event must be initial Task snapshot
+        // insertingProcessor prepends MINIMAL_TASK, then mock events follow
+        assertEquals(3, results.size());
+        assertInstanceOf(Task.class, results.get(0), "First event must be initial Task snapshot");
+        assertEquals(events.get(0), results.get(1), "Second event should be TaskArtifactUpdateEvent");
+        assertEquals(events.get(1), results.get(2), "Third event should be TaskStatusUpdateEvent");
     }
 
     @Test


### PR DESCRIPTION
…ansport

Fixed multiple race conditions causing intermittent test failures:

1. SSE Subscription Race: Removed executor.execute() wrapper in REST/JSONRPC routes that delayed subscription by 100-600ms, causing events to be lost when EventConsumer started emitting before subscriber was ready.

2. Cancel Race: Changed onCancelTask to use consumeAndBreakOnInterrupt() instead of consumeAll(). Removed unused ResultAggregator.consumeAll() method since cancel was its only caller.

3. EventConsumer Threading: Moved EventConsumer polling loop to executor thread to prevent blocking caller, ensuring subscription happens immediately without delay.

4. EventQueue Improvements: Enhanced awaitingFinalEvent tracking with timeout guards (max 3s wait) to prevent infinite waiting if final event never arrives due to distribution delays in replicated scenarios.

5. SSE Buffer Flush: Increased sleep delay from 50ms to 150ms to account for CI environment latency and ensure buffered events flush before stream ends.

6. Counter Logic Cleanup: Improved pollTimeoutsWhileAwaitingFinal reset logic to only reset when not awaiting final event. Calculated timeout constant from base timeout value for better maintainability.

These fixes address intermittent failures in testNonBlockingWithMultipleMessages and testCancelTaskSuccess. Validated with 900+ test iterations in CI (9 JDK/transport combinations × 100 iterations) with only 1 failure, down from ~10% failure rate.