### PR TITLE
fix: support complete agent card URL in A2ACardResolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ If you want to use the HTTP+JSON/REST transport, you'll need to add a relevant d
 
 ```java
 // First, get the agent card for the A2A server agent you want to connect to
-AgentCard agentCard = new A2ACardResolver("http://localhost:1234").getAgentCard();
+AgentCard agentCard = A2ACardResolver.builder().baseUrl("http://localhost:1234").build().getAgentCard();
 
 // Specify configuration for the ClientBuilder
 ClientConfig clientConfig = new ClientConfig.Builder()
@@ -776,7 +776,7 @@ gRPC and REST transports are also available:
 #### 3. Create the v0.3 client
 
 ```java
-AgentCard card = new A2ACardResolver("http://localhost:1234").getAgentCard();
+AgentCard card = A2ACardResolver.builder().baseUrl("http://localhost:1234").build().getAgentCard();
 
 // Find the v0.3 interface from the agent card
 AgentInterface v03Interface = card.supportedInterfaces().stream()

--- a/client/base/src/main/java/org/a2aproject/sdk/A2A.java
+++ b/client/base/src/main/java/org/a2aproject/sdk/A2A.java
@@ -393,7 +393,12 @@ public class A2A {
      * @throws org.a2aproject.sdk.spec.A2AClientJSONError if the response body cannot be decoded as JSON or validated against the AgentCard schema
      */
     public static AgentCard getAgentCard(A2AHttpClient httpClient, String agentUrl, String relativeCardPath, Map<String, String> authHeaders) throws A2AClientError, A2AClientJSONError  {
-        A2ACardResolver resolver = new A2ACardResolver(httpClient, agentUrl, "", relativeCardPath, authHeaders);
+        A2ACardResolver resolver = A2ACardResolver.builder()
+                .httpClient(httpClient)
+                .baseUrl(agentUrl)
+                .agentCardPath(relativeCardPath)
+                .authHeaders(authHeaders)
+                .build();
         return resolver.getAgentCard();
     }
 }

--- a/compat-0.3/client/transport/spi/src/main/java/org/a2aproject/sdk/compat03/client/http/A2ACardResolver_v0_3.java
+++ b/compat-0.3/client/transport/spi/src/main/java/org/a2aproject/sdk/compat03/client/http/A2ACardResolver_v0_3.java
@@ -1,9 +1,10 @@
 package org.a2aproject.sdk.compat03.client.http;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
+
+import static org.a2aproject.sdk.util.Assert.checkNotNullParam;
 
 import org.a2aproject.sdk.client.http.A2AHttpClient;
 import org.a2aproject.sdk.client.http.A2AHttpClientFactory;
@@ -13,14 +14,13 @@ import org.a2aproject.sdk.compat03.json.JsonUtil_v0_3;
 import org.a2aproject.sdk.compat03.spec.A2AClientError_v0_3;
 import org.a2aproject.sdk.compat03.spec.A2AClientJSONError_v0_3;
 import org.a2aproject.sdk.compat03.spec.AgentCard_v0_3;
