### PR TITLE
fix: remove redundant `isFinal` field from `TaskStatusUpdateEvent`

### DIFF
--- a/client/transport/jsonrpc/src/test/java/org/a2aproject/sdk/client/transport/jsonrpc/sse/SSEEventListenerTest.java
+++ b/client/transport/jsonrpc/src/test/java/org/a2aproject/sdk/client/transport/jsonrpc/sse/SSEEventListenerTest.java
@@ -190,7 +190,6 @@ public class SSEEventListenerTest {
                 "1234",
                 completedStatus,
                 "xyz",
-                completedStatus.state().isFinal(),  // Derive from state
                 null
         );
 

--- a/client/transport/spi/src/test/java/org/a2aproject/sdk/client/transport/spi/sse/SSEEventListenerTest.java
+++ b/client/transport/spi/src/test/java/org/a2aproject/sdk/client/transport/spi/sse/SSEEventListenerTest.java
@@ -120,7 +120,6 @@ public class SSEEventListenerTest {
                 TEST_TASK_ID,
                 new TaskStatus(state),
                 TEST_CONTEXT_ID,
-                isFinal,
                 null
         );
     }

--- a/extras/queue-manager-replicated/core/src/test/java/org/a2aproject/sdk/extras/queuemanager/replicated/core/EventSerializationTest.java
+++ b/extras/queue-manager-replicated/core/src/test/java/org/a2aproject/sdk/extras/queuemanager/replicated/core/EventSerializationTest.java
@@ -116,7 +116,8 @@ public class EventSerializationTest {
         String json = JsonUtil.toJson((Event) originalEvent);
         assertTrue(json.contains("\"statusUpdate\""), "JSON should contain statusUpdate wrapper");
         assertTrue(json.contains("\"taskId\":\"test-task-abc\""), "JSON should contain task ID");
-        assertTrue(json.contains("\"final\":true"), "JSON should contain final flag");
+        assertFalse(json.contains("\"final\":true"), "JSON shouldn't contain final flag");
+        assertFalse(json.contains("\"final\":false"), "JSON shouldn't contain final flag");
 
         // Test deserialization back to StreamingEventKind
         StreamingEventKind deserializedEvent = JsonUtil.fromJson(json, StreamingEventKind.class);

--- a/jsonrpc-common/src/test/java/org/a2aproject/sdk/jsonrpc/common/json/StreamingEventKindSerializationTest.java
+++ b/jsonrpc-common/src/test/java/org/a2aproject/sdk/jsonrpc/common/json/StreamingEventKindSerializationTest.java
@@ -107,7 +107,8 @@ class StreamingEventKindSerializationTest {
         assertTrue(json.contains("\"statusUpdate\""));
         assertTrue(json.contains("\"taskId\":\"task-abc\""));
         assertTrue(json.contains("\"state\":\"TASK_STATE_WORKING\""));
-        assertTrue(json.contains("\"final\":false"));
+        assertFalse(json.contains("\"final\":false"));
+        assertFalse(json.contains("\"final\":true"));
         assertFalse(json.contains("\"kind\""));
 
         // Deserialize back to StreamingEventKind

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/ResultAggregatorTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/ResultAggregatorTest.java
@@ -1,7 +1,6 @@
 package org.a2aproject.sdk.server.tasks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atMost;
@@ -374,7 +373,6 @@ public class ResultAggregatorTest {
             taskId,
             new TaskStatus(TaskState.TASK_STATE_AUTH_REQUIRED),
             "ctx1",
-            false,  // isFinal=false for AUTH_REQUIRED
             null
         );
 

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/TaskManagerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/TaskManagerTest.java
@@ -84,7 +84,6 @@ public class TaskManagerTest {
                 minimalTask.id(),
                 newStatus,
                 minimalTask.contextId(),
-                false,
                 new HashMap<>());
 
 

--- a/spec-grpc/src/main/java/org/a2aproject/sdk/grpc/mapper/TaskStatusUpdateEventMapper.java
+++ b/spec-grpc/src/main/java/org/a2aproject/sdk/grpc/mapper/TaskStatusUpdateEventMapper.java
@@ -37,7 +37,6 @@ public interface TaskStatusUpdateEventMapper {
                 proto.getTaskId(),
                 status,
                 proto.getContextId(),
-                status != null && status.state() != null && status.state().isFinal(),
                 A2ACommonFieldMapper.INSTANCE.metadataFromProto(proto.getMetadata())
         );
     }

--- a/spec-grpc/src/test/java/org/a2aproject/sdk/grpc/utils/ToProtoTest.java
+++ b/spec-grpc/src/test/java/org/a2aproject/sdk/grpc/utils/ToProtoTest.java
@@ -261,7 +261,6 @@ public class ToProtoTest {
                 "1234",
                 completedStatus,
                 "xyz",
-                completedStatus.state().isFinal(),  // Derive from state
                 null
         );
         org.a2aproject.sdk.grpc.TaskStatusUpdateEvent result = ProtoUtils.ToProto.taskStatusUpdateEvent(tsue);

--- a/spec/src/main/java/org/a2aproject/sdk/spec/TaskStatusUpdateEvent.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/TaskStatusUpdateEvent.java
@@ -8,7 +8,6 @@ import static org.a2aproject.sdk.spec.TaskState.TASK_STATE_REJECTED;
 
 import java.util.Map;
 
-import com.google.gson.annotations.SerializedName;
 import org.a2aproject.sdk.util.Assert;
 import org.jspecify.annotations.Nullable;
 
@@ -23,7 +22,7 @@ import org.jspecify.annotations.Nullable;
  * @param metadata additional metadata (optional)
  */
 public record TaskStatusUpdateEvent(String taskId, TaskStatus status, String contextId,
-        @SerializedName("final") boolean isFinal, @Nullable Map<String, Object> metadata) implements EventKind, StreamingEventKind, UpdateEvent {
+        @Nullable Map<String, Object> metadata) implements EventKind, StreamingEventKind, UpdateEvent {
 
     /**
      * The identifier when used in streaming responses
@@ -44,9 +43,6 @@ public record TaskStatusUpdateEvent(String taskId, TaskStatus status, String con
         Assert.checkNotNullParam("taskId", taskId);
         Assert.checkNotNullParam("status", status);
         Assert.checkNotNullParam("contextId", contextId);
-        if (isFinal != status.state().isFinal()) {
-            throw new IllegalArgumentException("isFinal must be the same as the Status state");
-        }
     }
 
     @Override
@@ -55,8 +51,17 @@ public record TaskStatusUpdateEvent(String taskId, TaskStatus status, String con
     }
 
     /**
-     * Indicates if the task is fianl or waiting for some inputs from the client.
-     * @return true if the task is fianl or waiting for some inputs from the client - false otherwise.
+     * Indicates if the task is final.
+     * @return true if the task is final - false otherwise.
+     */
+    public boolean isFinal() {
+        TaskState state = status.state();
+        return state != null && state.isFinal();
+    }
+
+    /**
+     * Indicates if the task is final or waiting for some inputs from the client.
+     * @return true if the task is final or waiting for some inputs from the client - false otherwise.
      */
     public boolean isFinalOrInterrupted() {
         return status.state() == TASK_STATE_COMPLETED || status.state() == TASK_STATE_FAILED || status.state() == TASK_STATE_CANCELED || status.state() == TASK_STATE_REJECTED || status.state() == TASK_STATE_INPUT_REQUIRED;
@@ -155,7 +160,6 @@ public record TaskStatusUpdateEvent(String taskId, TaskStatus status, String con
                     Assert.checkNotNullParam("taskId", taskId),
                     Assert.checkNotNullParam("status", status),
                     Assert.checkNotNullParam("contextId", contextId),
-                    Assert.checkNotNullParam("status", status).state().isFinal(),
                     metadata);
         }
     }


### PR DESCRIPTION
- The `isFinal` boolean was redundant since it can always be derived from `TaskStatus.state().isFinal()`.
- Removing it as a constructor parameter eliminates a source of inconsistency and the validation guard that was needed to keep it in sync.
- `isFinal()` is now a computed method, and the `final` field is no longer serialized to JSON.

Fixes #811 🦕