### PR TITLE
feat: support authentication field in push notification webhooks

### DIFF
--- a/server-common/src/main/java/io/a2a/server/tasks/BasePushNotificationSender.java
+++ b/server-common/src/main/java/io/a2a/server/tasks/BasePushNotificationSender.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ExecutionException;
 import io.a2a.client.http.A2AHttpClient;
 import io.a2a.json.JsonUtil;
 import io.a2a.client.http.A2AHttpClientFactory;
+import io.a2a.spec.PushNotificationAuthenticationInfo;
 import io.a2a.spec.PushNotificationConfig;
 import io.a2a.spec.Task;
 
@@ -73,6 +74,12 @@ public class BasePushNotificationSender implements PushNotificationSender {
         A2AHttpClient.PostBuilder postBuilder = httpClient.createPost();
         if (token != null && !token.isBlank()) {
             postBuilder.addHeader(X_A2A_NOTIFICATION_TOKEN, token);
+        }
+
+        PushNotificationAuthenticationInfo auth = pushInfo.authentication();
+        if (auth != null && !auth.schemes().isEmpty() && auth.credentials() != null && !auth.credentials().isBlank()) {
+            String scheme = auth.schemes().get(0);
+            postBuilder.addHeader("Authorization", scheme + " " + auth.credentials());
         }
 
         String body;

--- a/server-common/src/test/java/io/a2a/server/tasks/PushNotificationSenderTest.java
+++ b/server-common/src/test/java/io/a2a/server/tasks/PushNotificationSenderTest.java
@@ -21,6 +21,7 @@ import io.a2a.client.http.A2AHttpResponse;
 import io.a2a.common.A2AHeaders;
 import io.a2a.json.JsonProcessingException;
 import io.a2a.json.JsonUtil;
+import io.a2a.spec.PushNotificationAuthenticationInfo;
 import io.a2a.spec.PushNotificationConfig;
 import io.a2a.spec.Task;
 import io.a2a.spec.TaskState;
@@ -286,6 +287,139 @@ public class PushNotificationSenderTest {
             assertEquals(taskData.getContextId(), sentTask.getContextId());
             assertEquals(taskData.getStatus().state(), sentTask.getStatus().state());
         }
+    }
+
+    @Test
+    public void testSendNotificationWithAuthentication() throws InterruptedException {
+        String taskId = "task_send_with_auth";
+        Task taskData = createSampleTask(taskId, TaskState.COMPLETED);
+        PushNotificationAuthenticationInfo authInfo = new PushNotificationAuthenticationInfo(
+                List.of("Bearer"), "my-secret-credentials");
+        PushNotificationConfig config = new PushNotificationConfig.Builder()
+                .url("http://notify.me/here")
+                .id("cfg1")
+                .authenticationInfo(authInfo)
+                .build();
+
+        configStore.setInfo(taskId, config);
+        testHttpClient.latch = new CountDownLatch(1);
+
+        sender.sendNotification(taskData);
+
+        assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS));
+        assertEquals(1, testHttpClient.headers.size());
+        Map<String, String> sentHeaders = testHttpClient.headers.get(0);
+        assertEquals("Bearer my-secret-credentials", sentHeaders.get("Authorization"));
+    }
+
+    @Test
+    public void testSendNotificationWithTokenAndAuthentication() throws InterruptedException {
+        String taskId = "task_send_token_and_auth";
+        Task taskData = createSampleTask(taskId, TaskState.COMPLETED);
+        PushNotificationAuthenticationInfo authInfo = new PushNotificationAuthenticationInfo(
+                List.of("Bearer"), "my-secret-credentials");
+        PushNotificationConfig config = new PushNotificationConfig.Builder()
+                .url("http://notify.me/here")
+                .id("cfg1")
+                .token("my-token")
+                .authenticationInfo(authInfo)
+                .build();
+
+        configStore.setInfo(taskId, config);
+        testHttpClient.latch = new CountDownLatch(1);
+
+        sender.sendNotification(taskData);
+
+        assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS));
+        assertEquals(1, testHttpClient.headers.size());
+        Map<String, String> sentHeaders = testHttpClient.headers.get(0);
+        assertEquals("my-token", sentHeaders.get(A2AHeaders.X_A2A_NOTIFICATION_TOKEN));
+        assertEquals("Bearer my-secret-credentials", sentHeaders.get("Authorization"));
+    }
+
+    @Test
+    public void testSendNotificationWithNullAuthSchemes() throws InterruptedException {
+        String taskId = "task_send_null_schemes";
+        Task taskData = createSampleTask(taskId, TaskState.COMPLETED);
+        PushNotificationConfig config = new PushNotificationConfig.Builder()
+                .url("http://notify.me/here")
+                .id("cfg1")
+                .build();
+
+        configStore.setInfo(taskId, config);
+        testHttpClient.latch = new CountDownLatch(1);
+
+        sender.sendNotification(taskData);
+
+        assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS));
+        assertEquals(1, testHttpClient.headers.size());
+        assertTrue(testHttpClient.headers.get(0).isEmpty());
+    }
+
+    @Test
+    public void testSendNotificationWithEmptyAuthSchemes() throws InterruptedException {
+        String taskId = "task_send_empty_schemes";
+        Task taskData = createSampleTask(taskId, TaskState.COMPLETED);
+        PushNotificationAuthenticationInfo authInfo = new PushNotificationAuthenticationInfo(
+                List.of(), "my-secret-credentials");
+        PushNotificationConfig config = new PushNotificationConfig.Builder()
+                .url("http://notify.me/here")
+                .id("cfg1")
+                .authenticationInfo(authInfo)
+                .build();
+
+        configStore.setInfo(taskId, config);
+        testHttpClient.latch = new CountDownLatch(1);
+
+        sender.sendNotification(taskData);
+
+        assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS));
+        assertEquals(1, testHttpClient.headers.size());
+        assertTrue(testHttpClient.headers.get(0).isEmpty());
+    }
+
+    @Test
+    public void testSendNotificationWithNullAuthCredentials() throws InterruptedException {
+        String taskId = "task_send_null_creds";
+        Task taskData = createSampleTask(taskId, TaskState.COMPLETED);
+        PushNotificationAuthenticationInfo authInfo = new PushNotificationAuthenticationInfo(
+                List.of("Bearer"), null);
+        PushNotificationConfig config = new PushNotificationConfig.Builder()
+                .url("http://notify.me/here")
+                .id("cfg1")
+                .authenticationInfo(authInfo)
+                .build();
+
+        configStore.setInfo(taskId, config);
+        testHttpClient.latch = new CountDownLatch(1);
+
+        sender.sendNotification(taskData);
+
+        assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS));
+        assertEquals(1, testHttpClient.headers.size());
+        assertTrue(testHttpClient.headers.get(0).isEmpty());
+    }
+
+    @Test
+    public void testSendNotificationWithBlankAuthCredentials() throws InterruptedException {
+        String taskId = "task_send_blank_creds";
+        Task taskData = createSampleTask(taskId, TaskState.COMPLETED);
+        PushNotificationAuthenticationInfo authInfo = new PushNotificationAuthenticationInfo(
+                List.of("Bearer"), "   ");
+        PushNotificationConfig config = new PushNotificationConfig.Builder()
+                .url("http://notify.me/here")
+                .id("cfg1")
+                .authenticationInfo(authInfo)
+                .build();
+
+        configStore.setInfo(taskId, config);
+        testHttpClient.latch = new CountDownLatch(1);
+
+        sender.sendNotification(taskData);
+
+        assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS));
+        assertEquals(1, testHttpClient.headers.size());
+        assertTrue(testHttpClient.headers.get(0).isEmpty());
     }
 
     @Test


### PR DESCRIPTION
I found this wasn't getting propagated when working on https://github.com/a2aproject/a2a-tck/pull/178