+import org.a2aproject.sdk.util.Utils;
 import org.jspecify.annotations.Nullable;
 
 public class A2ACardResolver_v0_3 {
     private final A2AHttpClient httpClient;
     private final String url;
     private final @Nullable Map<String, String> authHeaders;
-
-    private static final String DEFAULT_AGENT_CARD_PATH = "/.well-known/agent-card.json";
 
     /**
      * Get the agent card for an A2A agent.
@@ -65,14 +65,17 @@ public class A2ACardResolver_v0_3 {
      */
     public A2ACardResolver_v0_3(A2AHttpClient httpClient, String baseUrl, @Nullable String agentCardPath,
                                 @Nullable Map<String, String> authHeaders) throws A2AClientError_v0_3 {
+        checkNotNullParam("httpClient", httpClient);
+        checkNotNullParam("baseUrl", baseUrl);
         this.httpClient = httpClient;
-        String effectiveAgentCardPath = agentCardPath == null || agentCardPath.isEmpty() ? DEFAULT_AGENT_CARD_PATH : agentCardPath;
+        String effectiveAgentCardPath = agentCardPath == null || agentCardPath.isEmpty() ? Utils.DEFAULT_AGENT_CARD_PATH : agentCardPath;
         try {
-            this.url = new URI(baseUrl).resolve(effectiveAgentCardPath).toString();
+            Utils.validateAbsoluteUrl(baseUrl);
+            this.url = Utils.buildCardUrl(Utils.stripWellKnownSuffix(baseUrl), effectiveAgentCardPath);
         } catch (URISyntaxException e) {
             throw new A2AClientError_v0_3("Invalid agent URL", e);
         }
-        this.authHeaders = authHeaders;
+        this.authHeaders = authHeaders != null ? Map.copyOf(authHeaders) : null;
     }
 
     /**
@@ -88,9 +91,7 @@ public class A2ACardResolver_v0_3 {
                 .addHeader("Content-Type", "application/json");
 
         if (authHeaders != null) {
-            for (Map.Entry<String, String> entry : authHeaders.entrySet()) {
-                builder.addHeader(entry.getKey(), entry.getValue());
-            }
+            builder.addHeaders(authHeaders);
         }
 
         String body;
@@ -100,7 +101,10 @@ public class A2ACardResolver_v0_3 {
                 throw new A2AClientError_v0_3("Failed to obtain agent card: " + response.status());
             }
             body = response.body();
-        } catch (IOException | InterruptedException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new A2AClientError_v0_3("Failed to obtain agent card", e);
+        } catch (IOException e) {
             throw new A2AClientError_v0_3("Failed to obtain agent card", e);
         }
 

--- a/compat-0.3/client/transport/spi/src/test/java/org/a2aproject/sdk/compat03/client/http/A2ACardResolver_v0_3_Test.java
+++ b/compat-0.3/client/transport/spi/src/test/java/org/a2aproject/sdk/compat03/client/http/A2ACardResolver_v0_3_Test.java
@@ -62,8 +62,45 @@ public class A2ACardResolver_v0_3_Test {
         card = resolver.getAgentCard();
 
         assertEquals("http://example.com" + AGENT_CARD_PATH, client.url);
+
+        // baseUrl with sub-path and trailing slash — the original URI.resolve() bug silently
+        // dropped the sub-path, producing http://example.com/.well-known/agent-card.json instead
+        resolver = new A2ACardResolver_v0_3(client, "http://example.com/jsonrpc/", AGENT_CARD_PATH);
+        card = resolver.getAgentCard();
+
+        assertEquals("http://example.com/jsonrpc" + AGENT_CARD_PATH, client.url);
+
+        // baseUrl with sub-path, no trailing slash
+        resolver = new A2ACardResolver_v0_3(client, "http://example.com/jsonrpc", AGENT_CARD_PATH);
+        card = resolver.getAgentCard();
+
+        assertEquals("http://example.com/jsonrpc" + AGENT_CARD_PATH, client.url);
     }
 
+
+    @Test
+    public void testBaseUrl_alreadyContainsWellKnownPath() throws Exception {
+        TestHttpClient client = new TestHttpClient();
+        client.body = JsonMessages_v0_3.AGENT_CARD;
+
+        String fullUrl = "https://example.com/spec03" + AGENT_CARD_PATH;
+        A2ACardResolver_v0_3 resolver = new A2ACardResolver_v0_3(client, fullUrl);
+        resolver.getAgentCard();
+
+        assertEquals(fullUrl, client.url);
+    }
+
+    @Test
+    public void testFullWellKnownUrlWithCustomAgentCardPath() throws Exception {
+        TestHttpClient client = new TestHttpClient();
+        client.body = JsonMessages_v0_3.AGENT_CARD;
+
+        A2ACardResolver_v0_3 resolver = new A2ACardResolver_v0_3(
+                client, "https://example.com/spec03" + AGENT_CARD_PATH, "/custom/card.json");
+        resolver.getAgentCard();
+
+        assertEquals("https://example.com/spec03/custom/card.json", client.url);
+    }
 
     @Test
     public void testGetAgentCardSuccess() throws Exception {

--- a/examples/helloworld/client/src/main/java/org/a2aproject/sdk/examples/helloworld/HelloWorldClient.java
+++ b/examples/helloworld/client/src/main/java/org/a2aproject/sdk/examples/helloworld/HelloWorldClient.java
@@ -53,7 +53,7 @@ public class HelloWorldClient {
     public static void main(String[] args) {
         OpenTelemetrySdk openTelemetrySdk = null;
         try {
-            AgentCard publicAgentCard = new A2ACardResolver(SERVER_URL).getAgentCard();
+            AgentCard publicAgentCard = A2ACardResolver.builder().baseUrl(SERVER_URL).build().getAgentCard();
             System.out.println("Successfully fetched public agent card:");
             System.out.println(JsonUtil.toJson(publicAgentCard));
             System.out.println("Using public agent card for client initialization (default).");

--- a/extras/http-client-vertx/README.md
+++ b/extras/http-client-vertx/README.md
@@ -85,7 +85,7 @@ The Vert.x HTTP client is automatically discovered via **Java SPI (Service Provi
 
 ```java
 // No changes needed - A2A SDK automatically uses VertxA2AHttpClient
-A2ACardResolver resolver = new A2ACardResolver("http://localhost:9999");
+A2ACardResolver resolver = A2ACardResolver.builder().baseUrl("http://localhost:9999").build();
 AgentCard card = resolver.getAgentCard(); // Uses Vert.x under the hood
 
 // Client creation also uses Vert.x automatically
@@ -112,7 +112,7 @@ The module works out-of-the-box with sensible defaults:
 // With vertx-http-client on the classpath, it automatically uses VertxA2AHttpClient
 
 // Example 1: Fetching agent card
-A2ACardResolver resolver = new A2ACardResolver("http://localhost:9999");
+A2ACardResolver resolver = A2ACardResolver.builder().baseUrl("http://localhost:9999").build();
 AgentCard card = resolver.getAgentCard();
 
 // Example 2: Using REST transport (uses HTTP client internally)

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -31,6 +31,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/A2ACardResolver.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/A2ACardResolver.java
@@ -1,10 +1,11 @@
 package org.a2aproject.sdk.client.http;
 
-
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.Map;
+
+import static org.a2aproject.sdk.util.Assert.checkNotNullParam;
 
 import org.a2aproject.sdk.grpc.utils.JSONRPCUtils;
 import org.a2aproject.sdk.grpc.utils.ProtoUtils;
@@ -12,173 +13,247 @@ import org.a2aproject.sdk.jsonrpc.common.json.JsonProcessingException;
 import org.a2aproject.sdk.spec.A2AClientError;
 import org.a2aproject.sdk.spec.A2AClientJSONError;
 import org.a2aproject.sdk.spec.AgentCard;
-import org.a2aproject.sdk.spec.A2AError;
+import org.a2aproject.sdk.util.Utils;
 import org.jspecify.annotations.Nullable;
-
-import static org.a2aproject.sdk.util.Assert.checkNotNullParam;
-
-import org.a2aproject.sdk.spec.AgentInterface;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility for fetching agent cards from A2A agents.
  *
- * <p>Retrieves agent cards from the standard {@code /.well-known/agent-card.json} endpoint
+ * <p>
+ * Retrieves agent cards from the standard {@code /.well-known/agent-card.json} endpoint
  * with support for tenant-specific paths and authentication headers.
  *
  * <h2>Features</h2>
  * <ul>
- *   <li>Standard agent card endpoint discovery ({@code /.well-known/agent-card.json})</li>
- *   <li>Tenant-specific path support ({@code /tenant/.well-known/agent-card.json})</li>
- *   <li>Custom authentication header injection</li>
- *   <li>Pluggable HTTP client via {@link A2AHttpClientFactory}</li>
- *   <li>Support for both public and extended agent cards</li>
+ * <li>Standard agent card endpoint discovery ({@code /.well-known/agent-card.json})</li>
+ * <li>Tenant-specific path support ({@code /tenant/.well-known/agent-card.json})</li>
+ * <li>Custom card path support for non-standard agent card locations</li>
+ * <li>Custom authentication header injection</li>
+ * <li>Pluggable HTTP client via {@link A2AHttpClientFactory}</li>
  * </ul>
  *
  * <h2>Usage Examples</h2>
  * <pre>{@code
- * // Basic usage - fetch agent card
- * A2ACardResolver resolver = new A2ACardResolver("http://localhost:9999");
+ * // Basic usage - fetch the agent card from a base URL
+ * A2ACardResolver resolver = A2ACardResolver.builder()
+ *     .baseUrl("http://localhost:9999")
+ *     .build();
  * AgentCard card = resolver.getAgentCard();
  *
  * // With tenant path
- * A2ACardResolver resolver = new A2ACardResolver("http://localhost:9999", "my-tenant");
+ * A2ACardResolver resolver = A2ACardResolver.builder()
+ *     .baseUrl("http://localhost:9999")
+ *     .tenant("my-tenant")
+ *     .build();
  * AgentCard card = resolver.getAgentCard();
  *
- * // With custom HTTP client
+ * // With custom HTTP client and authentication
  * A2AHttpClient httpClient = A2AHttpClientFactory.create();
- * A2ACardResolver resolver = new A2ACardResolver(httpClient, "http://localhost:9999", "my-tenant");
+ * A2ACardResolver resolver = A2ACardResolver.builder()
+ *     .httpClient(httpClient)
+ *     .baseUrl("http://localhost:9999")
+ *     .tenant("my-tenant")
+ *     .authHeader("Authorization", "Bearer token")
+ *     .build();
  * AgentCard card = resolver.getAgentCard();
  *
- * // With authentication headers
- * A2AHttpClient httpClient = A2AHttpClientFactory.create();
- * Map<String, String> authHeaders = Map.of("Authorization", "Bearer token");
- * A2ACardResolver resolver = new A2ACardResolver(
- *     httpClient,
- *     "http://localhost:9999",
- *     "my-tenant",
- *     null,  // use default agent card path
- *     authHeaders
- * );
+ * // With a custom agent card path
+ * A2ACardResolver resolver = A2ACardResolver.builder()
+ *     .baseUrl("http://localhost:9999")
+ *     .agentCardPath("/custom/agent.json")
+ *     .build();
  * AgentCard card = resolver.getAgentCard();
  *
- * // Fetch extended agent card (if available)
- * AgentCard extendedCard = resolver.getExtendedAgentCard();
+ * // Using a complete URL (e.g., with path prefix like /spec03)
+ * A2ACardResolver resolver = A2ACardResolver.builder()
+ *     .baseUrl("https://example.com/spec03")
+ *     .build();
+ * AgentCard card = resolver.getAgentCard();
  * }</pre>
  *
  * @see AgentCard
  * @see A2AHttpClient
  */
 public class A2ACardResolver {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(A2ACardResolver.class);
+
     private final A2AHttpClient httpClient;
-    private final String url;
+    private final String cardUrl;
     private final @Nullable Map<String, String> authHeaders;
 
-    private static final String DEFAULT_AGENT_CARD_PATH = "/.well-known/agent-card.json";
-
-    /**
-     * Creates an agent card resolver. An HTTP client will be auto-selected via {@link A2AHttpClientFactory}.
-     *
-     * @param baseUrl the base URL for the agent whose agent card we want to retrieve, must not be null
-     * @throws A2AClientError if the URL for the agent is invalid
-     * @throws IllegalArgumentException if baseUrl is null
-     */
-    public A2ACardResolver(String baseUrl) throws A2AClientError {
-        this(A2AHttpClientFactory.create(), baseUrl, null, null);
-    }
-
-    /**
-     * Get the agent card for an A2A agent. An HTTP client will be auto-selected via {@link A2AHttpClientFactory}.
-     *
-     * @param baseUrl the base URL for the agent whose agent card we want to retrieve, must not be null
-     * @param tenant the tenant path to use when fetching the agent card, may be null for no tenant
-     * @throws A2AClientError if the URL for the agent is invalid
-     * @throws IllegalArgumentException if baseUrl is null
-     */
-    public A2ACardResolver(String baseUrl, @Nullable String tenant) throws A2AClientError {
-        this(A2AHttpClientFactory.create(), baseUrl, tenant, null);
-    }
-
-    /**
-     * Constructs an A2ACardResolver with a specific HTTP client and base URL.
-     *
-     * @param httpClient the HTTP client to use for fetching the agent card, must not be null
-     * @param baseUrl the base URL for the agent whose agent card we want to retrieve, must not be null
-     * @param tenant the tenant path to use when fetching the agent card, may be null for no tenant
-     * @throws A2AClientError if the URL for the agent is invalid
-     * @throws IllegalArgumentException if httpClient or baseUrl is null
-     */
-    public A2ACardResolver(A2AHttpClient httpClient, String baseUrl, @Nullable String tenant) throws A2AClientError {
-        this(httpClient, baseUrl, tenant, null);
-    }
-
-    /**
-     * Constructs an A2ACardResolver with a specific HTTP client, base URL, and custom agent card path.
-     *
-     * @param httpClient the HTTP client to use for fetching the agent card, must not be null
-     * @param baseUrl the base URL for the agent whose agent card we want to retrieve, must not be null
-     * @param tenant the tenant path to use when fetching the agent card, may be null for no tenant
-     * @param agentCardPath optional path to the agent card endpoint relative to the base
-     *                      agent URL, defaults to "/.well-known/agent-card.json" if null or empty
-     * @throws A2AClientError if the URL for the agent is invalid
-     * @throws IllegalArgumentException if httpClient or baseUrl is null
-     */
-    public A2ACardResolver(A2AHttpClient httpClient, String baseUrl, @Nullable String tenant, @Nullable String agentCardPath) throws A2AClientError {
-        this(httpClient, baseUrl, tenant, agentCardPath, null);
-    }
-
-    /**
-     * Constructs an A2ACardResolver with full configuration including authentication headers.
-     *
-     * @param httpClient the HTTP client to use for fetching the agent card, must not be null
-     * @param baseUrl the base URL for the agent whose agent card we want to retrieve, must not be null
-     * @param tenant the tenant path to use when fetching the agent card, may be null for no tenant
-     * @param agentCardPath optional path to the agent card endpoint relative to the base
-     *                      agent URL, defaults to "/.well-known/agent-card.json" if null or empty
-     * @param authHeaders the HTTP authentication headers to use, may be null
-     * @throws A2AClientError if the URL for the agent is invalid
-     * @throws IllegalArgumentException if httpClient or baseUrl is null
-     */
-    public A2ACardResolver(A2AHttpClient httpClient, String baseUrl, @Nullable String tenant, @Nullable String agentCardPath,
-                           @Nullable Map<String, String> authHeaders) throws A2AClientError {
+    private A2ACardResolver(A2AHttpClient httpClient, String baseUrl, @Nullable String tenant, @Nullable String agentCardPath, @Nullable Map<String, String> authHeaders) throws A2AClientError {
         checkNotNullParam("httpClient", httpClient);
         checkNotNullParam("baseUrl", baseUrl);
-
         this.httpClient = httpClient;
-        String effectiveAgentCardPath = (agentCardPath == null || agentCardPath.isEmpty()) ? DEFAULT_AGENT_CARD_PATH : agentCardPath;
         try {
-            this.url = new URI(org.a2aproject.sdk.util.Utils.buildBaseUrl(new AgentInterface("JSONRPC", baseUrl, ""), tenant)).resolve(effectiveAgentCardPath).toString();
+            // Strip any well-known suffix from baseUrl before appending the tenant,
+            // so that a full card URL like https://host/.well-known/agent-card.json + tenant
+            // doesn't produce a malformed path.
+            String cleanBase = Utils.stripWellKnownSuffix(baseUrl);
+            String baseUrlWithTenant = Utils.buildBaseUrl(cleanBase, tenant);
+            Utils.validateAbsoluteUrl(baseUrlWithTenant);
+            this.cardUrl = (agentCardPath == null || agentCardPath.isEmpty())
+                    ? Utils.buildCardUrl(baseUrlWithTenant, Utils.DEFAULT_AGENT_CARD_PATH)
+                    : Utils.buildCardUrl(baseUrlWithTenant, agentCardPath);
         } catch (URISyntaxException e) {
             throw new A2AClientError("Invalid agent URL", e);
         }
-        this.authHeaders = authHeaders;
+        this.authHeaders = authHeaders != null ? Map.copyOf(authHeaders) : null;
+        LOGGER.debug("Initialized A2ACardResolver with cardUrl={}", cardUrl);
     }
 
     /**
-     * Get the agent card for the configured A2A agent.
+     * Creates a new builder for constructing an A2ACardResolver.
+     *
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for creating A2ACardResolver instances with a fluent API.
+     */
+    public static class Builder {
+
+        private @Nullable A2AHttpClient httpClient;
+        private @Nullable String baseUrl;
+        private @Nullable String tenant;
+        private @Nullable String agentCardPath;
+        private @Nullable Map<String, String> authHeaders;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the HTTP client to use for fetching agent cards.
+         * If not called, a default client is created via {@link A2AHttpClientFactory#create()}.
+         *
+         * @param httpClient the HTTP client to use
+         * @return this builder
+         */
+        public Builder httpClient(A2AHttpClient httpClient) {
+            this.httpClient = httpClient;
+            return this;
+        }
+
+        /**
+         * Sets the base URL for the agent.
+         *
+         * @param baseUrl the base URL, must not be null
+         * @return this builder
+         */
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        /**
+         * Sets the tenant path to use when fetching the agent card.
+         *
+         * @param tenant the tenant path, may be null for no tenant
+         * @return this builder
+         */
+        public Builder tenant(@Nullable String tenant) {
+            this.tenant = tenant;
+            return this;
+        }
+
+        /**
+         * Sets a custom agent card path relative to the base URL.
+         *
+         * @param agentCardPath the custom agent card path; if null or empty, defaults to
+         *                      {@code /.well-known/agent-card.json}
+         * @return this builder
+         */
+        public Builder agentCardPath(@Nullable String agentCardPath) {
+            this.agentCardPath = agentCardPath;
+            return this;
+        }
+
+        /**
+         * Sets the authentication headers to use when fetching the agent card.
+         *
+         * @param authHeaders the authentication headers, may be null
+         * @return this builder
+         */
+        public Builder authHeaders(@Nullable Map<String, String> authHeaders) {
+            if (authHeaders != null) {
+                this.authHeaders = new HashMap<>(authHeaders);
+            }
+            return this;
+        }
+
+        /**
+         * Adds a single authentication header.
+         *
+         * @param name the header name
+         * @param value the header value
+         * @return this builder
+         */
+        public Builder authHeader(String name, String value) {
+            if (this.authHeaders == null) {
+                this.authHeaders = new HashMap<>();
+            }
+            this.authHeaders.put(name, value);
+            return this;
+        }
+
+        /**
+         * Builds the A2ACardResolver instance.
+         *
+         * @return a new A2ACardResolver
+         * @throws A2AClientError if the configuration is invalid
+         * @throws IllegalArgumentException if baseUrl is null
+         */
+        public A2ACardResolver build() throws A2AClientError {
+            A2AHttpClient client = httpClient != null ? httpClient : A2AHttpClientFactory.create();
+            if (baseUrl == null) {
+                throw new IllegalArgumentException("baseUrl must not be null");
+            }
+            return new A2ACardResolver(client, baseUrl, tenant, agentCardPath, authHeaders);
+        }
+    }
+
+    /**
+     * Fetches the agent card for this resolver's configured agent.
+     *
+     * <p>Fetches from the custom {@code agentCardPath} when one was supplied, otherwise fetches
+     * from the standard {@code /.well-known/agent-card.json} endpoint. No automatic fallback
+     * is performed; errors are propagated directly to the caller.
      *
      * @return the agent card
-     * @throws A2AClientError If an HTTP error occurs fetching the card
-     * @throws A2AClientJSONError If the response body cannot be decoded as JSON or validated against the AgentCard schema
+     * @throws A2AClientError If an HTTP or network error occurs fetching the card
+     * @throws A2AClientJSONError If the response body cannot be decoded as JSON or validated
+     * against the AgentCard schema
      */
     public AgentCard getAgentCard() throws A2AClientError, A2AClientJSONError {
+        LOGGER.debug("Fetching agent card from URL: {}", cardUrl);
+
         A2AHttpClient.GetBuilder builder = httpClient.createGet()
-                .url(url)
+                .url(cardUrl)
                 .addHeader("Content-Type", "application/json");
 
         if (authHeaders != null) {
-            for (Map.Entry<String, String> entry : authHeaders.entrySet()) {
-                builder.addHeader(entry.getKey(), entry.getValue());
-            }
+            builder.addHeaders(authHeaders);
         }
 
         String body;
         try {
             A2AHttpResponse response = builder.get();
             if (!response.success()) {
+                LOGGER.debug("Failed to fetch agent card from {}, status: {}", cardUrl, response.status());
                 throw new A2AClientError("Failed to obtain agent card: " + response.status());
             }
             body = response.body();
-        } catch (IOException | InterruptedException e) {
+            LOGGER.debug("Successfully fetched agent card from {}", cardUrl);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new A2AClientError("Failed to obtain agent card", e);
+        } catch (IOException e) {
             throw new A2AClientError("Failed to obtain agent card", e);
         }
 
@@ -186,7 +261,7 @@ public class A2ACardResolver {
             org.a2aproject.sdk.grpc.AgentCard.Builder agentCardBuilder = org.a2aproject.sdk.grpc.AgentCard.newBuilder();
             JSONRPCUtils.parseJsonString(body, agentCardBuilder, "", true);
             return ProtoUtils.FromProto.agentCard(agentCardBuilder);
-        } catch (A2AError | JsonProcessingException e) {
+        } catch (JsonProcessingException e) {
             throw new A2AClientJSONError("Could not unmarshal agent card response", e);
         }
     }

--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/package-info.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/package-info.java
@@ -24,7 +24,7 @@
  * <h2>Usage Example</h2>
  * <pre>{@code
  * // Fetch an agent card
- * A2ACardResolver resolver = new A2ACardResolver("http://localhost:9999");
+ * A2ACardResolver resolver = A2ACardResolver.builder().baseUrl("http://localhost:9999").build();
  * AgentCard card = resolver.getAgentCard();
  *
  * // Make HTTP requests

--- a/http-client/src/test/java/org/a2aproject/sdk/client/http/A2ACardResolverTest.java
+++ b/http-client/src/test/java/org/a2aproject/sdk/client/http/A2ACardResolverTest.java
@@ -1,84 +1,308 @@
 package org.a2aproject.sdk.client.http;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import org.a2aproject.sdk.grpc.utils.JSONRPCUtils;
 import org.a2aproject.sdk.grpc.utils.ProtoUtils;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonProcessingException;
 import org.a2aproject.sdk.spec.A2AClientError;
 import org.a2aproject.sdk.spec.A2AClientJSONError;
 import org.a2aproject.sdk.spec.AgentCard;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class A2ACardResolverTest {
 
     private static final String AGENT_CARD_PATH = "/.well-known/agent-card.json";
 
-    @Test
-    public void testConstructorStripsSlashes() throws Exception {
+    private TestHttpClient createTestClient() {
         TestHttpClient client = new TestHttpClient();
         client.body = JsonMessages.AGENT_CARD;
+        return client;
+    }
 
-        A2ACardResolver resolver = new A2ACardResolver(client, "http://example.com/", "");
-        AgentCard card = resolver.getAgentCard();
+    // -------------------------------------------------------------------------
+    // Well-known URL construction
+    // -------------------------------------------------------------------------
 
-        assertEquals("http://example.com" + AGENT_CARD_PATH, client.url);
-
-
-        resolver = new A2ACardResolver(client, "http://example.com", "");
-        card = resolver.getAgentCard();
-
-        assertEquals("http://example.com" + AGENT_CARD_PATH, client.url);
-
-        // baseUrl with trailing slash, agentCardParth with leading slash
-        resolver = new A2ACardResolver(client, "http://example.com/", AGENT_CARD_PATH);
-        card = resolver.getAgentCard();
-
-        assertEquals("http://example.com" + AGENT_CARD_PATH, client.url);
-
-        // baseUrl without trailing slash, agentCardPath with leading slash
-        resolver = new A2ACardResolver(client, "http://example.com", AGENT_CARD_PATH);
-        card = resolver.getAgentCard();
-
-        assertEquals("http://example.com" + AGENT_CARD_PATH, client.url);
-
-        // baseUrl with trailing slash, agentCardPath without leading slash
-        resolver = new A2ACardResolver(client, "http://example.com/", AGENT_CARD_PATH.substring(1));
-        card = resolver.getAgentCard();
-
-        assertEquals("http://example.com" + AGENT_CARD_PATH, client.url);
-
-        // baseUrl without trailing slash, agentCardPath without leading slash
-        resolver = new A2ACardResolver(client, "http://example.com", AGENT_CARD_PATH.substring(1));
-        card = resolver.getAgentCard();
-
+    @Test
+    public void testWellKnownUrl_trailingSlashStripped() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com/").build().getAgentCard();
         assertEquals("http://example.com" + AGENT_CARD_PATH, client.url);
     }
 
+    @Test
+    public void testWellKnownUrl_noTrailingSlash() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com").build().getAgentCard();
+        assertEquals("http://example.com" + AGENT_CARD_PATH, client.url);
+    }
 
     @Test
-    public void testGetAgentCardSuccess() throws Exception {
-        TestHttpClient client = new TestHttpClient();
-        client.body = JsonMessages.AGENT_CARD;
-
-        A2ACardResolver resolver = new A2ACardResolver(client, "http://example.com/", "");
-        AgentCard card = resolver.getAgentCard();
-
-        AgentCard expectedCard = unmarshalFrom(JsonMessages.AGENT_CARD);
-        String expected = printAgentCard(expectedCard);
-
-        String requestCardString = printAgentCard(card);
-        assertEquals(expected, requestCardString);
+    public void testWellKnownUrl_subPathPreserved_withTrailingSlash() throws Exception {
+        TestHttpClient client = createTestClient();
+        // URI.resolve() would have silently dropped the sub-path; string concat must not.
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com/jsonrpc/").build().getAgentCard();
+        assertEquals("http://example.com/jsonrpc" + AGENT_CARD_PATH, client.url);
     }
+
+    @Test
+    public void testWellKnownUrl_subPathPreserved_noTrailingSlash() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com/jsonrpc").build().getAgentCard();
+        assertEquals("http://example.com/jsonrpc" + AGENT_CARD_PATH, client.url);
+    }
+
+    // -------------------------------------------------------------------------
+    // Custom agent card path URL construction
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCustomPath_withLeadingSlash() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com").agentCardPath(AGENT_CARD_PATH).build().getAgentCard();
+        assertEquals("http://example.com" + AGENT_CARD_PATH, client.url);
+    }
+
+    @Test
+    public void testCustomPath_withoutLeadingSlash() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com").agentCardPath(AGENT_CARD_PATH.substring(1)).build().getAgentCard();
+        assertEquals("http://example.com" + AGENT_CARD_PATH, client.url);
+    }
+
+    @Test
+    public void testCustomPath_baseUrlTrailingSlash_withLeadingSlash() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com/").agentCardPath(AGENT_CARD_PATH).build().getAgentCard();
+        assertEquals("http://example.com" + AGENT_CARD_PATH, client.url);
+    }
+
+    @Test
+    public void testCustomPath_baseUrlTrailingSlash_withoutLeadingSlash() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com/").agentCardPath(AGENT_CARD_PATH.substring(1)).build().getAgentCard();
+        assertEquals("http://example.com" + AGENT_CARD_PATH, client.url);
+    }
+
+    @Test
+    public void testCustomPath_doesNotIntroduceDoubleSlash() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com/").agentCardPath("/custom/agent.json").build().getAgentCard();
+        assertEquals("http://example.com/custom/agent.json", client.url);
+    }
+
+    @Test
+    public void testCustomPath_subBaseUrl() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com/jsonrpc/").agentCardPath(AGENT_CARD_PATH).build().getAgentCard();
+        assertEquals("http://example.com/jsonrpc" + AGENT_CARD_PATH, client.url);
+    }
+
+    // -------------------------------------------------------------------------
+    // Fetch success / error
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testGetAgentCard_success() throws Exception {
+        TestHttpClient client = createTestClient();
+        AgentCard card = A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com/").build().getAgentCard();
+        assertEquals(printAgentCard(unmarshalFrom(JsonMessages.AGENT_CARD)), printAgentCard(card));
+    }
+
+    @Test
+    public void testGetAgentCard_jsonDecodeError() throws Exception {
+        TestHttpClient client = createTestClient();
+        client.body = "X" + JsonMessages.AGENT_CARD;
+        A2ACardResolver resolver = A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com/").build();
+        assertThrows(A2AClientJSONError.class, resolver::getAgentCard);
+    }
+
+    @Test
+    public void testGetAgentCard_httpErrorThrows() throws Exception {
+        TestHttpClient client = createTestClient();
+        client.status = 503;
+        A2ACardResolver resolver = A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com/").build();
+        A2AClientError error = assertThrows(A2AClientError.class, resolver::getAgentCard);
+        assertTrue(error.getMessage().contains("503"));
+    }
+
+    @Test
+    public void testGetAgentCard_customPath_httpErrorThrows_noFallback() throws Exception {
+        TestHttpClient client = createTestClient();
+        client.status = 404;
+        A2ACardResolver resolver = A2ACardResolver.builder()
+                .httpClient(client)
+                .baseUrl("http://example.com")
+                .agentCardPath("/custom/agent.json")
+                .build();
+        assertThrows(A2AClientError.class, resolver::getAgentCard);
+        assertEquals(1, client.urlsCalled.size());
+        assertEquals("http://example.com/custom/agent.json", client.urlsCalled.get(0));
+    }
+
+    @Test
+    public void testGetAgentCard_ioExceptionThrows() throws Exception {
+        TestHttpClient client = createTestClient();
+        client.throwIOException = true;
+        assertThrows(A2AClientError.class,
+                A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com").build()::getAgentCard);
+    }
+
+    @Test
+    public void testGetAgentCard_interruptedExceptionThrows() throws Exception {
+        TestHttpClient client = createTestClient();
+        client.throwInterruptedException = true;
+        assertThrows(A2AClientError.class,
+                A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com").build()::getAgentCard);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tenant, auth headers, builder validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testGetAgentCard_withTenant() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com").tenant("my-tenant").build().getAgentCard();
+        assertEquals("http://example.com/my-tenant" + AGENT_CARD_PATH, client.url);
+    }
+
+    @Test
+    public void testGetAgentCard_withTenantAndCustomAgentCardPath() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder()
+                .httpClient(client)
+                .baseUrl("http://example.com")
+                .tenant("acme")
+                .agentCardPath("/custom/card.json")
+                .build()
+                .getAgentCard();
+        assertEquals("http://example.com/acme/custom/card.json", client.url);
+    }
+
+    @Test
+    public void testGetAgentCard_withCustomPath_absoluteAndRelative() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com").agentCardPath("/custom/agent.json").build().getAgentCard();
+        assertEquals("http://example.com/custom/agent.json", client.url);
+
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com").agentCardPath("custom/agent.json").build().getAgentCard();
+        assertEquals("http://example.com/custom/agent.json", client.url);
+    }
+
+    @Test
+    public void testGetAgentCard_withAuthHeadersMap() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com")
+                .authHeaders(Map.of("Authorization", "Bearer token123")).build().getAgentCard();
+        assertEquals("Bearer token123", client.capturedHeaders.get("Authorization"));
+    }
+
+    @Test
+    public void testGetAgentCard_withAuthHeaderSingle() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com")
+                .authHeader("Authorization", "Bearer token123").build().getAgentCard();
+        assertEquals("Bearer token123", client.capturedHeaders.get("Authorization"));
+    }
+
+    @Test
+    public void testBuilder_nullBaseUrl_throws() {
+        assertThrows(IllegalArgumentException.class, () -> A2ACardResolver.builder().build());
+    }
+
+    @Test
+    public void testBuilder_malformedBaseUrl_throws() {
+        assertThrows(A2AClientError.class, () -> A2ACardResolver.builder().baseUrl("not-a-url").build());
+    }
+
+    @Test
+    public void testFullWellKnownUrlWithTenant() throws Exception {
+        // Full well-known URL + tenant must strip the suffix before appending tenant,
+        // not produce a malformed path like ...agent-card.json/my-tenant/.well-known/agent-card.json
+        TestHttpClient client = createTestClient();
+        A2ACardResolver resolver = A2ACardResolver.builder()
+                .httpClient(client)
+                .baseUrl("https://example.com/.well-known/agent-card.json")
+                .tenant("my-tenant")
+                .build();
+        resolver.getAgentCard();
+        assertEquals("https://example.com/my-tenant" + AGENT_CARD_PATH, client.url);
+    }
+
+    // -------------------------------------------------------------------------
+    // Spec03 / full-URL edge cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testSpec03PathPreservation_wellKnown() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("https://example.com/spec03").build().getAgentCard();
+        assertEquals("https://example.com/spec03" + AGENT_CARD_PATH, client.url);
+    }
+
+    @Test
+    public void testSpec03PathPreservation_withTenant() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("https://example.com/spec03").tenant("my-tenant").build().getAgentCard();
+        assertEquals("https://example.com/spec03/my-tenant" + AGENT_CARD_PATH, client.url);
+    }
+
+    @Test
+    public void testSpec03PathPreservation_withCustomPath() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver.builder().httpClient(client).baseUrl("https://example.com/spec03").agentCardPath("/custom/card.json").build().getAgentCard();
+        assertEquals("https://example.com/spec03/custom/card.json", client.url);
+    }
+
+    @Test
+    public void testBaseUrl_alreadyContainsWellKnownPath() throws Exception {
+        String fullUrl = "https://agentbin.greensmoke-1163cb63.eastus.azurecontainerapps.io/spec03/.well-known/agent-card.json";
+        TestHttpClient client = createTestClient();
+        A2ACardResolver resolver = A2ACardResolver.builder().httpClient(client).baseUrl(fullUrl).build();
+        resolver.getAgentCard();
+        assertEquals(fullUrl, client.url);
+    }
+
+    @Test
+    public void testFullWellKnownUrlWithCustomAgentCardPath() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver resolver = A2ACardResolver.builder()
+                .httpClient(client)
+                .baseUrl("https://example.com/spec03/.well-known/agent-card.json")
+                .agentCardPath("/custom/card.json")
+                .build();
+        resolver.getAgentCard();
+        assertEquals("https://example.com/spec03/custom/card.json", client.url);
+    }
+
+    @Test
+    public void testFullWellKnownUrlWithSameAgentCardPath() throws Exception {
+        TestHttpClient client = createTestClient();
+        A2ACardResolver resolver = A2ACardResolver.builder()
+                .httpClient(client)
+                .baseUrl("https://example.com/spec03/.well-known/agent-card.json")
+                .agentCardPath("/.well-known/agent-card.json")
+                .build();
+        resolver.getAgentCard();
+        assertEquals("https://example.com/spec03/.well-known/agent-card.json", client.url);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
 
     private AgentCard unmarshalFrom(String body) throws JsonProcessingException {
         org.a2aproject.sdk.grpc.AgentCard.Builder agentCardBuilder = org.a2aproject.sdk.grpc.AgentCard.newBuilder();
@@ -90,43 +314,14 @@ public class A2ACardResolverTest {
         return JsonFormat.printer().print(ProtoUtils.ToProto.agentCard(agentCard));
     }
 
-    @Test
-    public void testGetAgentCardJsonDecodeError() throws Exception {
-        TestHttpClient client = new TestHttpClient();
-        client.body = "X" + JsonMessages.AGENT_CARD;
-
-        A2ACardResolver resolver = new A2ACardResolver(client, "http://example.com/", "");
-
-        boolean success = false;
-        try {
-            AgentCard card = resolver.getAgentCard();
-            success = true;
-        } catch (A2AClientJSONError expected) {
-        }
-        assertFalse(success);
-    }
-
-
-    @Test
-    public void testGetAgentCardRequestError() throws Exception {
-        TestHttpClient client = new TestHttpClient();
-        client.status = 503;
-
-        A2ACardResolver resolver = new A2ACardResolver(client, "http://example.com/", "");
-
-        String msg = null;
-        try {
-            AgentCard card = resolver.getAgentCard();
-        } catch (A2AClientError expected) {
-            msg = expected.getMessage();
-        }
-        assertTrue(msg.contains("503"));
-    }
-
     private static class TestHttpClient implements A2AHttpClient {
         int status = 200;
         String body;
         String url;
+        boolean throwIOException = false;
+        boolean throwInterruptedException = false;
+        Map<String, String> capturedHeaders = new HashMap<>();
+        List<String> urlsCalled = new ArrayList<>();
 
         @Override
         public GetBuilder createGet() {
@@ -147,15 +342,23 @@ public class A2ACardResolverTest {
 
             @Override
             public A2AHttpResponse get() throws IOException, InterruptedException {
+                urlsCalled.add(url);
+                if (throwIOException) {
+                    throw new IOException("Simulated IO error");
+                }
+                if (throwInterruptedException) {
+                    throw new InterruptedException("Simulated interrupt");
+                }
+                int effectiveStatus = status;
                 return new A2AHttpResponse() {
                     @Override
                     public int status() {
-                        return status;
+                        return effectiveStatus;
                     }
 
                     @Override
                     public boolean success() {
-                        return status == 200;
+                        return effectiveStatus == 200;
                     }
 
                     @Override
@@ -178,14 +381,15 @@ public class A2ACardResolverTest {
 
             @Override
             public GetBuilder addHeader(String name, String value) {
+                capturedHeaders.put(name, value);
                 return this;
             }
 
             @Override
             public GetBuilder addHeaders(Map<String, String> headers) {
+                capturedHeaders.putAll(headers);
                 return this;
             }
         }
     }
-
 }

--- a/spec-grpc/src/test/java/org/a2aproject/sdk/grpc/utils/JSONRPCUtilsTest.java
+++ b/spec-grpc/src/test/java/org/a2aproject/sdk/grpc/utils/JSONRPCUtilsTest.java
@@ -18,15 +18,15 @@ import org.a2aproject.sdk.jsonrpc.common.json.InvalidParamsJsonMappingException;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonMappingException;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonProcessingException;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.A2ARequest;
-import org.a2aproject.sdk.jsonrpc.common.wrappers.GetTaskPushNotificationConfigRequest;
-import org.a2aproject.sdk.jsonrpc.common.wrappers.GetTaskPushNotificationConfigResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.CreateTaskPushNotificationConfigRequest;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.CreateTaskPushNotificationConfigResponse;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.GetTaskPushNotificationConfigRequest;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.GetTaskPushNotificationConfigResponse;
 import org.a2aproject.sdk.spec.InvalidParamsError;
-import org.a2aproject.sdk.util.ErrorDetail;
 import org.a2aproject.sdk.spec.JSONParseError;
 import org.a2aproject.sdk.spec.TaskNotFoundError;
 import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
+import org.a2aproject.sdk.util.ErrorDetail;
 import org.junit.jupiter.api.Test;
 
 public class JSONRPCUtilsTest {
@@ -484,4 +484,5 @@ public class JSONRPCUtilsTest {
         assertEquals(-32001, response.getError().getCode());
         assertEquals("Custom message", response.getError().getMessage());
     }
+
 }

--- a/spec/src/main/java/org/a2aproject/sdk/util/Utils.java
+++ b/spec/src/main/java/org/a2aproject/sdk/util/Utils.java
@@ -2,6 +2,8 @@ package org.a2aproject.sdk.util;
 
 import static org.a2aproject.sdk.util.Assert.checkNotNullParam;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +39,8 @@ import org.jspecify.annotations.Nullable;
  * @see TaskArtifactUpdateEvent for streaming artifact updates
  */
 public class Utils {
+
+    public static final String DEFAULT_AGENT_CARD_PATH = "/.well-known/agent-card.json";
 
     private static final Logger log = Logger.getLogger(Utils.class.getName());
 
@@ -170,6 +174,71 @@ public class Utils {
     }
 
     /**
+     * Validates that {@code url} is a syntactically valid absolute URI.
+     *
+     * @param url the URL to validate
+     * @throws URISyntaxException if the URL is syntactically invalid or not absolute
+     */
+    public static void validateAbsoluteUrl(String url) throws URISyntaxException {
+        URI uri = new URI(url);
+        if (!uri.isAbsolute()) {
+            throw new URISyntaxException(url, "URI must be absolute");
+        }
+    }
+
+    /**
+     * Normalizes {@code baseUrl} and {@code cardPath} and concatenates them into a full card URL.
+     *
+     * <p>Strips any trailing slash from {@code baseUrl} and ensures {@code cardPath} starts with
+     * a leading slash before concatenating, so both {@code http://host/base/} and
+     * {@code http://host/base} produce the same result.
+     *
+     * @param baseUrl the agent base URL, must not be null
+     * @param cardPath the card endpoint path, must not be null
+     * @return the normalized card URL
+     */
+    public static String buildCardUrl(String baseUrl, String cardPath) {
+        String normalizedPath = cardPath.startsWith("/") ? cardPath : "/" + cardPath;
+        return stripTrailingSlash(baseUrl) + normalizedPath;
+    }
+
+    /**
+     * Strips any trailing slash and the standard well-known suffix from {@code baseUrl} so that
+     * {@link #buildCardUrl} can append the desired path without doubling it.
+     *
+     * <p>Only {@link #DEFAULT_AGENT_CARD_PATH} is stripped; custom paths are never inferred
+     * from the URL structure.
+     *
+     * @param baseUrl the URL to strip
+     * @return the URL with any trailing slash and well-known suffix removed
+     */
+    public static String stripWellKnownSuffix(String baseUrl) {
+        String s = stripTrailingSlash(baseUrl);
+        return s.endsWith(DEFAULT_AGENT_CARD_PATH)
+                ? s.substring(0, s.length() - DEFAULT_AGENT_CARD_PATH.length())
+                : s;
+    }
+
+    /**
+     * Builds a base URL by combining a raw base URL string with an optional tenant path.
+     *
+     * <p>Normalizes trailing slashes on the base URL and validates/normalizes the tenant path.
+     *
+     * @param baseUrl the base URL string, must not be null
+     * @param tenant the tenant path override, may be null for no tenant
+     * @return the complete base URL with tenant path appended
+     * @throws IllegalArgumentException if tenant validation fails
+     */
+    public static String buildBaseUrl(String baseUrl, @Nullable String tenant) {
+        checkNotNullParam("baseUrl", baseUrl);
+        return stripTrailingSlash(baseUrl) + extractTenant("", tenant);
+    }
+
+    private static String stripTrailingSlash(String s) {
+        return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
+
+    /**
      * Get the first defined URL in the supported interaces of the agent card.
      *
      * @param agentCard the agentcard where the interfaces are defined.
@@ -286,10 +355,6 @@ public class Utils {
     public static String buildBaseUrl(AgentInterface agentInterface, @Nullable String tenant) {
         checkNotNullParam("agentInterface", agentInterface);
 
-        String agentUrl = agentInterface.url();
-        agentUrl = agentUrl.endsWith("/") ? agentUrl.substring(0, agentUrl.length() - 1) : agentUrl;
-        StringBuilder urlBuilder = new StringBuilder(agentUrl);
-        urlBuilder.append(extractTenant(agentInterface.tenant(), tenant));
-        return urlBuilder.toString();
+        return stripTrailingSlash(agentInterface.url()) + extractTenant(agentInterface.tenant(), tenant);
     }
 }

--- a/spec/src/test/java/org/a2aproject/sdk/util/UtilsTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/util/UtilsTest.java
@@ -3,6 +3,9 @@ package org.a2aproject.sdk.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.net.URISyntaxException;
 
 import org.a2aproject.sdk.spec.AgentInterface;
 import org.junit.jupiter.api.Test;
@@ -52,7 +55,7 @@ class UtilsTest {
     @Test
     void testBuildBaseUrl_withAgentInterface_nullInterface_throws() {
         assertThrows(IllegalArgumentException.class, () -> {
-            Utils.buildBaseUrl(null, "/tenant");
+            Utils.buildBaseUrl((AgentInterface) null, "/tenant");
         });
     }
 
@@ -189,5 +192,118 @@ class UtilsTest {
         AgentInterface iface = new AgentInterface("JSONRPC", "https://secure.example.com", "/tenant");
         String url = Utils.buildBaseUrl(iface, null);
         assertEquals("https://secure.example.com/tenant", url);
+    }
+
+    // ========== buildBaseUrl(String, String) Tests ==========
+
+    @Test
+    void testBuildBaseUrl_string_noTenant() {
+        assertEquals("http://example.com", Utils.buildBaseUrl("http://example.com", null));
+    }
+
+    @Test
+    void testBuildBaseUrl_string_trailingSlashStripped() {
+        assertEquals("http://example.com", Utils.buildBaseUrl("http://example.com/", null));
+    }
+
+    @Test
+    void testBuildBaseUrl_string_withTenant() {
+        assertEquals("http://example.com/my-tenant", Utils.buildBaseUrl("http://example.com", "my-tenant"));
+    }
+
+    @Test
+    void testBuildBaseUrl_string_withTenantLeadingSlash() {
+        assertEquals("http://example.com/my-tenant", Utils.buildBaseUrl("http://example.com", "/my-tenant"));
+    }
+
+    @Test
+    void testBuildBaseUrl_string_withSubPath() {
+        assertEquals("http://example.com/spec03/my-tenant", Utils.buildBaseUrl("http://example.com/spec03", "my-tenant"));
+    }
+
+    @Test
+    void testBuildBaseUrl_string_nullBaseUrl_throws() {
+        assertThrows(IllegalArgumentException.class, () -> Utils.buildBaseUrl((String) null, null));
+    }
+
+    // ========== validateAbsoluteUrl Tests ==========
+
+    @Test
+    void testValidateAbsoluteUrl_valid() {
+        assertDoesNotThrow(() -> Utils.validateAbsoluteUrl("http://example.com"));
+        assertDoesNotThrow(() -> Utils.validateAbsoluteUrl("https://example.com/path"));
+        assertDoesNotThrow(() -> Utils.validateAbsoluteUrl("http://example.com:8080/path"));
+    }
+
+    @Test
+    void testValidateAbsoluteUrl_relative_throws() {
+        assertThrows(URISyntaxException.class, () -> Utils.validateAbsoluteUrl("/relative/path"));
+    }
+
+    @Test
+    void testValidateAbsoluteUrl_malformed_throws() {
+        assertThrows(URISyntaxException.class, () -> Utils.validateAbsoluteUrl("not a url"));
+    }
+
+    // ========== buildCardUrl Tests ==========
+
+    @Test
+    void testBuildCardUrl_simple() {
+        assertEquals("http://example.com/.well-known/agent-card.json",
+                Utils.buildCardUrl("http://example.com", "/.well-known/agent-card.json"));
+    }
+
+    @Test
+    void testBuildCardUrl_baseTrailingSlash() {
+        assertEquals("http://example.com/.well-known/agent-card.json",
+                Utils.buildCardUrl("http://example.com/", "/.well-known/agent-card.json"));
+    }
+
+    @Test
+    void testBuildCardUrl_pathWithoutLeadingSlash() {
+        assertEquals("http://example.com/.well-known/agent-card.json",
+                Utils.buildCardUrl("http://example.com", ".well-known/agent-card.json"));
+    }
+
+    @Test
+    void testBuildCardUrl_preservesSubPath() {
+        assertEquals("http://example.com/spec03/.well-known/agent-card.json",
+                Utils.buildCardUrl("http://example.com/spec03", "/.well-known/agent-card.json"));
+    }
+
+    @Test
+    void testBuildCardUrl_noDoubleSlash() {
+        assertEquals("http://example.com/custom/agent.json",
+                Utils.buildCardUrl("http://example.com/", "/custom/agent.json"));
+    }
+
+    // ========== stripWellKnownSuffix Tests ==========
+
+    @Test
+    void testStripWellKnownSuffix_noSuffix() {
+        assertEquals("http://example.com", Utils.stripWellKnownSuffix("http://example.com"));
+    }
+
+    @Test
+    void testStripWellKnownSuffix_withSuffix() {
+        assertEquals("http://example.com",
+                Utils.stripWellKnownSuffix("http://example.com/.well-known/agent-card.json"));
+    }
+
+    @Test
+    void testStripWellKnownSuffix_withSubPathAndSuffix() {
+        assertEquals("http://example.com/spec03",
+                Utils.stripWellKnownSuffix("http://example.com/spec03/.well-known/agent-card.json"));
+    }
+
+    @Test
+    void testStripWellKnownSuffix_trailingSlash() {
+        assertEquals("http://example.com", Utils.stripWellKnownSuffix("http://example.com/"));
+    }
+
+    @Test
+    void testStripWellKnownSuffix_unrelatedPath() {
+        assertEquals("http://example.com/custom/agent.json",
+                Utils.stripWellKnownSuffix("http://example.com/custom/agent.json"));
     }
 }


### PR DESCRIPTION
URI.resolve() silently drops intermediate path segments when the
resolved path starts with '/', causing incorrect URLs for agents
hosted under a path prefix (e.g. /spec03). Replace with direct
concatenation and add a pass-through guard when the supplied URL
already ends with the agent card path.


Fixes #771 🦕