### PR TITLE
chore: upgrade Quarkus to 3.35.2 and align dependency versions

### DIFF
--- a/examples/cloud-deployment/server/pom.xml
+++ b/examples/cloud-deployment/server/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- Database-backed task store -->

--- a/extras/queue-manager-replicated/tests-multi-instance/tests/pom.xml
+++ b/extras/queue-manager-replicated/tests-multi-instance/tests/pom.xml
@@ -42,17 +42,17 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>kafka</artifactId>
+            <artifactId>testcontainers-kafka</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
 
     <properties>
-        <grpc.version>1.77.0</grpc.version>
+        <grpc.version>1.79.0</grpc.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -56,20 +56,20 @@
         <jakarta.inject.jakarta.inject-api.version>2.0.1</jakarta.inject.jakarta.inject-api.version>
         <jakarta.json-api.version>2.1.3</jakarta.json-api.version>
         <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
-        <junit.version>5.13.4</junit.version>
+        <junit.version>6.0.3</junit.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <mapstruct-spi-protobuf.version>1.52.0</mapstruct-spi-protobuf.version>
         <mockito-core.version>5.17.0</mockito-core.version>
         <mockserver.version>5.15.0</mockserver.version>
         <mutiny-zero.version>1.1.1</mutiny-zero.version>
         <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
-        <protobuf-java.version>4.33.1</protobuf-java.version>
+        <protobuf-java.version>4.33.2</protobuf-java.version>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
-        <quarkus.platform.version>3.30.6</quarkus.platform.version>
+        <quarkus.platform.version>3.35.2</quarkus.platform.version>
         <rest-assured.version>5.5.1</rest-assured.version>
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.18</logback.version>
-        <version.testcontainers>1.21.4</version.testcontainers>
+        <version.testcontainers>2.0.5</version.testcontainers>
         <error-prone.version>2.49.0</error-prone.version>
         <nullaway.version>0.13.4</nullaway.version>
         <error-prone.flag>-XDaddTypeAnnotationsToSymbol=true</error-prone.flag>

--- a/reference/common/src/main/java/org/a2aproject/sdk/server/common/quarkus/VertxSecurityHelper.java
+++ b/reference/common/src/main/java/org/a2aproject/sdk/server/common/quarkus/VertxSecurityHelper.java
@@ -11,6 +11,7 @@ import io.quarkus.vertx.http.runtime.security.ChallengeData;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticator;
 import io.vertx.core.Context;
 import io.vertx.ext.web.RoutingContext;
+import java.util.Map;
 
 /**
  * CDI helper for integrating Quarkus security with Vert.x Web routes.
@@ -149,7 +150,9 @@ public final class VertxSecurityHelper {
                     ChallengeData challenge = httpAuthenticator.get().getChallenge(ctx).await().indefinitely();
                     if (challenge != null) {
                         status = challenge.status;
-                        ctx.response().putHeader(challenge.headerName, challenge.headerContent);
+                        for(Map.Entry<CharSequence, String> header : challenge.getHeaders().entrySet()) {
+                            ctx.response().putHeader(header.getKey(), header.getValue());
+                        }
                     }
                 }
                 ctx.response()


### PR DESCRIPTION
- Quarkus 3.30.6 ->  3.35.2
- JUnit 5.13.4 -> 6.0.3
- gRPC 1.77.0 -> 1.79.0
- Protobuf 4.33.1 -> 4.33.2
- Testcontainers 1.21.4-> 2.0.5
- Update VertxSecurityHelper to use challenge.getHeaders() map instead of the removed headerName/headerContent fields (API change in Quarkus 3.35.x)