### PR TITLE
docs: document v0.3 compatibility layer and standardize terminology

### DIFF
--- a/.claude/architecture/compatibility_0.3.md
+++ b/.claude/architecture/compatibility_0.3.md
@@ -424,27 +424,22 @@ The `server-conversion` module produces a test-jar containing shared test infras
 </dependency>
 ```
 
-**2. Check the agent card and choose the right client:**
+**2. Find the v0.3 interface and create the client:**
 
 ```java
 AgentCard card = // ... fetch agent card from /.well-known/agent-card.json
 
-for (AgentInterface iface : card.supportedInterfaces()) {
-    if ("0.3".equals(iface.protocolVersion())) {
-        // Use the compat client for v0.3 agents
-        Client_v0_3 client = ClientBuilder_v0_3.forUrl(iface.url())
-                .transport("JSONRPC")
-                .build();
-    } else if ("1.0".equals(iface.protocolVersion())) {
-        // Use the standard client for v1.0 agents
-        Client client = ClientBuilder.forUrl(iface.url())
-                .transport("JSONRPC")
-                .build();
-    }
-}
-```
+// Find the v0.3 interface from the agent card
+AgentInterface v03Interface = card.supportedInterfaces().stream()
+        .filter(iface -> "0.3".equals(iface.protocolVersion()))
+        .findFirst()
+        .orElseThrow();
 
-**3. Use the v0.3 client API:**
+// Create the v0.3 compatibility client
+Client_v0_3 client = ClientBuilder_v0_3.forUrl(v03Interface.url())
+        .withTransport(JSONRPCTransport_v0_3.class, new JSONRPCTransportConfigBuilder_v0_3())
+        .build();
+```
 
 `Client_v0_3` exposes only operations available in v0.3. Return types are v0.3 `org.a2aproject.sdk.compat03.spec` domain objects.
 

--- a/.claude/architecture/compatibility_0.3.md
+++ b/.claude/architecture/compatibility_0.3.md
@@ -1,6 +1,6 @@
-# PRD: A2A Protocol 0.3 Backward Compatibility Layer
+# A2A Protocol 0.3 Backward Compatibility Layer
 
-> **Goal**: Allow the A2A Java SDK (v1.0) to interoperate with agents running protocol v0.3 through a dedicated compatibility layer.
+> The A2A Java SDK (v1.0) interoperates with agents running protocol v0.3 through a dedicated compatibility layer.
 
 ---
 
@@ -24,6 +24,8 @@ The A2A protocol evolved from v0.3 to v1.0 with significant breaking changes. Ex
 - TCK conformance tests for v0.3
 - Integration test infrastructure (test-jar) for validating conversion layer
 - Inclusion in the SDK BOM as separate optional dependencies
+- Multi-version server deployment: `reference/multiversion-jsonrpc` and `reference/multiversion-rest` modules that dispatch requests to v1.0 or v0.3 handlers based on `A2A-Version` header via `VersionRouter`
+- Multi-version integration tests under `tests/reference/{jsonrpc,rest,grpc}` (package `org.a2aproject.sdk.tests.multiversion`)
 
 ### Out of Scope
 
@@ -31,12 +33,6 @@ The A2A protocol evolved from v0.3 to v1.0 with significant breaking changes. Ex
 - Automatic protocol version detection (client must explicitly choose API version)
 - Extras modules (OpenTelemetry, JPA stores, etc.) for v0.3
 - v0.3 format agent card (v0.3 clients must be able to parse v1.0 agent card format)
-
-### Deferred
-
-- **Dual-version server deployment**: Running both v1.0 and v0.3 transports simultaneously in a single server instance with a unified agent card
-  - **Current state**: v0.3 reference servers work standalone; need integration pattern for dual deployment
-  - **Remaining work**: Define CDI qualifier pattern, path prefix strategy, and unified agent card production
 
 ---
 
