### PR TITLE
feat: add version-aware push notification support

### DIFF
--- a/.claude/architecture/compatibility_0.3.md
+++ b/.claude/architecture/compatibility_0.3.md
@@ -168,6 +168,18 @@ These fields coexist alongside the v1.0 `supportedInterfaces` field. v1.0 client
 
 `Legacy_0_3_AgentInterface` is a separate record from `AgentInterface` because they serialize to different JSON field names (`transport`/`url` vs `protocolBinding`/`url`/`tenant`).
 
+### Version-Aware Push Notifications
+
+Push notification payloads are formatted according to the protocol version used when the push notification configuration was registered. The v0.3 transport handlers pass `A2AProtocol_v0_3.PROTOCOL_VERSION` when constructing the `ServerCallContext`, which propagates through to `PushNotificationConfigStore.setInfo()`. When a notification is later sent:
+
+1. `BasePushNotificationSender` retrieves the protocol version stored alongside each push notification configuration
+2. It looks up a `PushNotificationPayloadFormatter` matching that version (discovered via CDI)
+3. The formatter serializes the payload in the appropriate wire format:
+   - **v0.3** (`PushNotificationPayloadFormatter_v0_3`): sends a v0.3 `Task` JSON object, skipping `Message` events (not supported in v0.3 push notifications)
+   - **v1.0** (default): sends a `StreamResponse` wrapper containing the event
+
+If no protocol version is stored (e.g., for configurations created before this feature), the version defaults to `AgentInterface.CURRENT_PROTOCOL_VERSION` (`"1.0"`).
+
 ---
 
 ## Module Structure
@@ -436,7 +448,7 @@ AgentCard card = // ... fetch agent card from /.well-known/agent-card.json
 
 // Find the v0.3 interface from the agent card
 AgentInterface v03Interface = card.supportedInterfaces().stream()
-        .filter(iface -> "0.3".equals(iface.protocolVersion()))
+        .filter(iface -> A2AProtocol_v0_3.PROTOCOL_VERSION.equals(iface.protocolVersion()))
         .findFirst()
         .orElseThrow();
 
@@ -536,10 +548,10 @@ For JSON-RPC and REST, multi-version convenience modules are also available that
 
 ## Status
 
-The v0.3 compatibility layer is fully implemented: spec types, gRPC generation, conversion layer, all three transport handlers (JSON-RPC, gRPC, REST), client API and transports, reference servers, multi-version deployment, test infrastructure, 125+ integration tests, and TCK module are all in place.
+The v0.3 compatibility layer is fully implemented: spec types, gRPC generation, conversion layer, all three transport handlers (JSON-RPC, gRPC, REST), client API and transports, reference servers, multi-version deployment, version-aware push notifications, test infrastructure, 125+ integration tests, and TCK module are all in place.
 
 🔲 **Outstanding:**
