### PR TITLE
fix: Set TCCL before initialising A2AHttpClientFactory

### DIFF
--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/BasePushNotificationSender.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/BasePushNotificationSender.java
@@ -56,7 +56,15 @@ public class BasePushNotificationSender implements PushNotificationSender {
 
     @Inject
     public BasePushNotificationSender(PushNotificationConfigStore configStore) {
-        this.httpClient = A2AHttpClientFactory.create();
+        // Make sure the TCCL is one of the platform ones before the ServiceLoader
+        // in A2AHttpClientFactory's static initializer
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(BasePushNotificationSender.class.getClassLoader());
+            this.httpClient = A2AHttpClientFactory.create();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+        }
         this.configStore = configStore;
     }
 


### PR DESCRIPTION
It has a ServiceLoader using the TCCL to find clients
