### PR TITLE
fix: Fixes for Jakarta

### DIFF
--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/A2AHttpClientFactory.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/A2AHttpClientFactory.java
@@ -45,7 +45,7 @@ public final class A2AHttpClientFactory {
     private static final List<A2AHttpClientProvider> PROVIDERS;
 
     static {
-        PROVIDERS = StreamSupport.stream(ServiceLoader.load(A2AHttpClientProvider.class).spliterator(), false)
+        PROVIDERS = StreamSupport.stream(ServiceLoader.load(A2AHttpClientProvider.class, A2AHttpClientProvider.class.getClassLoader()).spliterator(), false)
                 .collect(Collectors.toList());
     }
 
@@ -85,7 +85,8 @@ public final class A2AHttpClientFactory {
             throw new IllegalArgumentException("Provider name must not be null or empty");
         }
 
-        ServiceLoader<A2AHttpClientProvider> loader = ServiceLoader.load(A2AHttpClientProvider.class);
+        ServiceLoader<A2AHttpClientProvider> loader =
+                ServiceLoader.load(A2AHttpClientProvider.class, A2AHttpClientProvider.class.getClassLoader());
 
         return StreamSupport.stream(loader.spliterator(), false)
                 .filter(provider -> providerName.equals(provider.name()))

--- a/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
+++ b/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
@@ -56,6 +56,7 @@ import org.a2aproject.sdk.spec.TaskNotCancelableError;
 import org.a2aproject.sdk.spec.TaskNotFoundError;
 import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
 import org.a2aproject.sdk.spec.TaskQueryParams;
+import org.a2aproject.sdk.spec.AgentInterface;
 import org.a2aproject.sdk.spec.TransportProtocol;
 import org.a2aproject.sdk.spec.A2AErrorCodes;
 import org.a2aproject.sdk.spec.UnsupportedOperationError;
@@ -686,7 +687,11 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
             }
             
             // Extract requested protocol version from gRPC context (set by interceptor)
+            // Default to current version since gRPC only handles 1.0 protocol
             String requestedVersion = getVersionFromContext();
+            if (requestedVersion == null) {
+                requestedVersion = AgentInterface.CURRENT_PROTOCOL_VERSION;
+            }
 
             // Extract requested extensions from gRPC context (set by interceptor)
             Set<String> requestedExtensions = new HashSet<>();


### PR DESCRIPTION
- Don't use TCCL to initialise the Http Client
- Default to protocol version 1.0 when no gRPC interceptor has set the version. The WildFly gRPC subsystem does not currently have an A2A header interceptor.