@@ -245,6 +241,30 @@ compat-0.3/
     └── pom.xml
 ```
 
+### Multi-Version Reference Modules
+
+These top-level modules provide version-dispatching routes that serve both v1.0 and v0.3 requests from a single server instance:
+
+```
+reference/
+├── common/                              # Shared utilities
+│   └── src/main/java/org/a2aproject/sdk/server/common/quarkus/
+│       └── VersionRouter.java           # Resolves protocol version from A2A-Version header
+├── multiversion-jsonrpc/                # Version-dispatching JSON-RPC routes
+│   └── src/main/java/org/a2aproject/sdk/server/multiversion/jsonrpc/
+│       └── MultiVersionJSONRPCRoutes.java
+└── multiversion-rest/                   # Version-dispatching REST routes
+    └── src/main/java/org/a2aproject/sdk/server/multiversion/rest/
+        └── MultiVersionRestRoutes.java
+
+tests/reference/                         # Multi-version integration tests
+├── jsonrpc/                             # JSON-RPC multi-version tests
+├── rest/                                # REST multi-version tests
+└── grpc/                                # gRPC multi-version tests
+```
+
+**Note**: gRPC version dispatch is handled by protobuf package namespace (`a2a.v1` for v0.3 vs `lf.a2a.v1` for v1.0), so no `multiversion-grpc` module is needed.
+
 ### Java Package Convention
 
 All compat-0.3 code uses the `org.a2aproject.sdk.compat03` package root:
@@ -311,6 +331,32 @@ The `ErrorConverter_v0_3` class centralizes error translation between v0.3 and v
 - For v1.0-only error codes, produce generic error with same code/message
 
 **Location**: `compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/ErrorConverter_v0_3.java`
+
+### Version Routing: `VersionRouter`
+
+The `VersionRouter` class in `reference/common` resolves the protocol version for incoming requests:
+
+**Location**: `reference/common/src/main/java/org/a2aproject/sdk/server/common/quarkus/VersionRouter.java`
+
+**Resolution Logic** (in `VersionRouter.resolveVersion()`):
+1. Check the `A2A-Version` HTTP header
+2. If absent, check the `A2A-Version` query parameter
+3. If neither is present, default to `"0.3"` (backward compatibility with clients that don't send a version header)
+
+The caller then dispatches based on the resolved version:
+```java
+String version = VersionRouter.resolveVersion(routingContext);
+if (VersionRouter.isV10(version)) {
+    // delegate to v1.0 handler
+} else if (VersionRouter.isV03(version)) {
+    // delegate to v0.3 handler
+} else {
+    // unrecognized version string — reject
+    throw new VersionNotSupportedError(...);
+}
+```
+
+The multi-version route classes (`MultiVersionJSONRPCRoutes`, `MultiVersionRestRoutes`) use this pattern to dispatch every endpoint to the appropriate version handler.
 
 ---
 
@@ -433,76 +479,44 @@ public AgentCard_v0_3 agentCard() {
 
 The existing `AgentExecutor` implementation works unchanged. The compat reference module registers v0.3 transport endpoints via Quarkus CDI auto-discovery and delegates to the same `AgentExecutor` through the v1.0 server pipeline.
 
-### Server: Serving Both v0.3 and v1.0 (Deferred)
+### Server: Serving Multiple Protocol Versions
 
-**Status**: Architecture is in place but dual-version deployment pattern is not yet defined.
+To serve multiple protocol versions from the same server, add the compat reference module for each version you want to support alongside the v1.0 reference module. For example, to serve both v1.0 and v0.3 over JSON-RPC:
 
-**Remaining work:**
-- Define CDI qualifier pattern to differentiate v0.3 and v1.0 beans
-- Establish path prefix strategy (e.g., `/v0.3` for compat endpoints)
-- Unified agent card production with multiple `AgentInterface` entries
-- Integration testing for dual-version scenarios
+```xml
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
+</dependency>
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-java-sdk-compat-0.3-reference-jsonrpc</artifactId>
+</dependency>
+```
 
-**Recommended approach:**
-1. Use separate URLs per protocol version (e.g., `http://localhost:9999` for v1.0, `http://localhost:9999/v0.3` for v0.3)
-2. Declare both in the v1.0 agent card with different `protocolVersion` values
-3. Register both transport handlers via Quarkus CDI with path-based routing
+For JSON-RPC and REST, multi-version convenience modules are also available that bundle all supported protocol versions with version-dispatching routes:
 