-- Push notification test porting (requires TestHttpClient; version-aware push notifications in PR #857)
+- Push notification test porting (requires TestHttpClient)
 - Test metadata classes (classpath scanning)
 - Replace FQNs with imports (97 occurrences in 34 files)
 - Unify AgentCard producers across reference modules

--- a/.github/workflows/run-tck.yml
+++ b/.github/workflows/run-tck.yml
@@ -12,7 +12,7 @@ on:
 env:
   # Tag/branch of the TCK
   TCK_VERSION: 1.0-dev
-  TCK_VERSION_0_3: 0.3.0.beta4
+  TCK_VERSION_0_3: 0.3.x
   # Tells uv to not need a venv, and instead use system
   UV_SYSTEM_PYTHON: 1
   SUT_URL: http://localhost:9999

--- a/README.md
+++ b/README.md
@@ -373,6 +373,10 @@ The two interface lists serve different clients:
 - `additionalInterfaces` — used by **v0.3 clients** to discover endpoints (uses `Legacy_0_3_AgentInterface` with v0.3 field names: `transport`/`url`)
 - `url` and `preferredTransport` — top-level fields that v0.3 clients use to discover the primary endpoint
 
+#### Push Notification Behavior
+
+Push notification payloads are automatically formatted to match the protocol version used when the push notification configuration was registered. When a v0.3 client registers a push notification configuration (via any transport), the server records the protocol version alongside the configuration. When a notification is later sent to that webhook, the payload is formatted as a v0.3 Task object. Configurations registered by v1.0 clients receive v1.0 `StreamResponse` payloads as usual. This happens transparently — no additional configuration is needed beyond adding the compat reference module.
+
 ## A2A Client
 
 The A2A Java SDK provides a Java client implementation of the [Agent2Agent (A2A) Protocol](https://a2a-protocol.org/), allowing communication with A2A servers. The Java client implementation supports the following transports:
@@ -776,7 +780,7 @@ AgentCard card = new A2ACardResolver("http://localhost:1234").getAgentCard();
 
 // Find the v0.3 interface from the agent card
 AgentInterface v03Interface = card.supportedInterfaces().stream()
-        .filter(iface -> "0.3".equals(iface.protocolVersion()))
+        .filter(iface -> A2AProtocol_v0_3.PROTOCOL_VERSION.equals(iface.protocolVersion()))
         .findFirst()
         .orElseThrow();
 

--- a/compat-0.3/reference/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/server/apps/quarkus/A2AServerRoutes_v0_3.java
+++ b/compat-0.3/reference/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/server/apps/quarkus/A2AServerRoutes_v0_3.java
@@ -327,7 +327,7 @@ public class A2AServerRoutes_v0_3 {
             List<String> extensionHeaderValues = rc.request().headers().getAll(A2AHeaders_v0_3.X_A2A_EXTENSIONS);
             Set<String> requestedExtensions = A2AExtensions.getRequestedExtensions(extensionHeaderValues);
 
-            return new ServerCallContext(user, state, requestedExtensions);
+            return new ServerCallContext(user, state, requestedExtensions, "0.3");
         } else {
             CallContextFactory_v0_3 builder = callContextFactory.get();
             return builder.build(rc);

--- a/compat-0.3/reference/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/server/apps/quarkus/A2AServerRoutes_v0_3.java
+++ b/compat-0.3/reference/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/server/apps/quarkus/A2AServerRoutes_v0_3.java
@@ -33,6 +33,7 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import org.a2aproject.sdk.compat03.common.A2AHeaders_v0_3;
+import org.a2aproject.sdk.compat03.conversion.A2AProtocol_v0_3;
 import org.a2aproject.sdk.compat03.json.JsonProcessingException_v0_3;
 import org.a2aproject.sdk.compat03.json.JsonUtil_v0_3;
 import org.a2aproject.sdk.compat03.spec.AgentCard_v0_3;
@@ -327,7 +328,7 @@ public class A2AServerRoutes_v0_3 {
             List<String> extensionHeaderValues = rc.request().headers().getAll(A2AHeaders_v0_3.X_A2A_EXTENSIONS);
             Set<String> requestedExtensions = A2AExtensions.getRequestedExtensions(extensionHeaderValues);
 
-            return new ServerCallContext(user, state, requestedExtensions, "0.3");
+            return new ServerCallContext(user, state, requestedExtensions, A2AProtocol_v0_3.PROTOCOL_VERSION);
         } else {
             CallContextFactory_v0_3 builder = callContextFactory.get();
             return builder.build(rc);

--- a/compat-0.3/reference/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/server/apps/quarkus/CallContextFactory_v0_3.java
+++ b/compat-0.3/reference/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/server/apps/quarkus/CallContextFactory_v0_3.java
@@ -3,6 +3,12 @@ package org.a2aproject.sdk.compat03.server.apps.quarkus;
 import org.a2aproject.sdk.server.ServerCallContext;
 import io.vertx.ext.web.RoutingContext;
 
+/**
+ * Factory interface for creating ServerCallContext from a Vert.x RoutingContext.
+ *
+ * <p>Implementations MUST pass {@code "0.3"} as the protocol version when constructing
+ * {@link ServerCallContext} so that push notification payloads are formatted correctly.</p>
+ */
 public interface CallContextFactory_v0_3 {
     ServerCallContext build(RoutingContext rc);
 }

--- a/compat-0.3/reference/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/server/apps/quarkus/CallContextFactory_v0_3.java
+++ b/compat-0.3/reference/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/server/apps/quarkus/CallContextFactory_v0_3.java
@@ -6,8 +6,9 @@ import io.vertx.ext.web.RoutingContext;
 /**
  * Factory interface for creating ServerCallContext from a Vert.x RoutingContext.
  *
- * <p>Implementations MUST pass {@code "0.3"} as the protocol version when constructing
- * {@link ServerCallContext} so that push notification payloads are formatted correctly.</p>
+ * <p>Implementations MUST pass {@link org.a2aproject.sdk.compat03.conversion.A2AProtocol_v0_3#PROTOCOL_VERSION}
+ * as the protocol version when constructing {@link ServerCallContext} so that push notification
+ * payloads are formatted correctly.</p>
  */
 public interface CallContextFactory_v0_3 {
     ServerCallContext build(RoutingContext rc);

--- a/compat-0.3/reference/rest/src/main/java/org/a2aproject/sdk/compat03/server/rest/quarkus/A2AServerRoutes_v0_3.java
+++ b/compat-0.3/reference/rest/src/main/java/org/a2aproject/sdk/compat03/server/rest/quarkus/A2AServerRoutes_v0_3.java
@@ -431,7 +431,7 @@ public class A2AServerRoutes_v0_3 {
             List<String> extensionHeaderValues = rc.request().headers().getAll(A2AHeaders_v0_3.X_A2A_EXTENSIONS);
             Set<String> requestedExtensions = A2AExtensions.getRequestedExtensions(extensionHeaderValues);
 
-            return new ServerCallContext(user, state, requestedExtensions);
+            return new ServerCallContext(user, state, requestedExtensions, "0.3");
         } else {
             CallContextFactory_v0_3 builder = callContextFactory.get();
             return builder.build(rc);

--- a/compat-0.3/reference/rest/src/main/java/org/a2aproject/sdk/compat03/server/rest/quarkus/A2AServerRoutes_v0_3.java
+++ b/compat-0.3/reference/rest/src/main/java/org/a2aproject/sdk/compat03/server/rest/quarkus/A2AServerRoutes_v0_3.java
@@ -33,6 +33,7 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import org.a2aproject.sdk.compat03.common.A2AHeaders_v0_3;
+import org.a2aproject.sdk.compat03.conversion.A2AProtocol_v0_3;
 import org.a2aproject.sdk.compat03.spec.CancelTaskRequest_v0_3;
 import org.a2aproject.sdk.compat03.spec.DeleteTaskPushNotificationConfigRequest_v0_3;
 import org.a2aproject.sdk.compat03.spec.GetTaskPushNotificationConfigRequest_v0_3;
@@ -431,7 +432,7 @@ public class A2AServerRoutes_v0_3 {
             List<String> extensionHeaderValues = rc.request().headers().getAll(A2AHeaders_v0_3.X_A2A_EXTENSIONS);
             Set<String> requestedExtensions = A2AExtensions.getRequestedExtensions(extensionHeaderValues);
 
-            return new ServerCallContext(user, state, requestedExtensions, "0.3");
+            return new ServerCallContext(user, state, requestedExtensions, A2AProtocol_v0_3.PROTOCOL_VERSION);
         } else {
             CallContextFactory_v0_3 builder = callContextFactory.get();
             return builder.build(rc);

--- a/compat-0.3/reference/rest/src/main/java/org/a2aproject/sdk/compat03/server/rest/quarkus/CallContextFactory_v0_3.java
+++ b/compat-0.3/reference/rest/src/main/java/org/a2aproject/sdk/compat03/server/rest/quarkus/CallContextFactory_v0_3.java
@@ -6,8 +6,9 @@ import io.vertx.ext.web.RoutingContext;
 /**
  * Factory interface for creating ServerCallContext from a Vert.x RoutingContext.
  *
- * <p>Implementations MUST pass {@code "0.3"} as the protocol version when constructing
- * {@link ServerCallContext} so that push notification payloads are formatted correctly.</p>
+ * <p>Implementations MUST pass {@link org.a2aproject.sdk.compat03.conversion.A2AProtocol_v0_3#PROTOCOL_VERSION}
+ * as the protocol version when constructing {@link ServerCallContext} so that push notification
+ * payloads are formatted correctly.</p>
  */
 public interface CallContextFactory_v0_3 {
     ServerCallContext build(RoutingContext rc);

--- a/compat-0.3/reference/rest/src/main/java/org/a2aproject/sdk/compat03/server/rest/quarkus/CallContextFactory_v0_3.java
+++ b/compat-0.3/reference/rest/src/main/java/org/a2aproject/sdk/compat03/server/rest/quarkus/CallContextFactory_v0_3.java
@@ -3,6 +3,12 @@ package org.a2aproject.sdk.compat03.server.rest.quarkus;
 import org.a2aproject.sdk.server.ServerCallContext;
 import io.vertx.ext.web.RoutingContext;
 
+/**
+ * Factory interface for creating ServerCallContext from a Vert.x RoutingContext.
+ *
+ * <p>Implementations MUST pass {@code "0.3"} as the protocol version when constructing
+ * {@link ServerCallContext} so that push notification payloads are formatted correctly.</p>
+ */
 public interface CallContextFactory_v0_3 {
     ServerCallContext build(RoutingContext rc);
 }

--- a/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/A2AProtocol_v0_3.java
+++ b/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/A2AProtocol_v0_3.java
@@ -1,0 +1,9 @@
+package org.a2aproject.sdk.compat03.conversion;
+
+public final class A2AProtocol_v0_3 {
+
+    public static final String PROTOCOL_VERSION = "0.3";
+
+    private A2AProtocol_v0_3() {
+    }
+}

--- a/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/PushNotificationPayloadFormatter_v0_3.java
+++ b/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/PushNotificationPayloadFormatter_v0_3.java
@@ -1,0 +1,44 @@
+package org.a2aproject.sdk.compat03.conversion;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.a2aproject.sdk.compat03.conversion.mappers.domain.TaskMapper_v0_3;
+import org.a2aproject.sdk.compat03.json.JsonProcessingException_v0_3;
+import org.a2aproject.sdk.compat03.json.JsonUtil_v0_3;
+import org.a2aproject.sdk.compat03.spec.Task_v0_3;
+import org.a2aproject.sdk.server.tasks.PushNotificationPayloadFormatter;
+import org.a2aproject.sdk.spec.Message;
+import org.a2aproject.sdk.spec.StreamingEventKind;
+import org.a2aproject.sdk.spec.Task;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class PushNotificationPayloadFormatter_v0_3 implements PushNotificationPayloadFormatter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PushNotificationPayloadFormatter_v0_3.class);
+
+    @Override
+    public String targetVersion() {
+        return "0.3";
+    }
+
+    @Override
+    public @Nullable String formatPayload(StreamingEventKind event, @Nullable Task taskSnapshot) {
+        if (event instanceof Message) {
+            return null;
+        }
+        if (taskSnapshot == null) {
+            LOGGER.warn("Cannot format v0.3 push notification: no task snapshot available");
+            return null;
+        }
+        Task_v0_3 v03Task = TaskMapper_v0_3.INSTANCE.fromV10(taskSnapshot);
+        try {
+            return JsonUtil_v0_3.toJson(v03Task);
+        } catch (JsonProcessingException_v0_3 e) {
+            LOGGER.error("Failed to serialize v0.3 task for push notification", e);
+            return null;
+        }
+    }
+}

--- a/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/PushNotificationPayloadFormatter_v0_3.java
+++ b/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/PushNotificationPayloadFormatter_v0_3.java
@@ -21,7 +21,7 @@ public class PushNotificationPayloadFormatter_v0_3 implements PushNotificationPa
 
     @Override
     public String targetVersion() {
-        return "0.3";
+        return A2AProtocol_v0_3.PROTOCOL_VERSION;
     }
 
     @Override

--- a/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/AbstractA2ARequestHandlerTest_v0_3.java
+++ b/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/AbstractA2ARequestHandlerTest_v0_3.java
@@ -183,7 +183,7 @@ public abstract class AbstractA2ARequestHandlerTest_v0_3 {
                 .defaultOutputModes(new ArrayList<>())
                 .preferredTransport("jsonrpc")
                 .skills(new ArrayList<>())
-                .protocolVersion("0.3")
+                .protocolVersion(A2AProtocol_v0_3.PROTOCOL_VERSION)
                 .build();
     }
 

--- a/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/AbstractA2ARequestHandlerTest_v0_3.java
+++ b/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/AbstractA2ARequestHandlerTest_v0_3.java
@@ -84,7 +84,7 @@ public abstract class AbstractA2ARequestHandlerTest_v0_3 {
             .parts(new TextPart_v0_3("test message"))
             .build();
 
-    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = task -> {};
+    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = (event, snapshot) -> {};
 
     // V1.0 backend infrastructure
     protected AgentExecutor agentExecutor;

--- a/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/PushNotificationPayloadFormatter_v0_3_Test.java
+++ b/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/PushNotificationPayloadFormatter_v0_3_Test.java
@@ -1,0 +1,94 @@
+package org.a2aproject.sdk.compat03.conversion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.a2aproject.sdk.spec.Message;
+import org.a2aproject.sdk.spec.Task;
+import org.a2aproject.sdk.spec.TaskState;
+import org.a2aproject.sdk.spec.TaskStatus;
+import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
+import org.a2aproject.sdk.spec.TextPart;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PushNotificationPayloadFormatter_v0_3_Test {
+
+    private PushNotificationPayloadFormatter_v0_3 formatter;
+
+    @BeforeEach
+    void setUp() {
+        formatter = new PushNotificationPayloadFormatter_v0_3();
+    }
+
+    @Test
+    void targetVersionIs03() {
+        assertEquals("0.3", formatter.targetVersion());
+    }
+
+    @Test
+    void formatsTaskEventAsV03Task() {
+        Task task = Task.builder()
+                .id("t1").contextId("c1")
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
+                .build();
+
+        String payload = formatter.formatPayload(task, task);
+
+        assertNotNull(payload);
+        assertTrue(payload.contains("\"kind\":\"task\""));
+        assertTrue(payload.contains("\"id\":\"t1\""));
+        assertTrue(payload.contains("\"status\""));
+    }
+
+    @Test
+    void formatsStatusUpdateUsingTaskSnapshot() {
+        Task snapshot = Task.builder()
+                .id("t1").contextId("c1")
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
+                .build();
+
+        TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
+                .taskId("t1").contextId("c1")
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
+                .build();
+
+        String payload = formatter.formatPayload(event, snapshot);
+
+        assertNotNull(payload);
+        assertTrue(payload.contains("\"kind\":\"task\""));
+        assertTrue(payload.contains("\"id\":\"t1\""));
+    }
+
+    @Test
+    void skipsMessageEvents() {
+        Task snapshot = Task.builder()
+                .id("t1").contextId("c1")
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
+                .build();
+
+        Message message = Message.builder()
+                .messageId("m1")
+                .role(Message.Role.ROLE_AGENT)
+                .parts(new TextPart("hello"))
+                .build();
+
+        String payload = formatter.formatPayload(message, snapshot);
+
+        assertNull(payload);
+    }
+
+    @Test
+    void returnsNullWhenSnapshotIsNull() {
+        Task task = Task.builder()
+                .id("t1").contextId("c1")
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
+                .build();
+
+        String payload = formatter.formatPayload(task, null);
+
+        assertNull(payload);
+    }
+}

--- a/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/PushNotificationPayloadFormatter_v0_3_Test.java
+++ b/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/PushNotificationPayloadFormatter_v0_3_Test.java
@@ -25,7 +25,7 @@ class PushNotificationPayloadFormatter_v0_3_Test {
 
     @Test
     void targetVersionIs03() {
-        assertEquals("0.3", formatter.targetVersion());
+        assertEquals(A2AProtocol_v0_3.PROTOCOL_VERSION, formatter.targetVersion());
     }
 
     @Test

--- a/compat-0.3/transport/grpc/src/main/java/org/a2aproject/sdk/compat03/transport/grpc/handler/CallContextFactory_v0_3.java
+++ b/compat-0.3/transport/grpc/src/main/java/org/a2aproject/sdk/compat03/transport/grpc/handler/CallContextFactory_v0_3.java
@@ -6,6 +6,9 @@ import io.grpc.stub.StreamObserver;
 /**
  * Factory interface for creating ServerCallContext from gRPC StreamObserver.
  * Implementations can provide custom context creation logic.
+ *
+ * <p>Implementations MUST pass {@code "0.3"} as the protocol version when constructing
+ * {@link ServerCallContext} so that push notification payloads are formatted correctly.</p>
  */
 public interface CallContextFactory_v0_3 {
     <V> ServerCallContext create(StreamObserver<V> responseObserver);

--- a/compat-0.3/transport/grpc/src/main/java/org/a2aproject/sdk/compat03/transport/grpc/handler/CallContextFactory_v0_3.java
+++ b/compat-0.3/transport/grpc/src/main/java/org/a2aproject/sdk/compat03/transport/grpc/handler/CallContextFactory_v0_3.java
@@ -7,8 +7,9 @@ import io.grpc.stub.StreamObserver;
  * Factory interface for creating ServerCallContext from gRPC StreamObserver.
  * Implementations can provide custom context creation logic.
  *
- * <p>Implementations MUST pass {@code "0.3"} as the protocol version when constructing
- * {@link ServerCallContext} so that push notification payloads are formatted correctly.</p>
+ * <p>Implementations MUST pass {@link org.a2aproject.sdk.compat03.conversion.A2AProtocol_v0_3#PROTOCOL_VERSION}
+ * as the protocol version when constructing {@link ServerCallContext} so that push notification
+ * payloads are formatted correctly.</p>
  */
 public interface CallContextFactory_v0_3 {
     <V> ServerCallContext create(StreamObserver<V> responseObserver);

--- a/compat-0.3/transport/grpc/src/main/java/org/a2aproject/sdk/compat03/transport/grpc/handler/GrpcHandler_v0_3.java
+++ b/compat-0.3/transport/grpc/src/main/java/org/a2aproject/sdk/compat03/transport/grpc/handler/GrpcHandler_v0_3.java
@@ -363,7 +363,7 @@ public abstract class GrpcHandler_v0_3 extends org.a2aproject.sdk.compat03.grpc.
             Map<String, Object> state = new HashMap<>();
             state.put("grpc_response_observer", responseObserver);
             Set<String> requestedExtensions = new HashSet<>();
-            return new ServerCallContext(user, state, requestedExtensions);
+            return new ServerCallContext(user, state, requestedExtensions, "0.3");
         } else {
             return factory.create(responseObserver);
         }

--- a/compat-0.3/transport/grpc/src/main/java/org/a2aproject/sdk/compat03/transport/grpc/handler/GrpcHandler_v0_3.java
+++ b/compat-0.3/transport/grpc/src/main/java/org/a2aproject/sdk/compat03/transport/grpc/handler/GrpcHandler_v0_3.java
@@ -12,6 +12,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;
 
 import com.google.protobuf.Empty;
+import org.a2aproject.sdk.compat03.conversion.A2AProtocol_v0_3;
 import org.a2aproject.sdk.compat03.conversion.Convert_v0_3_To10RequestHandler;
 import org.a2aproject.sdk.compat03.conversion.ErrorConverter_v0_3;
 import org.a2aproject.sdk.compat03.spec.AgentCard_v0_3;
@@ -363,7 +364,7 @@ public abstract class GrpcHandler_v0_3 extends org.a2aproject.sdk.compat03.grpc.
             Map<String, Object> state = new HashMap<>();
             state.put("grpc_response_observer", responseObserver);
             Set<String> requestedExtensions = new HashSet<>();
-            return new ServerCallContext(user, state, requestedExtensions, "0.3");
+            return new ServerCallContext(user, state, requestedExtensions, A2AProtocol_v0_3.PROTOCOL_VERSION);
         } else {
             return factory.create(responseObserver);
         }

--- a/compat-0.3/transport/grpc/src/test/java/org/a2aproject/sdk/compat03/transport/grpc/handler/GrpcHandler_v0_3_Test.java
+++ b/compat-0.3/transport/grpc/src/test/java/org/a2aproject/sdk/compat03/transport/grpc/handler/GrpcHandler_v0_3_Test.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.a2aproject.sdk.compat03.conversion.A2AProtocol_v0_3;
 import org.a2aproject.sdk.compat03.conversion.AbstractA2ARequestHandlerTest_v0_3;
 import org.a2aproject.sdk.compat03.conversion.Convert_v0_3_To10RequestHandler;
 import org.a2aproject.sdk.compat03.conversion.mappers.domain.TaskMapper_v0_3;
@@ -65,7 +66,7 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
             .build();
 
     private final ServerCallContext callContext = new ServerCallContext(
-            UnauthenticatedUser.INSTANCE, Map.of("foo", "bar"), new HashSet<>(), "0.3");
+            UnauthenticatedUser.INSTANCE, Map.of("foo", "bar"), new HashSet<>(), A2AProtocol_v0_3.PROTOCOL_VERSION);
 
     // ========================================
     // GetTask Tests

--- a/compat-0.3/transport/grpc/src/test/java/org/a2aproject/sdk/compat03/transport/grpc/handler/GrpcHandler_v0_3_Test.java
+++ b/compat-0.3/transport/grpc/src/test/java/org/a2aproject/sdk/compat03/transport/grpc/handler/GrpcHandler_v0_3_Test.java
@@ -65,7 +65,7 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
             .build();
 
     private final ServerCallContext callContext = new ServerCallContext(
-            UnauthenticatedUser.INSTANCE, Map.of("foo", "bar"), new HashSet<>());
+            UnauthenticatedUser.INSTANCE, Map.of("foo", "bar"), new HashSet<>(), "0.3");
 
     // ========================================
     // GetTask Tests

--- a/compat-0.3/transport/jsonrpc/src/test/java/org/a2aproject/sdk/compat03/transport/jsonrpc/handler/JSONRPCHandler_v0_3_Test.java
+++ b/compat-0.3/transport/jsonrpc/src/test/java/org/a2aproject/sdk/compat03/transport/jsonrpc/handler/JSONRPCHandler_v0_3_Test.java
@@ -85,7 +85,7 @@ import org.a2aproject.sdk.compat03.spec.UnsupportedOperationError_v0_3;
 public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
 
     private final ServerCallContext callContext = new ServerCallContext(
-            UnauthenticatedUser.INSTANCE, Map.of("foo", "bar"), new HashSet<>());
+            UnauthenticatedUser.INSTANCE, Map.of("foo", "bar"), new HashSet<>(), "0.3");
 
     // ========================================
     // GetTask Tests

--- a/compat-0.3/transport/jsonrpc/src/test/java/org/a2aproject/sdk/compat03/transport/jsonrpc/handler/JSONRPCHandler_v0_3_Test.java
+++ b/compat-0.3/transport/jsonrpc/src/test/java/org/a2aproject/sdk/compat03/transport/jsonrpc/handler/JSONRPCHandler_v0_3_Test.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.a2aproject.sdk.compat03.conversion.A2AProtocol_v0_3;
 import org.a2aproject.sdk.compat03.conversion.AbstractA2ARequestHandlerTest_v0_3;
 import org.a2aproject.sdk.compat03.conversion.Convert_v0_3_To10RequestHandler;
 import org.a2aproject.sdk.compat03.conversion.mappers.domain.TaskArtifactUpdateEventMapper_v0_3;
@@ -85,7 +86,7 @@ import org.a2aproject.sdk.compat03.spec.UnsupportedOperationError_v0_3;
 public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
 
     private final ServerCallContext callContext = new ServerCallContext(
-            UnauthenticatedUser.INSTANCE, Map.of("foo", "bar"), new HashSet<>(), "0.3");
+            UnauthenticatedUser.INSTANCE, Map.of("foo", "bar"), new HashSet<>(), A2AProtocol_v0_3.PROTOCOL_VERSION);
 
     // ========================================
     // GetTask Tests

--- a/compat-0.3/transport/rest/src/test/java/org/a2aproject/sdk/compat03/transport/rest/handler/RestHandler_v0_3_Test.java
+++ b/compat-0.3/transport/rest/src/test/java/org/a2aproject/sdk/compat03/transport/rest/handler/RestHandler_v0_3_Test.java
@@ -3,6 +3,7 @@ package org.a2aproject.sdk.compat03.transport.rest.handler;
 import java.util.HashSet;
 import java.util.Map;
 
+import org.a2aproject.sdk.compat03.conversion.A2AProtocol_v0_3;
 import org.a2aproject.sdk.compat03.conversion.AbstractA2ARequestHandlerTest_v0_3;
 import org.a2aproject.sdk.compat03.conversion.Convert_v0_3_To10RequestHandler;
 import org.a2aproject.sdk.compat03.conversion.mappers.domain.TaskMapper_v0_3;
@@ -32,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class RestHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
 
     private final ServerCallContext callContext = new ServerCallContext(
-            UnauthenticatedUser.INSTANCE, Map.of("foo", "bar"), new HashSet<>(), "0.3");
+            UnauthenticatedUser.INSTANCE, Map.of("foo", "bar"), new HashSet<>(), A2AProtocol_v0_3.PROTOCOL_VERSION);
 
     // ========================================
     // GetTask Tests

--- a/compat-0.3/transport/rest/src/test/java/org/a2aproject/sdk/compat03/transport/rest/handler/RestHandler_v0_3_Test.java
+++ b/compat-0.3/transport/rest/src/test/java/org/a2aproject/sdk/compat03/transport/rest/handler/RestHandler_v0_3_Test.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class RestHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
 
     private final ServerCallContext callContext = new ServerCallContext(
-            UnauthenticatedUser.INSTANCE, Map.of("foo", "bar"), new HashSet<>());
+            UnauthenticatedUser.INSTANCE, Map.of("foo", "bar"), new HashSet<>(), "0.3");
 
     // ========================================
     // GetTask Tests

--- a/extras/push-notification-config-store-database-jpa/src/main/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/JpaDatabasePushNotificationConfigStore.java
+++ b/extras/push-notification-config-store-database-jpa/src/main/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/JpaDatabasePushNotificationConfigStore.java
@@ -18,6 +18,7 @@ import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsResult;
 import org.a2aproject.sdk.util.Assert;
 import org.a2aproject.sdk.util.PageToken;
 import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +37,12 @@ public class JpaDatabasePushNotificationConfigStore implements PushNotificationC
     @Transactional
     @Override
     public TaskPushNotificationConfig setInfo(TaskPushNotificationConfig notificationConfig) {
+        return setInfo(notificationConfig, null);
+    }
+
+    @Transactional
+    @Override
+    public TaskPushNotificationConfig setInfo(TaskPushNotificationConfig notificationConfig, @Nullable String protocolVersion) {
         String taskId = Assert.checkNotNullParam("taskId", notificationConfig.taskId());
         // Ensure config has an ID - default to taskId if not provided (mirroring InMemoryPushNotificationConfigStore behavior)
         if (notificationConfig.id().isEmpty()) {
@@ -44,6 +51,7 @@ public class JpaDatabasePushNotificationConfigStore implements PushNotificationC
             notificationConfig = TaskPushNotificationConfig.builder(notificationConfig).id(taskId).build();
         }
 
+        String resolvedVersion = PushNotificationConfigStore.resolveProtocolVersion(protocolVersion);
         LOGGER.debug("Saving PushNotificationConfig for Task '{}' with ID: {}", taskId, notificationConfig.id());
         try {
             TaskConfigId configId = new TaskConfigId(taskId, notificationConfig.id());
@@ -54,11 +62,12 @@ public class JpaDatabasePushNotificationConfigStore implements PushNotificationC
             if (existingJpaConfig != null) {
                 // Update existing entity
                 existingJpaConfig.setConfig(notificationConfig);
+                existingJpaConfig.setProtocolVersion(resolvedVersion);
                 LOGGER.debug("Updated existing PushNotificationConfig for Task '{}' with ID: {}",
                         taskId, notificationConfig.id());
             } else {
                 // Create new entity
-                JpaPushNotificationConfig jpaConfig = JpaPushNotificationConfig.createFromConfig(taskId, notificationConfig);
+                JpaPushNotificationConfig jpaConfig = JpaPushNotificationConfig.createFromConfig(taskId, notificationConfig, resolvedVersion);
                 em.persist(jpaConfig);
                 LOGGER.debug("Persisted new PushNotificationConfig for Task '{}' with ID: {}",
                         taskId, notificationConfig.id());
@@ -162,6 +171,14 @@ public class JpaDatabasePushNotificationConfigStore implements PushNotificationC
             LOGGER.debug("PushNotificationConfig not found for deletion with Task '{}' and Config ID: {}",
                     taskId, configId);
         }
+    }
+
+    @Transactional
+    @Override
+    public @Nullable String getProtocolVersion(String taskId, String configId) {
+        JpaPushNotificationConfig jpaConfig = em.find(JpaPushNotificationConfig.class,
+                new TaskConfigId(taskId, configId));
+        return jpaConfig != null ? jpaConfig.getProtocolVersion() : null;
     }
 
 }

--- a/extras/push-notification-config-store-database-jpa/src/main/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/JpaDatabasePushNotificationConfigStore.java
+++ b/extras/push-notification-config-store-database-jpa/src/main/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/JpaDatabasePushNotificationConfigStore.java
@@ -181,4 +181,19 @@ public class JpaDatabasePushNotificationConfigStore implements PushNotificationC
         return jpaConfig != null ? jpaConfig.getProtocolVersion() : null;
     }
 
+    @Transactional
+    @Override
+    public java.util.Map<String, String> getProtocolVersions(String taskId) {
+        List<Object[]> results = em.createQuery(
+                "SELECT c.id.configId, c.protocolVersion FROM JpaPushNotificationConfig c " +
+                "WHERE c.id.taskId = :taskId AND c.protocolVersion IS NOT NULL", Object[].class)
+                .setParameter("taskId", taskId)
+                .getResultList();
+        java.util.Map<String, String> versions = new java.util.HashMap<>();
+        for (Object[] row : results) {
+            versions.put((String) row[0], (String) row[1]);
+        }
+        return versions;
+    }
+
 }

--- a/extras/push-notification-config-store-database-jpa/src/main/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/JpaDatabasePushNotificationConfigStore.java
+++ b/extras/push-notification-config-store-database-jpa/src/main/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/JpaDatabasePushNotificationConfigStore.java
@@ -175,10 +175,10 @@ public class JpaDatabasePushNotificationConfigStore implements PushNotificationC
 
     @Transactional
     @Override
-    public @Nullable String getProtocolVersion(String taskId, String configId) {
+    public String getProtocolVersion(String taskId, String configId) {
         JpaPushNotificationConfig jpaConfig = em.find(JpaPushNotificationConfig.class,
                 new TaskConfigId(taskId, configId));
-        return jpaConfig != null ? jpaConfig.getProtocolVersion() : null;
+        return jpaConfig != null ? jpaConfig.getProtocolVersion() : PushNotificationConfigStore.resolveProtocolVersion(null);
     }
 
     @Transactional

--- a/extras/push-notification-config-store-database-jpa/src/main/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/JpaPushNotificationConfig.java
+++ b/extras/push-notification-config-store-database-jpa/src/main/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/JpaPushNotificationConfig.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Transient;
 
 import org.a2aproject.sdk.jsonrpc.common.json.JsonProcessingException;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonUtil;
+import org.a2aproject.sdk.server.tasks.PushNotificationConfigStore;
 import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
 import org.jspecify.annotations.Nullable;
 
@@ -84,8 +85,8 @@ public class JpaPushNotificationConfig {
       this.createdAt = createdAt;
     }
 
-    public @Nullable String getProtocolVersion() {
-        return protocolVersion;
+    public String getProtocolVersion() {
+        return PushNotificationConfigStore.resolveProtocolVersion(protocolVersion);
     }
 
     public void setProtocolVersion(String protocolVersion) {

--- a/extras/push-notification-config-store-database-jpa/src/main/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/JpaPushNotificationConfig.java
+++ b/extras/push-notification-config-store-database-jpa/src/main/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/JpaPushNotificationConfig.java
@@ -10,6 +10,8 @@ import jakarta.persistence.Transient;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonProcessingException;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonUtil;
 import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
+import org.jspecify.annotations.Nullable;
+
 import java.time.Instant;
 
 @Entity
@@ -20,6 +22,9 @@ public class JpaPushNotificationConfig {
 
     @Column(name = "task_data", columnDefinition = "TEXT", nullable = false)
     private String configJson;
+
+    @Column(name = "protocol_version")
+    private String protocolVersion;
 
     @Column(name = "created_at")
     private Instant createdAt;
@@ -79,11 +84,20 @@ public class JpaPushNotificationConfig {
       this.createdAt = createdAt;
     }
 
-    static JpaPushNotificationConfig createFromConfig(String taskId, TaskPushNotificationConfig config) throws JsonProcessingException {
+    public @Nullable String getProtocolVersion() {
+        return protocolVersion;
+    }
+
+    public void setProtocolVersion(String protocolVersion) {
+        this.protocolVersion = protocolVersion;
+    }
+
+    static JpaPushNotificationConfig createFromConfig(String taskId, TaskPushNotificationConfig config, @Nullable String protocolVersion) throws JsonProcessingException {
         String json = JsonUtil.toJson(config);
         JpaPushNotificationConfig jpaPushNotificationConfig =
                 new JpaPushNotificationConfig(new TaskConfigId(taskId, config.id()), json);
         jpaPushNotificationConfig.config = config;
+        jpaPushNotificationConfig.protocolVersion = protocolVersion;
         return jpaPushNotificationConfig;
     }
 }

--- a/extras/push-notification-config-store-database-jpa/src/test/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/JpaDatabasePushNotificationConfigStoreIntegrationTest.java
+++ b/extras/push-notification-config-store-database-jpa/src/test/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/JpaDatabasePushNotificationConfigStoreIntegrationTest.java
@@ -91,7 +91,7 @@ public class JpaDatabasePushNotificationConfigStoreIntegrationTest {
             .build();
 
         // Directly trigger the mock
-        mockPushNotificationSender.sendNotification(testTask);
+        mockPushNotificationSender.sendNotification(testTask, null);
 
         // Verify it was captured
         Queue<Task> captured = mockPushNotificationSender.getCapturedTasks();

--- a/extras/push-notification-config-store-database-jpa/src/test/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/JpaPushNotificationConfigStoreTest.java
+++ b/extras/push-notification-config-store-database-jpa/src/test/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/JpaPushNotificationConfigStoreTest.java
@@ -249,7 +249,7 @@ public class JpaPushNotificationConfigStoreTest {
         when(mockPostBuilder.post()).thenReturn(mockHttpResponse);
         when(mockHttpResponse.success()).thenReturn(true);
 
-        notificationSender.sendNotification(task);
+        notificationSender.sendNotification(task, null);
 
         // Verify HTTP client was called
         ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
@@ -281,7 +281,7 @@ public class JpaPushNotificationConfigStoreTest {
         when(mockPostBuilder.post()).thenReturn(mockHttpResponse);
         when(mockHttpResponse.success()).thenReturn(true);
 
-        notificationSender.sendNotification(task);
+        notificationSender.sendNotification(task, null);
 
         // TODO: Once token authentication is implemented, verify that:
         // 1. The token is included in request headers (e.g., X-A2A-Notification-Token)
@@ -307,7 +307,7 @@ public class JpaPushNotificationConfigStoreTest {
         String taskId = "task_send_no_config";
         Task task = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
 
-        notificationSender.sendNotification(task);
+        notificationSender.sendNotification(task, null);
 
         // Verify HTTP client was never called
         verify(mockHttpClient, never()).createPost();

--- a/extras/push-notification-config-store-database-jpa/src/test/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/MockPushNotificationSender.java
+++ b/extras/push-notification-config-store-database-jpa/src/test/java/org/a2aproject/sdk/extras/pushnotificationconfigstore/database/jpa/MockPushNotificationSender.java
@@ -23,7 +23,7 @@ public class MockPushNotificationSender implements PushNotificationSender {
     private final Queue<StreamingEventKind> capturedEvents = new ConcurrentLinkedQueue<>();
 
     @Override
-    public void sendNotification(StreamingEventKind event) {
+    public void sendNotification(StreamingEventKind event, Task taskSnapshot) {
         capturedEvents.add(event);
     }
 

--- a/extras/queue-manager-replicated/core/src/test/java/org/a2aproject/sdk/extras/queuemanager/replicated/core/ReplicatedQueueManagerTest.java
+++ b/extras/queue-manager-replicated/core/src/test/java/org/a2aproject/sdk/extras/queuemanager/replicated/core/ReplicatedQueueManagerTest.java
@@ -44,7 +44,7 @@ class ReplicatedQueueManagerTest {
     private StreamingEventKind testEvent;
     private MainEventBus mainEventBus;
     private MainEventBusProcessor mainEventBusProcessor;
-    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = task -> {};
+    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = (event, snapshot) -> {};
 
     @BeforeEach
     void setUp() {

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/MainEventBusProcessor.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/MainEventBusProcessor.java
@@ -242,7 +242,7 @@ public class MainEventBusProcessor implements Runnable {
             // Skip push notifications for replicated events to avoid duplicate notifications in multi-instance deployments
             // Push notifications are sent for all StreamingEventKind events (Task, Message, TaskStatusUpdateEvent, TaskArtifactUpdateEvent)
             // per A2A spec section 4.3.3
-            if (!isReplicated && event instanceof StreamingEventKind streamingEvent) {
+            if (!isReplicated && eventToDistribute == event && event instanceof StreamingEventKind streamingEvent) {
                 // Send the streaming event directly - it will be wrapped in StreamResponse format by PushNotificationSender
                 sendPushNotification(taskId, streamingEvent, updateResult != null ? updateResult.taskSnapshot() : null);
             }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/MainEventBusProcessor.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/MainEventBusProcessor.java
@@ -1,6 +1,7 @@
 package org.a2aproject.sdk.server.events;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
@@ -16,8 +17,8 @@ import org.a2aproject.sdk.server.tasks.TaskStore;
 import org.a2aproject.sdk.spec.A2AError;
 import org.a2aproject.sdk.spec.Event;
 import org.a2aproject.sdk.spec.InternalError;
-import org.a2aproject.sdk.spec.Task;
 import org.a2aproject.sdk.spec.StreamingEventKind;
+import org.a2aproject.sdk.spec.Task;
 import org.a2aproject.sdk.spec.TaskArtifactUpdateEvent;
 import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
 import org.slf4j.Logger;
@@ -57,6 +58,8 @@ import org.slf4j.LoggerFactory;
 @ApplicationScoped
 public class MainEventBusProcessor implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(MainEventBusProcessor.class);
+
+    private record UpdateResult(boolean isFinal, @Nullable Task taskSnapshot) {}
 
     /**
      * Callback for testing synchronization with async event processing.
@@ -200,13 +203,15 @@ public class MainEventBusProcessor implements Runnable {
                     taskId, event.getClass().getSimpleName());
 
         Event eventToDistribute = null;
+        UpdateResult updateResult = null;
         boolean isReplicated = context.eventQueueItem().isReplicated();
         try {
             // Step 1: Update TaskStore FIRST (persistence before clients see it)
             // If this throws, we distribute an error to ensure "persist before client visibility"
 
             try {
-                boolean isFinal = updateTaskStore(taskId, event, isReplicated);
+                updateResult = updateTaskStore(taskId, event, isReplicated);
+                boolean isFinal = updateResult.isFinal();
 
                 eventToDistribute = event; // Success - distribute original event
 
@@ -239,7 +244,7 @@ public class MainEventBusProcessor implements Runnable {
             // per A2A spec section 4.3.3
             if (!isReplicated && event instanceof StreamingEventKind streamingEvent) {
                 // Send the streaming event directly - it will be wrapped in StreamResponse format by PushNotificationSender
-                sendPushNotification(taskId, streamingEvent);
+                sendPushNotification(taskId, streamingEvent, updateResult != null ? updateResult.taskSnapshot() : null);
             }
 
             // Step 3: Then distribute to ChildQueues (clients see either event or error AFTER persistence attempt)
@@ -293,7 +298,7 @@ public class MainEventBusProcessor implements Runnable {
      * @return true if the task reached a final state, false otherwise
      * @throws InternalError if persistence fails
      */
-    private boolean updateTaskStore(String taskId, Event event, boolean isReplicated) throws InternalError {
+    private UpdateResult updateTaskStore(String taskId, Event event, boolean isReplicated) throws InternalError {
         try {
             // Extract contextId from event (all relevant events have it)
             String contextId = extractContextId(event);
@@ -302,10 +307,11 @@ public class MainEventBusProcessor implements Runnable {
             TaskManager taskManager = new TaskManager(taskId, contextId, taskStore, null);
 
             // Use TaskManager.process() - handles all event types with existing logic
-            boolean isFinal = taskManager.process(event, isReplicated);
+            AtomicReference<Task> taskSnapshot = new AtomicReference<>();
+            boolean isFinal = taskManager.process(event, isReplicated, taskSnapshot);
             LOGGER.debug("TaskStore updated via TaskManager.process() for task {}: {} (final: {}, replicated: {})",
                         taskId, event.getClass().getSimpleName(), isFinal, isReplicated);
-            return isFinal;
+            return new UpdateResult(isFinal, taskSnapshot.get());
 
         } catch (TaskSerializationException e) {
             // Data corruption or schema mismatch - ALWAYS permanent
@@ -362,12 +368,12 @@ public class MainEventBusProcessor implements Runnable {
      * @param taskId the task ID
      * @param event the streaming event to send (Task, Message, TaskStatusUpdateEvent, or TaskArtifactUpdateEvent)
      */
-    private void sendPushNotification(String taskId, StreamingEventKind event) {
+    private void sendPushNotification(String taskId, StreamingEventKind event, @Nullable Task taskSnapshot) {
         Runnable pushTask = () -> {
             try {
                 if (event != null) {
                     LOGGER.debug("Sending push notification for task {}", taskId);
-                    pushSender.sendNotification(event);
+                    pushSender.sendNotification(event, taskSnapshot);
                 } else {
                     LOGGER.debug("Skipping push notification - event is null for task {}", taskId);
                 }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
@@ -504,8 +504,9 @@ public class DefaultRequestHandler implements RequestHandler {
             if (mss.task() == null && kind instanceof Task createdTask && shouldAddPushInfo(params)) {
                 LOGGER.debug("Storing push notification config for new task {} (original taskId from params: {})",
                         createdTask.id(), params.message().taskId());
+                String version = context != null ? context.getRequestedProtocolVersion() : null;
                 pushConfigStore.setInfo(TaskPushNotificationConfig.builder(params.configuration().taskPushNotificationConfig())
-                        .taskId(createdTask.id()).build());
+                        .taskId(createdTask.id()).build(), version);
             }
 
             // Check if task requires immediate return (AUTH_REQUIRED)
@@ -662,8 +663,9 @@ public class DefaultRequestHandler implements RequestHandler {
             Objects.requireNonNull(taskId.get(), "taskId was null");
             LOGGER.debug("Storing push notification config for new streaming task {} EARLY (original taskId from params: {})",
                     taskId.get(), params.message().taskId());
+            String version = context != null ? context.getRequestedProtocolVersion() : null;
             pushConfigStore.setInfo(TaskPushNotificationConfig.builder(params.configuration().taskPushNotificationConfig())
-                    .taskId(taskId.get()).build());
+                    .taskId(taskId.get()).build(), version);
         }
 
         ResultAggregator resultAggregator = new ResultAggregator(mss.taskManager, null, executor, eventConsumerExecutor);
@@ -796,7 +798,9 @@ public class DefaultRequestHandler implements RequestHandler {
             throw new TaskNotFoundError();
         }
 
-        return pushConfigStore.setInfo(params);
+        String version = context != null ? context.getRequestedProtocolVersion() : null;
+        TaskPushNotificationConfig result = pushConfigStore.setInfo(params, version);
+        return result;
     }
 
     @Override
@@ -1051,8 +1055,9 @@ public class DefaultRequestHandler implements RequestHandler {
 
             if (pushConfigStore != null && params.configuration() != null && params.configuration().taskPushNotificationConfig() != null) {
                 LOGGER.debug("Adding push info");
+                String version = context != null ? context.getRequestedProtocolVersion() : null;
                 pushConfigStore.setInfo(TaskPushNotificationConfig.builder(params.configuration().taskPushNotificationConfig())
-                        .taskId(task.id()).build());
+                        .taskId(task.id()).build(), version);
             }
 
             requestContext = requestContextBuilder.get()

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/BasePushNotificationSender.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/BasePushNotificationSender.java
@@ -4,16 +4,17 @@ import static org.a2aproject.sdk.client.http.A2AHttpClient.APPLICATION_JSON;
 import static org.a2aproject.sdk.client.http.A2AHttpClient.CONTENT_TYPE;
 import static org.a2aproject.sdk.common.A2AHeaders.X_A2A_NOTIFICATION_TOKEN;
 
-import jakarta.annotation.Nullable;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-
 
 import org.a2aproject.sdk.client.http.A2AHttpClient;
 import org.a2aproject.sdk.client.http.A2AHttpClientFactory;
@@ -26,6 +27,7 @@ import org.a2aproject.sdk.spec.Task;
 import org.a2aproject.sdk.spec.TaskArtifactUpdateEvent;
 import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
 import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +42,7 @@ public class BasePushNotificationSender implements PushNotificationSender {
     // final, is not proxyable in all runtimes
     private A2AHttpClient httpClient;
     private PushNotificationConfigStore configStore;
+    private Map<String, PushNotificationPayloadFormatter> formattersByVersion;
 
 
     /**
@@ -52,21 +55,44 @@ public class BasePushNotificationSender implements PushNotificationSender {
         // For CDI proxy creation
         this.httpClient = null;
         this.configStore = null;
+        this.formattersByVersion = Map.of();
     }
 
-    @Inject
     public BasePushNotificationSender(PushNotificationConfigStore configStore) {
         this.httpClient = A2AHttpClientFactory.create();
         this.configStore = configStore;
+        this.formattersByVersion = Map.of();
+    }
+
+    @Inject
+    public BasePushNotificationSender(PushNotificationConfigStore configStore,
+                                       Instance<PushNotificationPayloadFormatter> formatters) {
+        this.httpClient = A2AHttpClientFactory.create();
+        this.configStore = configStore;
+        this.formattersByVersion = new HashMap<>();
+        for (PushNotificationPayloadFormatter f : formatters) {
+            this.formattersByVersion.put(f.targetVersion(), f);
+        }
     }
 
     public BasePushNotificationSender(PushNotificationConfigStore configStore, A2AHttpClient httpClient) {
         this.configStore = configStore;
         this.httpClient = httpClient;
+        this.formattersByVersion = Map.of();
+    }
+
+    public BasePushNotificationSender(PushNotificationConfigStore configStore, A2AHttpClient httpClient,
+                                       List<PushNotificationPayloadFormatter> formatters) {
+        this.configStore = configStore;
+        this.httpClient = httpClient;
+        this.formattersByVersion = new HashMap<>();
+        for (PushNotificationPayloadFormatter f : formatters) {
+            formattersByVersion.put(f.targetVersion(), f);
+        }
     }
 
     @Override
-    public void sendNotification(StreamingEventKind event) {
+    public void sendNotification(StreamingEventKind event, @Nullable Task taskSnapshot) {
         String taskId = extractTaskId(event);
         if (taskId == null) {
             LOGGER.warn("Cannot send push notification: event does not contain taskId");
@@ -84,9 +110,20 @@ public class BasePushNotificationSender implements PushNotificationSender {
           nextPageToken = pageResult.nextPageToken();
         } while (nextPageToken != null);
 
+        Map<String, String> versionsByConfigKey = new HashMap<>();
+        for (TaskPushNotificationConfig config : configs) {
+            String configTaskId = config.taskId();
+            if (configTaskId != null) {
+                String version = configStore.getProtocolVersion(configTaskId, config.id());
+                if (version != null) {
+                    versionsByConfigKey.put(configTaskId + ":" + config.id(), version);
+                }
+            }
+        }
+
         List<CompletableFuture<Boolean>> dispatchResults = configs
                 .stream()
-                .map(pushConfig -> dispatch(event, pushConfig))
+                .map(pushConfig -> dispatch(event, taskSnapshot, pushConfig, versionsByConfigKey))
                 .toList();
         CompletableFuture<Void> allFutures = CompletableFuture.allOf(dispatchResults.toArray(new CompletableFuture[0]));
         CompletableFuture<Boolean> dispatchResult = allFutures.thenApply(v -> dispatchResults.stream()
@@ -123,13 +160,47 @@ public class BasePushNotificationSender implements PushNotificationSender {
         throw new IllegalStateException("Unknown StreamingEventKind: " + event);
     }
 
-    private CompletableFuture<Boolean> dispatch(StreamingEventKind event, TaskPushNotificationConfig pushInfo) {
-        return CompletableFuture.supplyAsync(() -> dispatchNotification(event, pushInfo));
+    private CompletableFuture<Boolean> dispatch(StreamingEventKind event,
+                                                 @Nullable Task taskSnapshot,
+                                                 TaskPushNotificationConfig pushInfo,
+                                                 Map<String, String> versionsByConfigKey) {
+        return CompletableFuture.supplyAsync(() -> dispatchNotification(event, taskSnapshot, pushInfo, versionsByConfigKey));
     }
 
-    private boolean dispatchNotification(StreamingEventKind event, TaskPushNotificationConfig pushInfo) {
+    private boolean dispatchNotification(StreamingEventKind event,
+                                          @Nullable Task taskSnapshot,
+                                          TaskPushNotificationConfig pushInfo,
+                                          Map<String, String> versionsByConfigKey) {
         String url = pushInfo.url();
         String token = pushInfo.token();
+
+        String taskId = pushInfo.taskId();
+        String version = taskId != null ? versionsByConfigKey.get(taskId + ":" + pushInfo.id()) : null;
+        PushNotificationPayloadFormatter formatter = version != null
+                ? formattersByVersion.get(version) : null;
+
+        String body;
+        if (formatter != null) {
+            try {
+                body = formatter.formatPayload(event, taskSnapshot);
+            } catch (Throwable throwable) {
+                LOGGER.error("Error formatting payload with {} formatter: {}",
+                        version, throwable.getMessage(), throwable);
+                return false;
+            }
+            if (body == null) {
+                LOGGER.debug("Formatter for version {} returned null, skipping notification for {}",
+                        version, url);
+                return true;
+            }
+        } else {
+            try {
+                body = JsonUtil.toJson(event);
+            } catch (Throwable throwable) {
+                LOGGER.error("Error serializing StreamingEventKind to JSON: {}", throwable.getMessage(), throwable);
+                return false;
+            }
+        }
 
         A2AHttpClient.PostBuilder postBuilder = httpClient.createPost();
         if (token != null && !token.isBlank()) {
@@ -138,16 +209,6 @@ public class BasePushNotificationSender implements PushNotificationSender {
         if (pushInfo.authentication() != null && pushInfo.authentication().credentials() != null) {
             postBuilder.addHeader("Authorization",
                     pushInfo.authentication().scheme() + " " + pushInfo.authentication().credentials());
-        }
-
-        String body;
-        try {
-            // JsonUtil.toJson automatically wraps StreamingEventKind in StreamResponse format
-            // (task/message/statusUpdate/artifactUpdate) per A2A spec section 4.3.3
-            body = JsonUtil.toJson(event);
-        } catch (Throwable throwable) {
-            LOGGER.error("Error serializing StreamingEventKind to JSON: {}", throwable.getMessage(), throwable);
-            return false;
         }
 
         try {

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/BasePushNotificationSender.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/BasePushNotificationSender.java
@@ -110,20 +110,11 @@ public class BasePushNotificationSender implements PushNotificationSender {
           nextPageToken = pageResult.nextPageToken();
         } while (nextPageToken != null);
 
-        Map<String, String> versionsByConfigKey = new HashMap<>();
-        for (TaskPushNotificationConfig config : configs) {
-            String configTaskId = config.taskId();
-            if (configTaskId != null) {
-                String version = configStore.getProtocolVersion(configTaskId, config.id());
-                if (version != null) {
-                    versionsByConfigKey.put(configTaskId + ":" + config.id(), version);
-                }
-            }
-        }
+        Map<String, String> versionsByConfigId = configStore.getProtocolVersions(taskId);
 
         List<CompletableFuture<Boolean>> dispatchResults = configs
                 .stream()
-                .map(pushConfig -> dispatch(event, taskSnapshot, pushConfig, versionsByConfigKey))
+                .map(pushConfig -> dispatch(event, taskSnapshot, pushConfig, versionsByConfigId))
                 .toList();
         CompletableFuture<Void> allFutures = CompletableFuture.allOf(dispatchResults.toArray(new CompletableFuture[0]));
         CompletableFuture<Boolean> dispatchResult = allFutures.thenApply(v -> dispatchResults.stream()
@@ -163,19 +154,18 @@ public class BasePushNotificationSender implements PushNotificationSender {
     private CompletableFuture<Boolean> dispatch(StreamingEventKind event,
                                                  @Nullable Task taskSnapshot,
                                                  TaskPushNotificationConfig pushInfo,
-                                                 Map<String, String> versionsByConfigKey) {
-        return CompletableFuture.supplyAsync(() -> dispatchNotification(event, taskSnapshot, pushInfo, versionsByConfigKey));
+                                                 Map<String, String> versionsByConfigId) {
+        return CompletableFuture.supplyAsync(() -> dispatchNotification(event, taskSnapshot, pushInfo, versionsByConfigId));
     }
 
     private boolean dispatchNotification(StreamingEventKind event,
                                           @Nullable Task taskSnapshot,
                                           TaskPushNotificationConfig pushInfo,
-                                          Map<String, String> versionsByConfigKey) {
+                                          Map<String, String> versionsByConfigId) {
         String url = pushInfo.url();
         String token = pushInfo.token();
 
-        String taskId = pushInfo.taskId();
-        String version = taskId != null ? versionsByConfigKey.get(taskId + ":" + pushInfo.id()) : null;
+        String version = versionsByConfigId.get(pushInfo.id());
         PushNotificationPayloadFormatter formatter = version != null
                 ? formattersByVersion.get(version) : null;
 

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStore.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStore.java
@@ -10,10 +10,11 @@ import java.util.Map;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import org.a2aproject.sdk.util.Assert;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsParams;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsResult;
 import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
+import org.a2aproject.sdk.util.Assert;
+import org.jspecify.annotations.Nullable;
 
 /**
  * In-memory implementation of the PushNotificationConfigStore interface.
@@ -24,6 +25,7 @@ import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
 public class InMemoryPushNotificationConfigStore implements PushNotificationConfigStore {
 
     private final Map<String, List<TaskPushNotificationConfig>> pushNotificationInfos = Collections.synchronizedMap(new HashMap<>());
+    private final Map<String, String> protocolVersions = Collections.synchronizedMap(new HashMap<>());
 
     @Inject
     public InMemoryPushNotificationConfigStore() {
@@ -50,6 +52,13 @@ public class InMemoryPushNotificationConfigStore implements PushNotificationConf
         notificationConfigList.add(notificationConfig);
         pushNotificationInfos.put(taskId, notificationConfigList);
         return notificationConfig;
+    }
+
+    @Override
+    public TaskPushNotificationConfig setInfo(TaskPushNotificationConfig config, @Nullable String protocolVersion) {
+        TaskPushNotificationConfig result = setInfo(config);
+        protocolVersions.put(result.taskId() + ":" + result.id(), PushNotificationConfigStore.resolveProtocolVersion(protocolVersion));
+        return result;
     }
 
     @Override
@@ -106,8 +115,14 @@ public class InMemoryPushNotificationConfigStore implements PushNotificationConf
                 break;
             }
         }
+        protocolVersions.remove(taskId + ":" + configId);
         if (notificationConfigList.isEmpty()) {
             pushNotificationInfos.remove(taskId);
         }
+    }
+
+    @Override
+    public @Nullable String getProtocolVersion(String taskId, String configId) {
+        return protocolVersions.get(taskId + ":" + configId);
     }
 }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStore.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStore.java
@@ -125,4 +125,16 @@ public class InMemoryPushNotificationConfigStore implements PushNotificationConf
     public @Nullable String getProtocolVersion(String taskId, String configId) {
         return protocolVersions.get(taskId + ":" + configId);
     }
+
+    @Override
+    public Map<String, String> getProtocolVersions(String taskId) {
+        String prefix = taskId + ":";
+        Map<String, String> result = new HashMap<>();
+        protocolVersions.forEach((key, version) -> {
+            if (key.startsWith(prefix)) {
+                result.put(key.substring(prefix.length()), version);
+            }
+        });
+        return result;
+    }
 }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStore.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStore.java
@@ -122,8 +122,9 @@ public class InMemoryPushNotificationConfigStore implements PushNotificationConf
     }
 
     @Override
-    public @Nullable String getProtocolVersion(String taskId, String configId) {
-        return protocolVersions.get(taskId + ":" + configId);
+    public String getProtocolVersion(String taskId, String configId) {
+        String version = protocolVersions.get(taskId + ":" + configId);
+        return PushNotificationConfigStore.resolveProtocolVersion(version);
     }
 
     @Override

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/PushNotificationConfigStore.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/PushNotificationConfigStore.java
@@ -148,10 +148,10 @@ public interface PushNotificationConfigStore {
      *
      * @param taskId the task ID
      * @param configId the push notification configuration ID
-     * @return the protocol version string, or null if not set
+     * @return the protocol version string, defaults to the current protocol version if not set
      */
-    default @Nullable String getProtocolVersion(String taskId, String configId) {
-        return null;
+    default String getProtocolVersion(String taskId, String configId) {
+        return resolveProtocolVersion(null);
     }
 
     /**

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/PushNotificationConfigStore.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/PushNotificationConfigStore.java
@@ -3,6 +3,7 @@ package org.a2aproject.sdk.server.tasks;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsParams;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsResult;
 import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Interface for storing and retrieving push notification configurations for tasks.
@@ -82,6 +83,29 @@ public interface PushNotificationConfigStore {
     TaskPushNotificationConfig setInfo(TaskPushNotificationConfig notificationConfig);
 
     /**
+     * Sets or updates the push notification configuration for a task, along with the
+     * protocol version that registered it.
+     * <p>
+     * This merged method ensures the protocol version is stored using the normalized
+     * config ID (after {@link #setInfo(TaskPushNotificationConfig)} applies defaults).
+     * </p>
+     *
+     * @param notificationConfig the task push notification configuration
+     * @param protocolVersion the protocol version string, or null to use {@link org.a2aproject.sdk.spec.AgentInterface#CURRENT_PROTOCOL_VERSION}
+     * @return the potentially updated configuration (with ID set if it was null)
+     */
+    default TaskPushNotificationConfig setInfo(TaskPushNotificationConfig notificationConfig, @Nullable String protocolVersion) {
+        return setInfo(notificationConfig);
+    }
+
+    /**
+     * Resolves the protocol version, defaulting null to the current protocol version.
+     */
+    static String resolveProtocolVersion(@Nullable String protocolVersion) {
+        return protocolVersion != null ? protocolVersion : org.a2aproject.sdk.spec.AgentInterface.CURRENT_PROTOCOL_VERSION;
+    }
+
+    /**
      * Retrieves push notification configurations for a task with pagination support.
      * <p>
      * Returns all configs if {@code params.pageSize()} is 0. Otherwise, returns up to
@@ -118,5 +142,16 @@ public interface PushNotificationConfigStore {
      * @param configId the push notification configuration ID (null = use task ID)
      */
     void deleteInfo(String taskId, String configId);
+
+    /**
+     * Gets the protocol version associated with a push notification configuration.
+     *
+     * @param taskId the task ID
+     * @param configId the push notification configuration ID
+     * @return the protocol version string, or null if not set
+     */
+    default @Nullable String getProtocolVersion(String taskId, String configId) {
+        return null;
+    }
 
 }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/PushNotificationConfigStore.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/PushNotificationConfigStore.java
@@ -154,4 +154,14 @@ public interface PushNotificationConfigStore {
         return null;
     }
 
+    /**
+     * Gets all protocol versions for a task's push notification configurations in a single call.
+     *
+     * @param taskId the task ID
+     * @return a map of config ID to protocol version (only includes configs with a version set)
+     */
+    default java.util.Map<String, String> getProtocolVersions(String taskId) {
+        return java.util.Map.of();
+    }
+
 }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/PushNotificationPayloadFormatter.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/PushNotificationPayloadFormatter.java
@@ -1,0 +1,12 @@
+package org.a2aproject.sdk.server.tasks;
+
+import org.a2aproject.sdk.spec.StreamingEventKind;
+import org.a2aproject.sdk.spec.Task;
+import org.jspecify.annotations.Nullable;
+
+public interface PushNotificationPayloadFormatter {
+
+    String targetVersion();
+
+    @Nullable String formatPayload(StreamingEventKind event, @Nullable Task taskSnapshot);
+}

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/PushNotificationSender.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/PushNotificationSender.java
@@ -29,8 +29,10 @@ import org.jspecify.annotations.Nullable;
  * {@link BasePushNotificationSender} provides HTTP webhook delivery:
  * <ul>
  *   <li>Retrieves webhook URLs from {@link PushNotificationConfigStore}</li>
- *   <li>Wraps events in StreamResponse format (per A2A spec section 4.3.3)</li>
- *   <li>Sends HTTP POST requests with StreamResponse JSON payload</li>
+ *   <li>Formats payloads according to the protocol version stored with each configuration
+ *       (v1.0 StreamResponse by default; version-specific formatters via
+ *       {@link PushNotificationPayloadFormatter} SPI)</li>
+ *   <li>Sends HTTP POST requests with the formatted JSON payload</li>
  *   <li>Logs errors but doesn't fail the request</li>
  * </ul>
  *
@@ -80,5 +82,37 @@ import org.jspecify.annotations.Nullable;
  */
 public interface PushNotificationSender {
 
+    /**
+     * Sends a push notification containing a streaming event.
+     * <p>
+     * Called after the event has been persisted to {@link TaskStore}. The payload format
+     * depends on the protocol version used to register the push notification configuration.
+     * <ul>
+     *   <li><b>v1.0 (default):</b> The event is wrapped in a StreamResponse format (per A2A spec section 4.3.3)
+     *       with the appropriate oneof field set (task, message, statusUpdate, or artifactUpdate).</li>
+     *   <li><b>v0.3:</b> The payload is a v0.3 {@code Task} JSON object, using the provided {@code taskSnapshot}.
+     *       {@code Message} events are skipped.</li>
+     * </ul>
+     * <p>
+     * Retrieve push notification URLs or messaging configurations from
+     * {@link PushNotificationConfigStore} using the task ID extracted from the event.
+     * </p>
+     * Supported event types:
+     * <ul>
+     *   <li>{@link Task}</li>
+     *   <li>{@link org.a2aproject.sdk.spec.Message}</li>
+     *   <li>{@link org.a2aproject.sdk.spec.TaskStatusUpdateEvent}</li>
+     *   <li>{@link org.a2aproject.sdk.spec.TaskArtifactUpdateEvent}</li>
+     * </ul>
+     * <p>
+     * <b>Error Handling:</b> Log errors but don't throw exceptions. Notifications are
+     * best-effort and should not fail the primary request.
+     * </p>
+     *
+     * @param event the streaming event to send.
+     * @param taskSnapshot the current state of the task after the event has been applied.
+     *                     Used by formatters for older protocol versions that require
+     *                     the full task state in notifications.
+     */
     void sendNotification(StreamingEventKind event, @Nullable Task taskSnapshot);
 }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/PushNotificationSender.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/PushNotificationSender.java
@@ -2,6 +2,7 @@ package org.a2aproject.sdk.server.tasks;
 
 import org.a2aproject.sdk.spec.StreamingEventKind;
 import org.a2aproject.sdk.spec.Task;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Interface for delivering push notifications containing task state updates to external systems.
@@ -52,7 +53,7 @@ import org.a2aproject.sdk.spec.Task;
  *     KafkaProducer<String, StreamingEventKind> producer;
  *
  *     @Override
- *     public void sendNotification(StreamingEventKind event) {
+ *     public void sendNotification(StreamingEventKind event, Task taskSnapshot) {
  *         String taskId = extractTaskId(event);
  *         producer.send("task-updates", taskId, event);
  *     }
@@ -79,30 +80,5 @@ import org.a2aproject.sdk.spec.Task;
  */
 public interface PushNotificationSender {
 
-    /**
-     * Sends a push notification containing a streaming event.
-     * <p>
-     * Called after the event has been persisted to {@link TaskStore}. The event is wrapped
-     * in a StreamResponse format (per A2A spec section 4.3.3) with the appropriate oneof
-     * field set (task, message, statusUpdate, or artifactUpdate).
-     * </p>
-     * <p>
-     * Retrieve push notification URLs or messaging configurations from
-     * {@link PushNotificationConfigStore} using the task ID extracted from the event.
-     * </p>
-     * Supported event types:
-     * <ul>
-     *   <li>{@link Task} - wrapped in StreamResponse.task</li>
-     *   <li>{@link org.a2aproject.sdk.spec.Message} - wrapped in StreamResponse.message</li>
-     *   <li>{@link org.a2aproject.sdk.spec.TaskStatusUpdateEvent} - wrapped in StreamResponse.statusUpdate</li>
-     *   <li>{@link org.a2aproject.sdk.spec.TaskArtifactUpdateEvent} - wrapped in StreamResponse.artifactUpdate</li>
-     * </ul>
-     * <p>
-     * <b>Error Handling:</b> Log errors but don't throw exceptions. Notifications are
-     * best-effort and should not fail the primary request.
-     * </p>
-     *
-     * @param event the streaming event to send (Task, Message, TaskStatusUpdateEvent, or TaskArtifactUpdateEvent)
-     */
-    void sendNotification(StreamingEventKind event);
+    void sendNotification(StreamingEventKind event, @Nullable Task taskSnapshot);
 }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/TaskManager.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/TaskManager.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.a2aproject.sdk.spec.A2AError;
 import org.a2aproject.sdk.spec.A2AServerException;
@@ -62,12 +63,25 @@ public class TaskManager {
     }
 
     boolean saveTaskEvent(Task task, boolean isReplicated) throws A2AServerException {
+        return saveTaskEvent(task, isReplicated, null);
+    }
+
+    boolean saveTaskEvent(Task task, boolean isReplicated, @Nullable AtomicReference<Task> taskSnapshot)
+            throws A2AServerException {
         checkIdsAndUpdateIfNecessary(task.id(), task.contextId());
         Task savedTask = saveTask(task, isReplicated);
+        if (taskSnapshot != null) {
+            taskSnapshot.set(savedTask);
+        }
         return savedTask.status() != null && savedTask.status().state() != null && savedTask.status().state().isFinal();
     }
 
     boolean saveTaskEvent(TaskStatusUpdateEvent event, boolean isReplicated) throws A2AServerException {
+        return saveTaskEvent(event, isReplicated, null);
+    }
+
+    boolean saveTaskEvent(TaskStatusUpdateEvent event, boolean isReplicated, @Nullable AtomicReference<Task> taskSnapshot)
+            throws A2AServerException {
         checkIdsAndUpdateIfNecessary(event.taskId(), event.contextId());
         Task task = ensureTask(event.taskId(), event.contextId());
 
@@ -90,10 +104,18 @@ public class TaskManager {
 
         task = builder.build();
         Task savedTask = saveTask(task, isReplicated);
+        if (taskSnapshot != null) {
+            taskSnapshot.set(savedTask);
+        }
         return savedTask.status() != null && savedTask.status().state() != null && savedTask.status().state().isFinal();
     }
 
     boolean saveTaskEvent(TaskArtifactUpdateEvent event, boolean isReplicated) throws A2AServerException {
+        return saveTaskEvent(event, isReplicated, null);
+    }
+
+    boolean saveTaskEvent(TaskArtifactUpdateEvent event, boolean isReplicated, @Nullable AtomicReference<Task> taskSnapshot)
+            throws A2AServerException {
         checkIdsAndUpdateIfNecessary(event.taskId(), event.contextId());
         Task task = ensureTask(event.taskId(), event.contextId());
         // taskId is guaranteed to be non-null after checkIdsAndUpdateIfNecessary
@@ -103,17 +125,25 @@ public class TaskManager {
         }
         task = appendArtifactToTask(task, event, nonNullTaskId);
         Task savedTask = saveTask(task, isReplicated);
+        if (taskSnapshot != null) {
+            taskSnapshot.set(savedTask);
+        }
         return savedTask.status() != null && savedTask.status().state() != null && savedTask.status().state().isFinal();
     }
 
     public boolean process(Event event, boolean isReplicated) throws A2AServerException {
+        return process(event, isReplicated, null);
+    }
+
+    public boolean process(Event event, boolean isReplicated, @Nullable AtomicReference<Task> taskSnapshot)
+            throws A2AServerException {
         boolean isFinal = false;
         if (event instanceof Task task) {
-            isFinal = saveTaskEvent(task, isReplicated);
+            isFinal = saveTaskEvent(task, isReplicated, taskSnapshot);
         } else if (event instanceof TaskStatusUpdateEvent taskStatusUpdateEvent) {
-            isFinal = saveTaskEvent(taskStatusUpdateEvent, isReplicated);
+            isFinal = saveTaskEvent(taskStatusUpdateEvent, isReplicated, taskSnapshot);
         } else if (event instanceof TaskArtifactUpdateEvent taskArtifactUpdateEvent) {
-            isFinal = saveTaskEvent(taskArtifactUpdateEvent, isReplicated);
+            isFinal = saveTaskEvent(taskArtifactUpdateEvent, isReplicated, taskSnapshot);
         } else if (event instanceof A2AError) {
             // A2AError events trigger automatic transition to FAILED state
             // Error details are NOT persisted in TaskStore (client-specific)
@@ -144,7 +174,7 @@ public class TaskManager {
                         .contextId(errorContextId)
                         .status(new TaskStatus(TASK_STATE_FAILED))
                         .build();
-                isFinal = saveTaskEvent(failedEvent, isReplicated);
+                isFinal = saveTaskEvent(failedEvent, isReplicated, taskSnapshot);
             } else {
                 // Can't update status without contextId, but error is still terminal
                 LOGGER.debug("A2AError event for task {} without contextId - skipping state update", taskId);

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/EventConsumerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/EventConsumerTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 
 public class EventConsumerTest {
 
-    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = task -> {};
+    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = (event, snapshot) -> {};
     private static final String TASK_ID = "123";  // Must match MINIMAL_TASK id
 
     private EventQueue eventQueue;

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/EventQueueTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/EventQueueTest.java
@@ -55,7 +55,7 @@ public class EventQueueTest {
             }
             """;
 
-    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = task -> {};
+    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = (event, snapshot) -> {};
 
     @BeforeEach
     public void init() {

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/InMemoryQueueManagerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/InMemoryQueueManagerTest.java
@@ -28,7 +28,7 @@ public class InMemoryQueueManagerTest {
     private InMemoryTaskStore taskStore;
     private MainEventBus mainEventBus;
     private MainEventBusProcessor mainEventBusProcessor;
-    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = task -> {};
+    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = (event, snapshot) -> {};
 
     @BeforeEach
     public void setUp() {

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/MainEventBusProcessorExceptionTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/MainEventBusProcessorExceptionTest.java
@@ -45,7 +45,7 @@ import ch.qos.logback.core.read.ListAppender;
  */
 public class MainEventBusProcessorExceptionTest {
 
-    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = task -> {};
+    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = (event, snapshot) -> {};
     private static final String TASK_ID = "test-task-123";
 
     private MainEventBus mainEventBus;

--- a/server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/AbstractA2ARequestHandlerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/AbstractA2ARequestHandlerTest.java
@@ -70,7 +70,7 @@ public class AbstractA2ARequestHandlerTest {
     private static final String PREFERRED_TRANSPORT = "preferred-transport";
     private static final String A2A_REQUESTHANDLER_TEST_PROPERTIES = "/a2a-requesthandler-test.properties";
 
-    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = task -> {};
+    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = (event, snapshot) -> {};
 
     protected AgentExecutor executor;
     protected TaskStore taskStore;

--- a/server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandlerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandlerTest.java
@@ -8,9 +8,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -36,9 +39,11 @@ import org.a2aproject.sdk.spec.InvalidParamsError;
 import org.a2aproject.sdk.spec.Message;
 import org.a2aproject.sdk.spec.MessageSendConfiguration;
 import org.a2aproject.sdk.spec.MessageSendParams;
+import org.a2aproject.sdk.spec.StreamingEventKind;
 import org.a2aproject.sdk.spec.Task;
 import org.a2aproject.sdk.spec.TaskArtifactUpdateEvent;
 import org.a2aproject.sdk.spec.TaskNotFoundError;
+import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
 import org.a2aproject.sdk.spec.TaskState;
 import org.a2aproject.sdk.spec.TaskStatus;
 import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
@@ -72,11 +77,12 @@ public class DefaultRequestHandlerTest {
         .parts(new TextPart("test message"))
         .build();
 
-    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = task -> {};
+    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = (event, snapshot) -> {};
 
     // Test infrastructure components
     protected AgentExecutor executor;
     protected TaskStore taskStore;
+    protected PushNotificationConfigStore pushConfigStore;
     protected RequestHandler requestHandler;
     protected InMemoryQueueManager queueManager;
     protected MainEventBus mainEventBus;
@@ -109,7 +115,7 @@ public class DefaultRequestHandlerTest {
         InMemoryTaskStore inMemoryTaskStore = new InMemoryTaskStore();
         taskStore = inMemoryTaskStore;
 
-        PushNotificationConfigStore pushConfigStore = new InMemoryPushNotificationConfigStore();
+        pushConfigStore = new InMemoryPushNotificationConfigStore();
 
         // Create MainEventBus and MainEventBusProcessor
         mainEventBus = new MainEventBus();
@@ -904,5 +910,214 @@ public class DefaultRequestHandlerTest {
 
         // Cleanup: release the first agent
         releaseFirstAgent.countDown();
+    }
+
+    // ── Protocol version propagation tests ──────────────────────────────────────
+
+    private static ServerCallContext contextWithVersion(String version) {
+        return new ServerCallContext(null, Map.of(), Set.of(), version);
+    }
+
+    /**
+     * Verify that onCreateTaskPushNotificationConfig stores the protocol version
+     * from the ServerCallContext in the PushNotificationConfigStore.
+     */
+    @Test
+    void testVersionStored_OnCreateTaskPushNotificationConfig() throws Exception {
+        // Arrange: create a task directly in the store so the handler can find it
+        String taskId = "version-test-task-1";
+        Task task = new Task(
+            taskId,
+            "ctx-1",
+            new TaskStatus(TaskState.TASK_STATE_WORKING),
+            null,
+            null,
+            null
+        );
+        taskStore.save(task, false);
+
+        TaskPushNotificationConfig pushConfig = TaskPushNotificationConfig.builder()
+            .id("")
+            .taskId(taskId)
+            .url("http://example.com/webhook")
+            .build();
+
+        // Act
+        requestHandler.onCreateTaskPushNotificationConfig(pushConfig, contextWithVersion("1.0"));
+
+        // Assert: version is stored; configId defaults to taskId when id is empty
+        assertEquals("1.0", pushConfigStore.getProtocolVersion(taskId, taskId),
+            "Protocol version should be stored for the push notification config");
+    }
+
+    /**
+     * Verify that onMessageSend stores the protocol version when the request
+     * includes a push notification config (new task path).
+     */
+    @Test
+    void testVersionStored_OnMessageSend_NewTask() throws Exception {
+        // Arrange: agent completes immediately
+        agentExecutorExecute = (context, emitter) -> emitter.complete();
+
+        TaskPushNotificationConfig pushConfig = TaskPushNotificationConfig.builder()
+            .id("")
+            .url("http://example.com/webhook")
+            .build();
+        MessageSendConfiguration config = MessageSendConfiguration.builder()
+            .returnImmediately(true)
+            .acceptedOutputModes(List.of())
+            .taskPushNotificationConfig(pushConfig)
+            .build();
+        MessageSendParams params = MessageSendParams.builder()
+            .message(MESSAGE)
+            .configuration(config)
+            .build();
+
+        // Act
+        EventKind eventKind = requestHandler.onMessageSend(params, contextWithVersion("1.0"));
+
+        // Assert
+        assertInstanceOf(Task.class, eventKind);
+        Task result = (Task) eventKind;
+        String taskId = result.id();
+
+        assertEquals("1.0", pushConfigStore.getProtocolVersion(taskId, taskId),
+            "Protocol version should be stored when push config is provided via onMessageSend");
+    }
+
+    /**
+     * Verify that onMessageSend stores the protocol version when the request
+     * includes a push notification config on a follow-up to an existing task.
+     */
+    @Test
+    void testVersionStored_OnMessageSend_ExistingTask() throws Exception {
+        // Arrange: create an initial task (no push config) — agent stays active
+        CountDownLatch agentStarted = new CountDownLatch(1);
+        CountDownLatch agentRelease = new CountDownLatch(1);
+
+        agentExecutorExecute = (context, emitter) -> {
+            emitter.startWork();
+            agentStarted.countDown();
+            try {
+                agentRelease.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            emitter.complete();
+        };
+
+        MessageSendParams initialParams = MessageSendParams.builder()
+            .message(MESSAGE)
+            .configuration(DEFAULT_CONFIG)
+            .build();
+
+        EventKind initialResult = requestHandler.onMessageSend(initialParams, NULL_CONTEXT);
+        assertInstanceOf(Task.class, initialResult);
+        Task existingTask = (Task) initialResult;
+        assertTrue(agentStarted.await(5, TimeUnit.SECONDS), "Agent should start");
+
+        try {
+            // Now set up agent for the follow-up
+            agentExecutorExecute = (context, emitter) -> emitter.complete();
+
+            // Follow-up message WITH push config and version context
+            TaskPushNotificationConfig pushConfig = TaskPushNotificationConfig.builder()
+                .id("")
+                .url("http://example.com/webhook")
+                .build();
+            MessageSendConfiguration followUpConfig = MessageSendConfiguration.builder()
+                .returnImmediately(true)
+                .acceptedOutputModes(List.of())
+                .taskPushNotificationConfig(pushConfig)
+                .build();
+            Message followUpMsg = Message.builder()
+                .messageId("follow-up-version-test")
+                .role(Message.Role.ROLE_USER)
+                .taskId(existingTask.id())
+                .parts(new TextPart("follow up"))
+                .build();
+            MessageSendParams followUpParams = MessageSendParams.builder()
+                .message(followUpMsg)
+                .configuration(followUpConfig)
+                .build();
+
+            // Act
+            EventKind result = requestHandler.onMessageSend(followUpParams, contextWithVersion("1.0"));
+
+            // Assert
+            assertInstanceOf(Task.class, result);
+            String taskId = existingTask.id();
+            assertEquals("1.0", pushConfigStore.getProtocolVersion(taskId, taskId),
+                "Protocol version should be stored for push config on existing task");
+        } finally {
+            agentRelease.countDown();
+        }
+    }
+
+    /**
+     * Verify that onMessageSendStream stores the protocol version when the request
+     * includes a push notification config (new task, streaming path).
+     */
+    @Test
+    void testVersionStored_OnMessageSendStream_NewTask() throws Exception {
+        // Arrange: agent completes immediately
+        agentExecutorExecute = (context, emitter) -> emitter.complete();
+
+        TaskPushNotificationConfig pushConfig = TaskPushNotificationConfig.builder()
+            .id("")
+            .url("http://example.com/webhook")
+            .build();
+        MessageSendConfiguration config = MessageSendConfiguration.builder()
+            .returnImmediately(true)
+            .acceptedOutputModes(List.of())
+            .taskPushNotificationConfig(pushConfig)
+            .build();
+        MessageSendParams params = MessageSendParams.builder()
+            .message(MESSAGE)
+            .configuration(config)
+            .build();
+
+        // Act
+        Flow.Publisher<StreamingEventKind> publisher = requestHandler.onMessageSendStream(
+            params, contextWithVersion("1.0"));
+
+        AtomicReference<String> taskIdRef = new AtomicReference<>();
+        CountDownLatch streamDone = new CountDownLatch(1);
+        publisher.subscribe(new Flow.Subscriber<>() {
+            Flow.Subscription subscription;
+
+            @Override
+            public void onSubscribe(Flow.Subscription s) {
+                subscription = s;
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(StreamingEventKind item) {
+                if (item instanceof Task t) {
+                    taskIdRef.set(t.id());
+                } else if (item instanceof TaskStatusUpdateEvent e) {
+                    taskIdRef.set(e.taskId());
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                streamDone.countDown();
+            }
+
+            @Override
+            public void onComplete() {
+                streamDone.countDown();
+            }
+        });
+
+        assertTrue(streamDone.await(5, TimeUnit.SECONDS), "Stream should complete");
+        String taskId = taskIdRef.get();
+        assertNotNull(taskId, "Should have received a task ID from the stream");
+
+        // Assert
+        assertEquals("1.0", pushConfigStore.getProtocolVersion(taskId, taskId),
+            "Protocol version should be stored when push config is provided via onMessageSendStream");
     }
 }

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/AgentEmitterTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/AgentEmitterTest.java
@@ -43,7 +43,7 @@ public class AgentEmitterTest {
 
     private static final List<Part<?>> SAMPLE_PARTS = List.of(new TextPart("Test message"));
 
-    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = task -> {};
+    private static final PushNotificationSender NOOP_PUSHNOTIFICATION_SENDER = (event, snapshot) -> {};
 
     EventQueue eventQueue;
     private MainEventBus mainEventBus;

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStoreTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStoreTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import org.a2aproject.sdk.client.http.A2AHttpClient;
 import org.a2aproject.sdk.client.http.A2AHttpResponse;
 import org.a2aproject.sdk.common.A2AHeaders;
+import org.a2aproject.sdk.spec.AgentInterface;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsParams;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsResult;
 import org.a2aproject.sdk.spec.Task;
@@ -601,7 +602,7 @@ class InMemoryPushNotificationConfigStoreTest {
                 .id(configId).taskId(taskId).url("http://example.com/hook").build();
         configStore.setInfo(config);
 
-        assertNull(configStore.getProtocolVersion(taskId, configId));
+        assertEquals(AgentInterface.CURRENT_PROTOCOL_VERSION, configStore.getProtocolVersion(taskId, configId));
 
         configStore.setInfo(config, "0.3");
         assertEquals("0.3", configStore.getProtocolVersion(taskId, configId));
@@ -618,12 +619,12 @@ class InMemoryPushNotificationConfigStoreTest {
         assertEquals("0.3", configStore.getProtocolVersion(taskId, configId));
 
         configStore.deleteInfo(taskId, configId);
-        assertNull(configStore.getProtocolVersion(taskId, configId));
+        assertEquals(AgentInterface.CURRENT_PROTOCOL_VERSION, configStore.getProtocolVersion(taskId, configId));
     }
 
     @Test
-    public void testGetProtocolVersionReturnsNullForUnknownConfig() {
-        assertNull(configStore.getProtocolVersion("nonexistent", "nonexistent"));
+    public void testGetProtocolVersionReturnsDefaultForUnknownConfig() {
+        assertEquals(AgentInterface.CURRENT_PROTOCOL_VERSION, configStore.getProtocolVersion("nonexistent", "nonexistent"));
     }
 
     @Test

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStoreTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStoreTest.java
@@ -249,7 +249,7 @@ class InMemoryPushNotificationConfigStoreTest {
         // Mock successful HTTP response
         setupBasicMockHttpResponse();
 
-        notificationSender.sendNotification(task);
+        notificationSender.sendNotification(task, null);
 
         // Verify HTTP client was called
         ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
@@ -279,7 +279,7 @@ class InMemoryPushNotificationConfigStoreTest {
         when(mockPostBuilder.post()).thenReturn(mockHttpResponse);
         when(mockHttpResponse.success()).thenReturn(true);
 
-        notificationSender.sendNotification(task);
+        notificationSender.sendNotification(task, null);
 
         // Verify HTTP client was called with proper authentication
         ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
@@ -301,7 +301,7 @@ class InMemoryPushNotificationConfigStoreTest {
         String taskId = "task_send_no_config";
         Task task = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
 
-        notificationSender.sendNotification(task);
+        notificationSender.sendNotification(task, null);
 
         // Verify HTTP client was never called
         verify(mockHttpClient, never()).createPost();
@@ -315,7 +315,7 @@ class InMemoryPushNotificationConfigStoreTest {
         configStore.setInfo(config);
 
         setupBasicMockHttpResponse();
-        notificationSender.sendNotification(task);
+        notificationSender.sendNotification(task, null);
         verifyHttpCallWithoutToken(config, task, "");
     }
 
@@ -327,7 +327,7 @@ class InMemoryPushNotificationConfigStoreTest {
         configStore.setInfo(config);
 
         setupBasicMockHttpResponse();
-        notificationSender.sendNotification(task);
+        notificationSender.sendNotification(task, null);
         verifyHttpCallWithoutToken(config, task, "   ");
     }
 
@@ -591,6 +591,39 @@ class InMemoryPushNotificationConfigStoreTest {
         assertNotNull(result);
         assertTrue(result.configs().isEmpty(), "Should return empty list for non-existent task");
         assertNull(result.nextPageToken(), "Should not have nextPageToken for empty result");
+    }
+
+    @Test
+    public void testSetAndGetProtocolVersion() {
+        String taskId = "task1";
+        String configId = "cfg1";
+        TaskPushNotificationConfig config = TaskPushNotificationConfig.builder()
+                .id(configId).taskId(taskId).url("http://example.com/hook").build();
+        configStore.setInfo(config);
+
+        assertNull(configStore.getProtocolVersion(taskId, configId));
+
+        configStore.setInfo(config, "0.3");
+        assertEquals("0.3", configStore.getProtocolVersion(taskId, configId));
+    }
+
+    @Test
+    public void testDeleteInfoCleansUpProtocolVersion() {
+        String taskId = "task1";
+        String configId = "cfg1";
+        TaskPushNotificationConfig config = TaskPushNotificationConfig.builder()
+                .id(configId).taskId(taskId).url("http://example.com/hook").build();
+        configStore.setInfo(config, "0.3");
+
+        assertEquals("0.3", configStore.getProtocolVersion(taskId, configId));
+
+        configStore.deleteInfo(taskId, configId);
+        assertNull(configStore.getProtocolVersion(taskId, configId));
+    }
+
+    @Test
+    public void testGetProtocolVersionReturnsNullForUnknownConfig() {
+        assertNull(configStore.getProtocolVersion("nonexistent", "nonexistent"));
     }
 
     @Test

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/PushNotificationSenderTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/PushNotificationSenderTest.java
@@ -25,13 +25,14 @@ import org.a2aproject.sdk.jsonrpc.common.json.JsonUtil;
 import org.a2aproject.sdk.spec.Artifact;
 import org.a2aproject.sdk.spec.Message;
 import org.a2aproject.sdk.spec.StreamingEventKind;
-import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
 import org.a2aproject.sdk.spec.Task;
 import org.a2aproject.sdk.spec.TaskArtifactUpdateEvent;
+import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
 import org.a2aproject.sdk.spec.TaskState;
 import org.a2aproject.sdk.spec.TaskStatus;
 import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
 import org.a2aproject.sdk.spec.TextPart;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -164,7 +165,7 @@ public class PushNotificationSenderTest {
         // Set up latch to wait for async completion
         testHttpClient.latch = new CountDownLatch(1);
 
-        sender.sendNotification(taskData);
+        sender.sendNotification(taskData, null);
 
         // Wait for the async operation to complete
         assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS), "HTTP call should complete within 5 seconds");
@@ -218,7 +219,7 @@ public class PushNotificationSenderTest {
         // Set up latch to wait for async completion
         testHttpClient.latch = new CountDownLatch(1);
 
-        sender.sendNotification(taskData);
+        sender.sendNotification(taskData, null);
 
         // Wait for the async operation to complete
         assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS), "HTTP call should complete within 5 seconds");
@@ -249,7 +250,7 @@ public class PushNotificationSenderTest {
         // Set up latch to wait for async completion
         testHttpClient.latch = new CountDownLatch(1);
 
-        sender.sendNotification(taskData);
+        sender.sendNotification(taskData, null);
 
         // Wait for the async operation to complete
         assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS), "HTTP call should complete within 5 seconds");
@@ -279,7 +280,7 @@ public class PushNotificationSenderTest {
         Task taskData = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
 
         // Don't set any configuration in the store
-        sender.sendNotification(taskData);
+        sender.sendNotification(taskData, null);
 
         // Verify no HTTP calls were made
         assertEquals(0, testHttpClient.events.size());
@@ -309,7 +310,7 @@ public class PushNotificationSenderTest {
         // Set up latch to wait for async completion (2 calls expected)
         testHttpClient.latch = new CountDownLatch(2);
 
-        sender.sendNotification(taskData);
+        sender.sendNotification(taskData, null);
 
         // Wait for the async operations to complete
         assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS), "HTTP calls should complete within 5 seconds");
@@ -342,7 +343,7 @@ public class PushNotificationSenderTest {
         testHttpClient.shouldThrowException = true;
 
         // This should not throw an exception - errors should be handled gracefully
-        sender.sendNotification(taskData);
+        sender.sendNotification(taskData, null);
 
         // Verify no events were successfully processed due to the error
         assertEquals(0, testHttpClient.events.size());
@@ -364,7 +365,7 @@ public class PushNotificationSenderTest {
         // Set up latch to wait for async completion
         testHttpClient.latch = new CountDownLatch(1);
 
-        sender.sendNotification(message);
+        sender.sendNotification(message, null);
 
         // Wait for the async operation to complete
         assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS), "HTTP call should complete within 5 seconds");
@@ -397,7 +398,7 @@ public class PushNotificationSenderTest {
         // Set up latch to wait for async completion
         testHttpClient.latch = new CountDownLatch(1);
 
-        sender.sendNotification(statusUpdate);
+        sender.sendNotification(statusUpdate, null);
 
         // Wait for the async operation to complete
         assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS), "HTTP call should complete within 5 seconds");
@@ -436,7 +437,7 @@ public class PushNotificationSenderTest {
         // Set up latch to wait for async completion
         testHttpClient.latch = new CountDownLatch(1);
 
-        sender.sendNotification(artifactUpdate);
+        sender.sendNotification(artifactUpdate, null);
 
         // Wait for the async operation to complete
         assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS), "HTTP call should complete within 5 seconds");
@@ -451,5 +452,68 @@ public class PushNotificationSenderTest {
         // Verify StreamResponse wrapper with 'artifactUpdate' discriminator
         String rawBody = testHttpClient.rawBodies.get(0);
         assertTrue(rawBody.contains("\"artifactUpdate\""), "Raw body should contain 'artifactUpdate' discriminator for StreamResponse");
+    }
+
+    @Test
+    public void testSendNotificationUsesFormatterForVersionedConfig() throws InterruptedException {
+        String taskId = "task_formatter_test";
+        Task taskData = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
+
+        TaskPushNotificationConfig config = TaskPushNotificationConfig.builder()
+                .url("http://notify.me/here")
+                .id("cfg1")
+                .taskId(taskId)
+                .build();
+        configStore.setInfo(config, "0.3");
+
+        PushNotificationPayloadFormatter formatter = new PushNotificationPayloadFormatter() {
+            @Override
+            public String targetVersion() { return "0.3"; }
+
+            @Override
+            public @Nullable String formatPayload(StreamingEventKind event, @Nullable Task snapshot) {
+                return "{\"id\":\"" + taskId + "\",\"kind\":\"task\",\"formatted\":true}";
+            }
+        };
+
+        BasePushNotificationSender formatterSender = new BasePushNotificationSender(
+                configStore, testHttpClient, List.of(formatter));
+        testHttpClient.latch = new CountDownLatch(1);
+
+        formatterSender.sendNotification(taskData, taskData);
+
+        assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS));
+        assertEquals(1, testHttpClient.rawBodies.size());
+        assertTrue(testHttpClient.rawBodies.get(0).contains("\"formatted\":true"));
+    }
+
+    @Test
+    public void testSendNotificationSkipsWhenFormatterReturnsNull() throws InterruptedException {
+        String taskId = "task_formatter_skip";
+        Task taskData = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
+
+        TaskPushNotificationConfig config = TaskPushNotificationConfig.builder()
+                .url("http://notify.me/here")
+                .id("cfg1")
+                .taskId(taskId)
+                .build();
+        configStore.setInfo(config, "0.3");
+
+        PushNotificationPayloadFormatter formatter = new PushNotificationPayloadFormatter() {
+            @Override
+            public String targetVersion() { return "0.3"; }
+
+            @Override
+            public @Nullable String formatPayload(StreamingEventKind event, @Nullable Task snapshot) {
+                return null;
+            }
+        };
+
+        BasePushNotificationSender formatterSender = new BasePushNotificationSender(
+                configStore, testHttpClient, List.of(formatter));
+
+        formatterSender.sendNotification(taskData, taskData);
+
+        assertTrue(testHttpClient.rawBodies.isEmpty());
     }
 }

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/ResultAggregatorTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/ResultAggregatorTest.java
@@ -248,7 +248,7 @@ public class ResultAggregatorTest {
         InMemoryTaskStore taskStore = new InMemoryTaskStore();
         InMemoryQueueManager queueManager =
             new InMemoryQueueManager(new MockTaskStateProvider(), mainEventBus);
-        MainEventBusProcessor processor = new MainEventBusProcessor(mainEventBus, taskStore, task -> {}, queueManager);
+        MainEventBusProcessor processor = new MainEventBusProcessor(mainEventBus, taskStore, (event, snapshot) -> {}, queueManager);
         EventQueueUtil.start(processor);
 
         EventQueue queue = queueManager.getEventQueueBuilder(taskId).build().tap();
@@ -296,7 +296,7 @@ public class ResultAggregatorTest {
         InMemoryTaskStore taskStore = new InMemoryTaskStore();
         InMemoryQueueManager queueManager =
             new InMemoryQueueManager(new MockTaskStateProvider(), mainEventBus);
-        MainEventBusProcessor processor = new MainEventBusProcessor(mainEventBus, taskStore, task -> {}, queueManager);
+        MainEventBusProcessor processor = new MainEventBusProcessor(mainEventBus, taskStore, (event, snapshot) -> {}, queueManager);
         EventQueueUtil.start(processor);
 
         EventQueue queue = queueManager.getEventQueueBuilder(taskId).build().tap();
@@ -338,7 +338,7 @@ public class ResultAggregatorTest {
         InMemoryTaskStore taskStore = new InMemoryTaskStore();
         InMemoryQueueManager queueManager =
             new InMemoryQueueManager(new MockTaskStateProvider(), mainEventBus);
-        MainEventBusProcessor processor = new MainEventBusProcessor(mainEventBus, taskStore, task -> {}, queueManager);
+        MainEventBusProcessor processor = new MainEventBusProcessor(mainEventBus, taskStore, (event, snapshot) -> {}, queueManager);
         EventQueueUtil.start(processor);
 
         EventQueue queue = queueManager.getEventQueueBuilder(taskId).build().tap();
@@ -385,7 +385,7 @@ public class ResultAggregatorTest {
         InMemoryTaskStore taskStore = new InMemoryTaskStore();
         InMemoryQueueManager queueManager =
             new InMemoryQueueManager(new MockTaskStateProvider(), mainEventBus);
-        MainEventBusProcessor processor = new MainEventBusProcessor(mainEventBus, taskStore, task -> {}, queueManager);
+        MainEventBusProcessor processor = new MainEventBusProcessor(mainEventBus, taskStore, (event, snapshot) -> {}, queueManager);
         EventQueueUtil.start(processor);
 
         EventQueue queue = queueManager.getEventQueueBuilder(taskId).build().tap();
@@ -431,7 +431,7 @@ public class ResultAggregatorTest {
         InMemoryTaskStore taskStore = new InMemoryTaskStore();
         InMemoryQueueManager queueManager =
             new InMemoryQueueManager(new MockTaskStateProvider(), mainEventBus);
-        MainEventBusProcessor processor = new MainEventBusProcessor(mainEventBus, taskStore, task -> {}, queueManager);
+        MainEventBusProcessor processor = new MainEventBusProcessor(mainEventBus, taskStore, (event, snapshot) -> {}, queueManager);
         EventQueueUtil.start(processor);
 
         EventQueue queue = queueManager.getEventQueueBuilder(taskId).build().tap();

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/TaskManagerSnapshotTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/TaskManagerSnapshotTest.java
@@ -1,0 +1,75 @@
+package org.a2aproject.sdk.server.tasks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.a2aproject.sdk.spec.Task;
+import org.a2aproject.sdk.spec.TaskState;
+import org.a2aproject.sdk.spec.TaskStatus;
+import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TaskManagerSnapshotTest {
+
+    private InMemoryTaskStore taskStore;
+
+    @BeforeEach
+    void setUp() {
+        taskStore = new InMemoryTaskStore();
+    }
+
+    @Test
+    void snapshotCapturedForTaskEvent() throws Exception {
+        Task task = Task.builder()
+                .id("t1").contextId("c1")
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
+                .build();
+
+        AtomicReference<Task> snapshot = new AtomicReference<>();
+        TaskManager tm = new TaskManager("t1", "c1", taskStore, null);
+        tm.process(task, false, snapshot);
+
+        assertNotNull(snapshot.get());
+        assertEquals("t1", snapshot.get().id());
+    }
+
+    @Test
+    void snapshotCapturedForStatusUpdateEvent() throws Exception {
+        // Seed a task first
+        Task task = Task.builder()
+                .id("t1").contextId("c1")
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
+                .build();
+        taskStore.save(task, false);
+
+        TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
+                .taskId("t1").contextId("c1")
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
+                .build();
+
+        AtomicReference<Task> snapshot = new AtomicReference<>();
+        TaskManager tm = new TaskManager("t1", "c1", taskStore, null);
+        tm.process(event, false, snapshot);
+
+        assertNotNull(snapshot.get());
+        assertEquals(TaskState.TASK_STATE_WORKING, snapshot.get().status().state());
+    }
+
+    @Test
+    void snapshotNullWhenNotProvided() throws Exception {
+        Task task = Task.builder()
+                .id("t1").contextId("c1")
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
+                .build();
+
+        TaskManager tm = new TaskManager("t1", "c1", taskStore, null);
+        // Old signature still works, no snapshot
+        tm.process(task, false);
+
+        // Just confirm the old method doesn't crash
+        assertNotNull(taskStore.get("t1"));
+    }
+}


### PR DESCRIPTION
The protocol version used when creating a TaskPushNotificationConfig dictates the wire format of subsequent push notifications. v0.3 configs receive plain Task payloads; v1.0 configs receive StreamResponse-wrapped events.

Key changes:
- PushNotificationPayloadFormatter SPI for version-specific serialization
- Protocol version tracked in PushNotificationConfigStore alongside configs
- BasePushNotificationSender resolves formatter per config at dispatch time
- JPA store persists protocol_version column

Tested the compat-0.3/tck server with https://github.com/a2aproject/a2a-tck/pull/178