### PR TITLE
fix: Remove invalid 'final' field from TaskStatusUpdateEvent JSON serialization

### DIFF
--- a/client/transport/jsonrpc/src/test/java/org/a2aproject/sdk/client/transport/jsonrpc/sse/SSEEventListenerTest.java
+++ b/client/transport/jsonrpc/src/test/java/org/a2aproject/sdk/client/transport/jsonrpc/sse/SSEEventListenerTest.java
@@ -185,12 +185,10 @@ public class SSEEventListenerTest {
     @Test
     public void testFinalTaskStatusUpdateEventCancels() {
         TaskStatus completedStatus = new TaskStatus(TaskState.TASK_STATE_COMPLETED);
-        // Use constructor since Builder doesn't have isFinal method
         TaskStatusUpdateEvent tsue = new TaskStatusUpdateEvent(
                 "1234",
                 completedStatus,
                 "xyz",
-                completedStatus.state().isFinal(),  // Derive from state
                 null
         );
 

--- a/client/transport/spi/src/test/java/org/a2aproject/sdk/client/transport/spi/sse/SSEEventListenerTest.java
+++ b/client/transport/spi/src/test/java/org/a2aproject/sdk/client/transport/spi/sse/SSEEventListenerTest.java
@@ -114,13 +114,11 @@ public class SSEEventListenerTest {
                 .build();
     }
 
-    private static TaskStatusUpdateEvent createTaskStatusUpdateEvent(TaskState state, boolean isFinal) {
-        // Use constructor since Builder doesn't have isFinal method
+    private static TaskStatusUpdateEvent createTaskStatusUpdateEvent(TaskState state) {
         return new TaskStatusUpdateEvent(
                 TEST_TASK_ID,
                 new TaskStatus(state),
                 TEST_CONTEXT_ID,
-                isFinal,
                 null
         );
     }
@@ -206,7 +204,7 @@ public class SSEEventListenerTest {
     @Test
     public void testShouldAutoCloseWithFinalTaskStatusUpdateEvent() {
         TestSSEEventListener listener = createBasicListener();
-        TaskStatusUpdateEvent finalEvent = createTaskStatusUpdateEvent(TaskState.TASK_STATE_COMPLETED, true);
+        TaskStatusUpdateEvent finalEvent = createTaskStatusUpdateEvent(TaskState.TASK_STATE_COMPLETED);
 
         assertTrue(listener.shouldAutoClose(finalEvent));
     }
@@ -214,7 +212,7 @@ public class SSEEventListenerTest {
     @Test
     public void testShouldAutoCloseWithNonFinalTaskStatusUpdateEvent() {
         TestSSEEventListener listener = createBasicListener();
-        TaskStatusUpdateEvent nonFinalEvent = createTaskStatusUpdateEvent(TaskState.TASK_STATE_WORKING, false);
+        TaskStatusUpdateEvent nonFinalEvent = createTaskStatusUpdateEvent(TaskState.TASK_STATE_WORKING);
 
         assertFalse(listener.shouldAutoClose(nonFinalEvent));
     }
@@ -252,7 +250,7 @@ public class SSEEventListenerTest {
         AtomicReference<StreamingEventKind> receivedEvent = new AtomicReference<>();
         TestSSEEventListener listener = createListenerWithEventCapture(receivedEvent);
 
-        TaskStatusUpdateEvent finalEvent = createTaskStatusUpdateEvent(TaskState.TASK_STATE_COMPLETED, true);
+        TaskStatusUpdateEvent finalEvent = createTaskStatusUpdateEvent(TaskState.TASK_STATE_COMPLETED);
         CancelCapturingFuture future = new CancelCapturingFuture();
 
         listener.setEventToHandle(finalEvent);
@@ -283,7 +281,7 @@ public class SSEEventListenerTest {
         AtomicReference<StreamingEventKind> receivedEvent = new AtomicReference<>();
         TestSSEEventListener listener = createListenerWithEventCapture(receivedEvent);
 
-        TaskStatusUpdateEvent finalEvent = createTaskStatusUpdateEvent(TaskState.TASK_STATE_COMPLETED, true);
+        TaskStatusUpdateEvent finalEvent = createTaskStatusUpdateEvent(TaskState.TASK_STATE_COMPLETED);
 
         // Should not throw with null future
         listener.setEventToHandle(finalEvent);

--- a/extras/queue-manager-replicated/core/src/test/java/org/a2aproject/sdk/extras/queuemanager/replicated/core/EventSerializationTest.java
+++ b/extras/queue-manager-replicated/core/src/test/java/org/a2aproject/sdk/extras/queuemanager/replicated/core/EventSerializationTest.java
@@ -116,7 +116,7 @@ public class EventSerializationTest {
         String json = JsonUtil.toJson((Event) originalEvent);
         assertTrue(json.contains("\"statusUpdate\""), "JSON should contain statusUpdate wrapper");
         assertTrue(json.contains("\"taskId\":\"test-task-abc\""), "JSON should contain task ID");
-        assertTrue(json.contains("\"final\":true"), "JSON should contain final flag");
+        assertFalse(json.contains("\"final\""), "JSON should not contain final field");
 
         // Test deserialization back to StreamingEventKind
         StreamingEventKind deserializedEvent = JsonUtil.fromJson(json, StreamingEventKind.class);

--- a/jsonrpc-common/src/test/java/org/a2aproject/sdk/jsonrpc/common/json/StreamingEventKindSerializationTest.java
+++ b/jsonrpc-common/src/test/java/org/a2aproject/sdk/jsonrpc/common/json/StreamingEventKindSerializationTest.java
@@ -107,7 +107,7 @@ class StreamingEventKindSerializationTest {
         assertTrue(json.contains("\"statusUpdate\""));
         assertTrue(json.contains("\"taskId\":\"task-abc\""));
         assertTrue(json.contains("\"state\":\"TASK_STATE_WORKING\""));
-        assertTrue(json.contains("\"final\":false"));
+        assertFalse(json.contains("\"final\""));
         assertFalse(json.contains("\"kind\""));
 
         // Deserialize back to StreamingEventKind
@@ -217,8 +217,7 @@ class StreamingEventKindSerializationTest {
               "contextId": "context-999",
               "status": {
                 "state": "TASK_STATE_WORKING"
-              },
-              "final": false
+              }
             }
             """;
 

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/ResultAggregatorTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/ResultAggregatorTest.java
@@ -374,7 +374,6 @@ public class ResultAggregatorTest {
             taskId,
             new TaskStatus(TaskState.TASK_STATE_AUTH_REQUIRED),
             "ctx1",
-            false,  // isFinal=false for AUTH_REQUIRED
             null
         );
 

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/TaskManagerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/TaskManagerTest.java
@@ -84,7 +84,6 @@ public class TaskManagerTest {
                 minimalTask.id(),
                 newStatus,
                 minimalTask.contextId(),
-                false,
                 new HashMap<>());
 
 

--- a/spec-grpc/src/main/java/org/a2aproject/sdk/grpc/mapper/TaskStatusUpdateEventMapper.java
+++ b/spec-grpc/src/main/java/org/a2aproject/sdk/grpc/mapper/TaskStatusUpdateEventMapper.java
@@ -7,9 +7,6 @@ import org.mapstruct.Mapping;
 
 /**
  * Mapper between {@link org.a2aproject.sdk.spec.TaskStatusUpdateEvent} and {@link org.a2aproject.sdk.grpc.TaskStatusUpdateEvent}.
- * <p>
- * Now fully declarative using Builder pattern with @BeanMapping.
- * Builder's isFinal() method handles the Java "final" keyword mapping.
  */
 @Mapper(config = A2AProtoMapperConfig.class, uses = {TaskStatusMapper.class, A2ACommonFieldMapper.class})
 public interface TaskStatusUpdateEventMapper {
@@ -18,15 +15,12 @@ public interface TaskStatusUpdateEventMapper {
 
     /**
      * Converts domain TaskStatusUpdateEvent to proto.
-     * Uses declarative mapping with CommonFieldMapper for metadata conversion.
-     * Note: isFinal field is ignored as it has been removed from the proto (field 4 is reserved).
      */
     @Mapping(target = "metadata", source = "metadata", qualifiedByName = "metadataToProto")
     org.a2aproject.sdk.grpc.TaskStatusUpdateEvent toProto(TaskStatusUpdateEvent domain);
 
     /**
      * Converts proto TaskStatusUpdateEvent to domain.
-     * Note: isFinal is derived from status.state().isFinal() since the field has been removed from the proto (field 4 is reserved).
      */
     default TaskStatusUpdateEvent fromProto(org.a2aproject.sdk.grpc.TaskStatusUpdateEvent proto) {
         if (proto == null) {
@@ -37,7 +31,6 @@ public interface TaskStatusUpdateEventMapper {
                 proto.getTaskId(),
                 status,
                 proto.getContextId(),
-                status != null && status.state() != null && status.state().isFinal(),
                 A2ACommonFieldMapper.INSTANCE.metadataFromProto(proto.getMetadata())
         );
     }

--- a/spec-grpc/src/test/java/org/a2aproject/sdk/grpc/utils/ToProtoTest.java
+++ b/spec-grpc/src/test/java/org/a2aproject/sdk/grpc/utils/ToProtoTest.java
@@ -256,12 +256,10 @@ public class ToProtoTest {
     @Test
     public void convertTaskStatusUpdateEvent() {
         TaskStatus completedStatus = new TaskStatus(TaskState.TASK_STATE_COMPLETED);
-        // Use constructor since Builder doesn't have isFinal method
         TaskStatusUpdateEvent tsue = new TaskStatusUpdateEvent(
                 "1234",
                 completedStatus,
                 "xyz",
-                completedStatus.state().isFinal(),  // Derive from state
                 null
         );
         org.a2aproject.sdk.grpc.TaskStatusUpdateEvent result = ProtoUtils.ToProto.taskStatusUpdateEvent(tsue);

--- a/spec/src/main/java/org/a2aproject/sdk/spec/TaskStatusUpdateEvent.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/TaskStatusUpdateEvent.java
@@ -8,7 +8,6 @@ import static org.a2aproject.sdk.spec.TaskState.TASK_STATE_REJECTED;
 
 import java.util.Map;
 
-import com.google.gson.annotations.SerializedName;
 import org.a2aproject.sdk.util.Assert;
 import org.jspecify.annotations.Nullable;
 
@@ -19,11 +18,10 @@ import org.jspecify.annotations.Nullable;
  * @param taskId the task identifier (required)
  * @param status the task status (required)
  * @param contextId the context identifier (required)
- * @param isFinal whether this is a final status
  * @param metadata additional metadata (optional)
  */
 public record TaskStatusUpdateEvent(String taskId, TaskStatus status, String contextId,
-        @SerializedName("final") boolean isFinal, @Nullable Map<String, Object> metadata) implements EventKind, StreamingEventKind, UpdateEvent {
+        @Nullable Map<String, Object> metadata) implements EventKind, StreamingEventKind, UpdateEvent {
 
     /**
      * The identifier when used in streaming responses
@@ -36,7 +34,6 @@ public record TaskStatusUpdateEvent(String taskId, TaskStatus status, String con
      * @param taskId the task identifier (required)
      * @param status the task status (required)
      * @param contextId the context identifier (required)
-     * @param isFinal whether this is a final status
      * @param metadata additional metadata (optional)
      * @throws IllegalArgumentException if taskId, status, or contextId is null
      */
@@ -44,9 +41,6 @@ public record TaskStatusUpdateEvent(String taskId, TaskStatus status, String con
         Assert.checkNotNullParam("taskId", taskId);
         Assert.checkNotNullParam("status", status);
         Assert.checkNotNullParam("contextId", contextId);
-        if (isFinal != status.state().isFinal()) {
-            throw new IllegalArgumentException("isFinal must be the same as the Status state");
-        }
     }
 
     @Override
@@ -55,11 +49,19 @@ public record TaskStatusUpdateEvent(String taskId, TaskStatus status, String con
     }
 
     /**
-     * Indicates if the task is fianl or waiting for some inputs from the client.
-     * @return true if the task is fianl or waiting for some inputs from the client - false otherwise.
+     * Indicates if this is a final status event, derived from the task state.
+     * @return true if the task state is terminal - false otherwise.
+     */
+    public boolean isFinal() {
+        return status.state().isFinal();
+    }
+
+    /**
+     * Indicates if the task is final or waiting for some inputs from the client.
+     * @return true if the task is final or waiting for some inputs from the client - false otherwise.
      */
     public boolean isFinalOrInterrupted() {
-        return status.state() == TASK_STATE_COMPLETED || status.state() == TASK_STATE_FAILED || status.state() == TASK_STATE_CANCELED || status.state() == TASK_STATE_REJECTED || status.state() == TASK_STATE_INPUT_REQUIRED;
+        return status.state().isFinal() || status.state().isInterrupted();
     }
 
     /**
@@ -155,7 +157,6 @@ public record TaskStatusUpdateEvent(String taskId, TaskStatus status, String con
                     Assert.checkNotNullParam("taskId", taskId),
                     Assert.checkNotNullParam("status", status),
                     Assert.checkNotNullParam("contextId", contextId),
-                    Assert.checkNotNullParam("status", status).state().isFinal(),
                     metadata);
         }
     }


### PR DESCRIPTION
The 'final' field was being serialized as part of TaskStatusUpdateEvent payloads but is not defined in the A2A specification for this type. Removed isFinal from the record components and replaced it with a derived method that computes the value from status.state().isFinal().

Also simplified the delegation of the `isFinalOrInterrupted()` method.

Fixes #811