----
+```xml
+<!-- Includes v1.0 + v0.3 JSON-RPC with automatic version routing -->
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-java-sdk-reference-multiversion-jsonrpc</artifactId>
+</dependency>
 
-## Implementation Summary
+<!-- Includes v1.0 + v0.3 REST with automatic version routing -->
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-java-sdk-reference-multiversion-rest</artifactId>
+</dependency>
+```
 
-The implementation was completed in phases:
+**Version routing:**
+- **JSON-RPC and REST**: Clients indicate their protocol version via the `A2A-Version` header (or query parameter). If absent, the server defaults to v0.3 for backward compatibility.
+- **gRPC**: Version dispatch is handled by protobuf package namespace (`a2a.v1` vs `lf.a2a.v1`), so both v1.0 and v0.3 gRPC services are registered on the same port without a dedicated multi-version module.
 
-### Phase 1: Foundation
-- Set up module structure and POMs
-- Port v0.3 spec types to `compat-0.3/spec`
-- Generate v0.3 gRPC classes in `compat-0.3/spec-grpc`
-- Apply `_v0_3` suffix naming convention
+**Agent card**: The agent card is served in v1.0 format only. Older clients must be able to parse the v1.0 agent card format to discover their endpoint.
 
-### Phase 2: Conversion Layer
-- Create `server-conversion` module
-- Implement `Convert_v0_3_To10RequestHandler`
-- Build MapStruct mappers (params, domain, result)
-- Centralize error conversion in `ErrorConverter_v0_3`
-- Export test infrastructure via test-jar
-
-### Phase 3: Transport Handlers
-- Implement server-side transport handlers (JSONRPC, gRPC, REST)
-- Wire each transport to `Convert_v0_3_To10RequestHandler`
-- Test with v1.0 backend via `AbstractA2ARequestHandlerTest_v0_3`
-
-### Phase 4: Client
-- Implement `Client_v0_3` API
-- Build client transports (JSONRPC, gRPC, REST)
-- Validate against v0.3 spec constraints
-
-### Phase 5: Reference Servers
-- Port Quarkus reference servers (JSONRPC, gRPC, REST)
-- Integrate with test infrastructure
-- Run integration tests using v0.3 client against v0.3 reference servers
-
-### Phase 6: Testing & Validation
-- Port transport handler tests (37+ tests across 3 transports)
-- Port streaming tests (Flow.Publisher, SSE, gRPC)
-- Port reference server tests (125+ integration tests passing)
-- Enable TCK module
-
----
-
-## Key Differences from Original Plan
-
-1. **Conversion layer as separate module**: Original plan embedded mapping in `spec-grpc`; implementation uses dedicated `server-conversion` module with `Convert_v0_3_To10RequestHandler`
-
-2. **`_v0_3` suffix naming**: Not in original plan; adopted to eliminate IDE naming conflicts (233 out of 284 classes had conflicts)
-
-3. **No `reference/common` module**: Each reference server is standalone; no shared reference base
-
-4. **Test-jar pattern**: Test infrastructure exported from `server-conversion` module rather than reference common
-
-5. **Package migration during implementation**: The main codebase migrated from `io.a2a` to `org.a2aproject.sdk` while this work was in progress (PRs #750, #786)
-
-6. **Implementation order**: Test infrastructure built early; tests ported incrementally to validate conversion layer
+**Integration tests**: Multi-version scenarios are tested under `tests/reference/{jsonrpc,rest,grpc}` using both v1.0 and v0.3 clients against a single server instance.
 
 ---
 
@@ -522,23 +536,10 @@ The implementation was completed in phases:
 
 ## Status
 
-✅ **Complete:**
-- Module structure and POMs
-- v0.3 spec types and gRPC generation
-- Server conversion layer with all mappers
-- Server-side transport handlers (JSONRPC, gRPC, REST)
-- Client API and transports
-- Reference servers (JSONRPC, gRPC, REST)
-- Test infrastructure (test-jar pattern)
-- Core integration tests (125+ passing)
-- TCK module enabled
+The v0.3 compatibility layer is fully implemented: spec types, gRPC generation, conversion layer, all three transport handlers (JSON-RPC, gRPC, REST), client API and transports, reference servers, multi-version deployment, test infrastructure, 125+ integration tests, and TCK module are all in place.
 
-🔲 **Deferred:**
-- Dual v1.0/v0.3 server deployment pattern
-- Push notification test porting (requires TestHttpClient)
+🔲 **Outstanding:**
+- Push notification test porting (requires TestHttpClient; version-aware push notifications in PR #857)
 - Test metadata classes (classpath scanning)
-
-🧹 **Nice-to-have cleanup:**
 - Replace FQNs with imports (97 occurrences in 34 files)
 - Unify AgentCard producers across reference modules
-- Remove obsolete TODOs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,8 @@ For detailed architectural documentation:
   - **[Queue Lifecycle](.claude/architecture/eventqueue/LIFECYCLE.md)**: Two-level protection, fire-and-forget, late reconnections
   - **[Request Flows](.claude/architecture/eventqueue/FLOWS.md)**: Non-streaming vs streaming, cleanup patterns
   - **[Usage Scenarios](.claude/architecture/eventqueue/SCENARIOS.md)**: Real-world patterns and common pitfalls
+- **Compatibility with previous protocol versions**:
+  - 0.3 protocol compatibility layer: `.claude/architecture/compatibility_0.3.md`
 
 > 💡 Deep-dive docs are loaded on-demand when working in related areas.
 

--- a/README.md
+++ b/README.md
@@ -743,25 +743,21 @@ gRPC and REST transports are also available:
 - `a2a-java-sdk-compat-0.3-client-transport-grpc`
 - `a2a-java-sdk-compat-0.3-client-transport-rest`
 
-#### 3. Check the agent card and choose the right client
+#### 3. Create the v0.3 client
 
 ```java
 AgentCard card = new A2ACardResolver("http://localhost:1234").getAgentCard();
 
-for (AgentInterface iface : card.supportedInterfaces()) {
-    if ("0.3".equals(iface.protocolVersion())) {
-        // Use the v0.3 compatibility client
-        Client_v0_3 client = ClientBuilder_v0_3.forUrl(iface.url())
-                .transport("JSONRPC")
-                .build();
-        // client exposes only v0.3-compatible operations
-    } else if ("1.0".equals(iface.protocolVersion())) {
-        // Use the standard v1.0 client
-        Client client = Client.builder(card)
-                .withTransport(JSONRPCTransport.class, new JSONRPCTransportConfig())
-                .build();
-    }
-}
+// Find the v0.3 interface from the agent card
+AgentInterface v03Interface = card.supportedInterfaces().stream()
+        .filter(iface -> "0.3".equals(iface.protocolVersion()))
+        .findFirst()
+        .orElseThrow();
+
+// Create the v0.3 compatibility client
+Client_v0_3 client = ClientBuilder_v0_3.forUrl(v03Interface.url())
+        .withTransport(JSONRPCTransport_v0_3.class, new JSONRPCTransportConfigBuilder_v0_3())
+        .build();
 ```
 
 **Note:** `Client_v0_3` exposes only operations available in protocol v0.3. For example, `listTasks()` is not available (it was added in v1.0). Return types use v0.3 domain objects from the `org.a2aproject.sdk.compat03.spec` package.

--- a/README.md
+++ b/README.md
@@ -270,6 +270,83 @@ a2a.blocking.consumption.timeout.seconds=5
 
 **Note:** The reference server implementations (Quarkus-based) automatically include the MicroProfile Config integration, so properties work out of the box in `application.properties`.
 
+### Serving Older Protocol Versions (Backward Compatibility)
+
+The A2A Java SDK includes compatibility layers that allow your server to accept requests from clients using older protocol versions. Each compatibility layer is a separate set of modules that you add to your project as needed. **No changes to your `AgentExecutor` are needed** — the compatibility layer converts older protocol requests to v1.0 internally before delegating to your agent.
+
+#### Adding v0.3 Protocol Support
+
+To enable v0.3 support, add the v0.3 compat reference module for your chosen transport alongside (or instead of) the v1.0 reference module:
+
+```xml
+<!-- v0.3 JSON-RPC support -->
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-java-sdk-compat-0.3-reference-jsonrpc</artifactId>
+    <!-- Use a released version from https://github.com/a2aproject/a2a-java/releases -->
+    <version>${org.a2aproject.sdk.version}</version>
+</dependency>
+
+<!-- v0.3 REST support -->
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-java-sdk-compat-0.3-reference-rest</artifactId>
+    <version>${org.a2aproject.sdk.version}</version>
+</dependency>
+
+<!-- v0.3 gRPC support -->
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-java-sdk-compat-0.3-reference-grpc</artifactId>
+    <version>${org.a2aproject.sdk.version}</version>
+</dependency>
+```
+
+For example, a server that supports **v1.0 and v0.3 over JSON-RPC** would include both:
+
+```xml
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
+    <version>${org.a2aproject.sdk.version}</version>
+</dependency>
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-java-sdk-compat-0.3-reference-jsonrpc</artifactId>
+    <version>${org.a2aproject.sdk.version}</version>
+</dependency>
+```
+
+A server that only needs to support **v0.3** would include only the compat dependency.
+
+#### Multi-Version Convenience Modules
+
+For JSON-RPC and REST, multi-version modules are provided that bundle all supported protocol versions together with version-dispatching routes:
+
+```xml
+<!-- Includes v1.0 + v0.3 JSON-RPC support with automatic version routing -->
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-java-sdk-reference-multiversion-jsonrpc</artifactId>
+    <version>${org.a2aproject.sdk.version}</version>
+</dependency>
+
+<!-- Includes v1.0 + v0.3 REST support with automatic version routing -->
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-java-sdk-reference-multiversion-rest</artifactId>
+    <version>${org.a2aproject.sdk.version}</version>
+</dependency>
+```
+
+These are a convenience — they transitively include all the individual compat reference modules.
+
+#### How Version Routing Works
+
+- **JSON-RPC and REST**: When serving multiple protocol versions, version routing inspects the `A2A-Version` HTTP header on each request. If the header is `"1.0"`, the request is routed to the v1.0 handler. If it is `"0.3"` or absent, the request is routed to the v0.3 handler.
+- **gRPC**: Version dispatch is implicit — v0.3 clients use the `a2a.v1` protobuf package and v1.0 clients use `lf.a2a.v1`, so requests are routed to the correct service automatically.
+- **Agent card**: The agent card is served in v1.0 format only. Older clients must be able to parse the v1.0 agent card.
+
 ## A2A Client
 
 The A2A Java SDK provides a Java client implementation of the [Agent2Agent (A2A) Protocol](https://a2a-protocol.org/), allowing communication with A2A servers. The Java client implementation supports the following transports:
@@ -635,6 +712,59 @@ client.subscribeToTask(taskIdParams, clientCallContext);
 ```java
 AgentCard serverAgentCard = client.getAgentCard();
 ```
+
+### Communicating with v0.3 Agents
+
+If you need to communicate with an agent that only supports protocol v0.3, use the compatibility client `Client_v0_3`.
+
+#### 1. Add the v0.3 client dependency
+
+```xml
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-java-sdk-compat-0.3-client</artifactId>
+    <!-- Use a released version from https://github.com/a2aproject/a2a-java/releases -->
+    <version>${org.a2aproject.sdk.version}</version>
+</dependency>
+```
+
+#### 2. Add a v0.3 client transport dependency
+
+```xml
+<!-- JSON-RPC transport for v0.3 -->
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-java-sdk-compat-0.3-client-transport-jsonrpc</artifactId>
+    <version>${org.a2aproject.sdk.version}</version>
+</dependency>
+```
+
+gRPC and REST transports are also available:
+- `a2a-java-sdk-compat-0.3-client-transport-grpc`
+- `a2a-java-sdk-compat-0.3-client-transport-rest`
+
+#### 3. Check the agent card and choose the right client
+
+```java
+AgentCard card = new A2ACardResolver("http://localhost:1234").getAgentCard();
+
+for (AgentInterface iface : card.supportedInterfaces()) {
+    if ("0.3".equals(iface.protocolVersion())) {
+        // Use the v0.3 compatibility client
+        Client_v0_3 client = ClientBuilder_v0_3.forUrl(iface.url())
+                .transport("JSONRPC")
+                .build();
+        // client exposes only v0.3-compatible operations
+    } else if ("1.0".equals(iface.protocolVersion())) {
+        // Use the standard v1.0 client
+        Client client = Client.builder(card)
+                .withTransport(JSONRPCTransport.class, new JSONRPCTransportConfig())
+                .build();
+    }
+}
+```
+
+**Note:** `Client_v0_3` exposes only operations available in protocol v0.3. For example, `listTasks()` is not available (it was added in v1.0). Return types use v0.3 domain objects from the `org.a2aproject.sdk.compat03.spec` package.
 
 ## Additional Examples
 

--- a/pom.xml
+++ b/pom.xml
@@ -596,7 +596,7 @@
         <module>reference/multiversion-jsonrpc</module>
         <module>reference/multiversion-rest</module>
 
-        <!-- Dual-version test modules -->
+        <!-- Multi-version test modules -->
         <module>tests/reference/jsonrpc</module>
         <module>tests/reference/rest</module>
         <module>tests/reference/grpc</module>

--- a/reference/multiversion-jsonrpc/pom.xml
+++ b/reference/multiversion-jsonrpc/pom.xml
@@ -15,7 +15,7 @@
     <packaging>jar</packaging>
 
     <name>Java A2A SDK Reference Multiversion JSON-RPC</name>
-    <description>Version-dispatching routes for dual v1.0/v0.3 JSON-RPC deployment</description>
+    <description>Version-dispatching routes for multi-version v1.0/v0.3 JSON-RPC deployment</description>
 
     <dependencies>
         <dependency>

--- a/reference/multiversion-rest/pom.xml
+++ b/reference/multiversion-rest/pom.xml
@@ -15,7 +15,7 @@
     <packaging>jar</packaging>
 
     <name>Java A2A SDK Reference Multiversion REST</name>
-    <description>Version-dispatching routes for dual v1.0/v0.3 REST deployment</description>
+    <description>Version-dispatching routes for multi-version v1.0/v0.3 REST deployment</description>
 
     <dependencies>
         <dependency>

--- a/server-common/src/test/java/org/a2aproject/sdk/server/version/A2AVersionValidatorTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/version/A2AVersionValidatorTest.java
@@ -76,7 +76,7 @@ public class A2AVersionValidatorTest {
     }
 
     @Test
-    public void testValidateProtocolVersion_NoVersionProvided_DualVersionServer() {
+    public void testValidateProtocolVersion_NoVersionProvided_MultiVersionServer() {
         // A server supporting both 1.0 and 0.3 should accept missing version (defaults to 0.3)
         AgentCard agentCard = createAgentCardWithVersions("1.0", "0.3");
         ServerCallContext context = createContext(null);

--- a/tests/reference/grpc/pom.xml
+++ b/tests/reference/grpc/pom.xml
@@ -14,8 +14,8 @@
 
     <packaging>jar</packaging>
 
-    <name>Java A2A SDK Tests Dual-Version gRPC</name>
-    <description>Tests for dual v1.0/v0.3 gRPC deployment</description>
+    <name>Java A2A SDK Tests Multi-Version gRPC</name>
+    <description>Tests for multi-version v1.0/v0.3 gRPC deployment</description>
 
     <dependencies>
         <!-- v1.0 gRPC reference server -->

--- a/tests/reference/jsonrpc/pom.xml
+++ b/tests/reference/jsonrpc/pom.xml
@@ -14,8 +14,8 @@
 
     <packaging>jar</packaging>
 
-    <name>Java A2A SDK Tests Dual-Version JSON-RPC</name>
-    <description>Tests for dual v1.0/v0.3 JSON-RPC deployment</description>
+    <name>Java A2A SDK Tests Multi-Version JSON-RPC</name>
+    <description>Tests for multi-version v1.0/v0.3 JSON-RPC deployment</description>
 
     <dependencies>
         <!-- Production multiversion module (provides MultiVersionJSONRPCRoutes) -->

--- a/tests/reference/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multiversion/jsonrpc/MultiVersionJSONRPC_v0_3_Test.java
+++ b/tests/reference/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multiversion/jsonrpc/MultiVersionJSONRPC_v0_3_Test.java
@@ -33,7 +33,7 @@ public class MultiVersionJSONRPC_v0_3_Test extends AbstractA2AServerServerTest_v
 
     @Test
     @Override
-    @Disabled("Agent card is v1.0 format in dual-version mode")
+    @Disabled("Agent card is v1.0 format in multi-version mode")
     public void testGetAgentCard() {
     }
 }

--- a/tests/reference/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multiversion/jsonrpc/MultiVersionJSONRPC_v0_3_WithAuthTest.java
+++ b/tests/reference/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multiversion/jsonrpc/MultiVersionJSONRPC_v0_3_WithAuthTest.java
@@ -47,7 +47,7 @@ public class MultiVersionJSONRPC_v0_3_WithAuthTest extends AbstractA2AServerWith
 
     @Test
     @Override
-    @Disabled("Agent card is v1.0 format in dual-version mode")
+    @Disabled("Agent card is v1.0 format in multi-version mode")
     public void testGetAgentCardIsPublic() {
     }
 }

--- a/tests/reference/rest/pom.xml
+++ b/tests/reference/rest/pom.xml
@@ -14,8 +14,8 @@
 
     <packaging>jar</packaging>
 
-    <name>Java A2A SDK Tests Dual-Version REST</name>
-    <description>Tests for dual v1.0/v0.3 REST deployment</description>
+    <name>Java A2A SDK Tests Multi-Version REST</name>
+    <description>Tests for multi-version v1.0/v0.3 REST deployment</description>
 
     <dependencies>
         <!-- Production multiversion module (provides MultiVersionRestRoutes) -->

--- a/tests/reference/rest/src/test/java/org/a2aproject/sdk/tests/multiversion/rest/MultiVersion_v0_3_RestTest.java
+++ b/tests/reference/rest/src/test/java/org/a2aproject/sdk/tests/multiversion/rest/MultiVersion_v0_3_RestTest.java
@@ -33,7 +33,7 @@ public class MultiVersion_v0_3_RestTest extends AbstractA2AServerServerTest_v0_3
 
     @Test
     @Override
-    @Disabled("Agent card is v1.0 format in dual-version mode")
+    @Disabled("Agent card is v1.0 format in multi-version mode")
     public void testGetAgentCard() {
     }
 }

--- a/tests/reference/rest/src/test/java/org/a2aproject/sdk/tests/multiversion/rest/MultiVersion_v0_3_RestWithAuthTest.java
+++ b/tests/reference/rest/src/test/java/org/a2aproject/sdk/tests/multiversion/rest/MultiVersion_v0_3_RestWithAuthTest.java
@@ -47,7 +47,7 @@ public class MultiVersion_v0_3_RestWithAuthTest extends AbstractA2AServerWithAut
 
     @Test
     @Override
-    @Disabled("Agent card is v1.0 format in dual-version mode")
+    @Disabled("Agent card is v1.0 format in multi-version mode")
     public void testGetAgentCardIsPublic() {
     }
 


### PR DESCRIPTION
- Update architecture doc (compatibility_0.3.md) to reflect current state: multi-version deployment is implemented, remove historical planning artifacts, add VersionRouter and multi-version module docs
- Add README sections for serving v0.3 clients (standalone and multi-version) and communicating with v0.3 agents using Client_v0_3
- Standardize terminology from "dual-version" to "multi-version" across POM descriptions, @Disabled annotations, and test names
- Add AGENTS.md reference to compatibility architecture doc

Fixes #856