### PR TITLE
feat: enable multi-mode protocol testing for both TCKs

### DIFF
--- a/.claude/architecture/compatibility_0.3.md
+++ b/.claude/architecture/compatibility_0.3.md
@@ -32,7 +32,7 @@ The A2A protocol evolved from v0.3 to v1.0 with significant breaking changes. Ex
 - Changes to existing v1.0 modules (no regressions, no API changes)
 - Automatic protocol version detection (client must explicitly choose API version)
 - Extras modules (OpenTelemetry, JPA stores, etc.) for v0.3
-- v0.3 format agent card (v0.3 clients must be able to parse v1.0 agent card format)
+- Serving a separate v0.3-format agent card (the v1.0 card is served, with optional v0.3-compatible fields added by the user)
 
 ---
 
@@ -149,19 +149,24 @@ v0.3 Client Response
 
 `TASK_STATE_REJECTED` (v1.0-only) is mapped to `TASK_STATE_FAILED` when converting to v0.3 wire format. The original state is preserved in metadata (`"original_state": "REJECTED"`) so information is not entirely lost. Both are terminal states, so v0.3 clients can handle the result correctly.
 
-### Agent Card: v1.0 Only
+### Agent Card Precedence in Multi-Version Mode
 
-The agent card (`/.well-known/agent-card.json`) is produced only using the v1.0 format. The compat layer does not produce a v0.3-format agent card.
+When both v1.0 and v0.3 protocol support are enabled, a single agent card is served at `/.well-known/agent-card.json`:
 
-A server that supports both versions should advertise this via a single v1.0 agent card containing multiple `AgentInterface` entries — one per version — each with its own URL and `protocolVersion` field. v0.3 clients must be able to parse the v1.0 agent card format to discover their endpoint.
+- **Both v1.0 and v0.3 enabled**: The v1.0 `AgentCard` takes precedence. The v0.3 `AgentCard_v0_3` is ignored.
+- **Only v0.3 enabled**: The v0.3 `AgentCard_v0_3` is used.
+- **Only v1.0 enabled**: The v1.0 `AgentCard` is used as-is.
 
-**Pros:**
-- **Single source of truth**: one agent card at one well-known URL describes all supported versions and transports
-- **Simpler server implementation**: no need for separate v0.3 agent card endpoint, serializer, or CDI producer
-- **Forward-looking**: encourages v0.3 clients to understand the v1.0 discovery format
+### Making the v1.0 Agent Card Parsable by v0.3 Clients
 
-**Cons:**
-- **v0.3 clients must parse v1.0 agent card**: pure v0.3 clients that only understand the v0.3 structure need updating
+Existing v0.3 client implementations (across all languages) expect specific fields in the agent card that don't exist in the v1.0 format. Since we cannot control what external v0.3 clients can parse, the v1.0 `AgentCard` must include backward-compatible fields when serving both protocol versions:
+
+- `url` and `preferredTransport` — top-level fields that v0.3 clients use to discover the primary endpoint
+- `additionalInterfaces` — a list of `Legacy_0_3_AgentInterface(transport, url)` entries using v0.3 field names (`transport` instead of v1.0's `protocolBinding`)
+
+These fields coexist alongside the v1.0 `supportedInterfaces` field. v1.0 clients use `supportedInterfaces`; v0.3 clients use `url`, `preferredTransport`, and `additionalInterfaces`.
+
+`Legacy_0_3_AgentInterface` is a separate record from `AgentInterface` because they serialize to different JSON field names (`transport`/`url` vs `protocolBinding`/`url`/`tenant`).
 
 ---
 

--- a/.github/workflows/run-tck.yml
+++ b/.github/workflows/run-tck.yml
@@ -12,9 +12,12 @@ on:
 env:
   # Tag/branch of the TCK
   TCK_VERSION: 1.0-dev
+  TCK_VERSION_0_3: 0.3.0.beta4
   # Tells uv to not need a venv, and instead use system
   UV_SYSTEM_PYTHON: 1
   SUT_URL: http://localhost:9999
+  # Slow system on CI
+  TCK_STREAMING_TIMEOUT_0_3: 5.0
 
 # Only run the latest job
 concurrency:
@@ -27,6 +30,7 @@ jobs:
     strategy:
       matrix:
         java-version: [17]
+        profile: ['', 'multi-mode']
     steps:
       - name: Checkout a2a-java
         uses: actions/checkout@v6
@@ -54,7 +58,7 @@ jobs:
           uv pip install -e .
         working-directory: a2a-tck
       - name: Start SUT
-        run: mvn -B quarkus:dev -Dquarkus.console.enabled=false &
+        run: mvn -B quarkus:dev ${{ matrix.profile && format('-P{0}', matrix.profile) || '' }} -Dquarkus.console.enabled=false &
         working-directory: tck
       - name: Wait for SUT to start
         run: |
@@ -97,7 +101,7 @@ jobs:
             # Extract everything after the first ═══ separator line
             SUMMARY=$(sed -n '/^═══/,$p' a2a-tck/tck-output.log)
             if [ -n "$SUMMARY" ]; then
-              echo '### TCK Results (Java ${{ matrix.java-version }})' >> $GITHUB_STEP_SUMMARY
+              echo '### TCK 1.0 Results (Java ${{ matrix.java-version }}${{ matrix.profile && format(', {0}', matrix.profile) || '' }})' >> $GITHUB_STEP_SUMMARY
               echo '```' >> $GITHUB_STEP_SUMMARY
               echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
               echo '```' >> $GITHUB_STEP_SUMMARY
@@ -112,7 +116,106 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: tck-reports-java-${{ matrix.java-version }}
+          name: tck-reports-java-${{ matrix.java-version }}${{ matrix.profile && format('-{0}', matrix.profile) || '' }}
           path: a2a-tck/reports/
+          retention-days: 14
+          if-no-files-found: warn
+
+  tck-test-0-3:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [17]
+        profile: ['', 'multi-mode']
+    steps:
+      - name: Checkout a2a-java
+        uses: actions/checkout@v6
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
+          cache: maven
+      - name: Build a2a-java SDK
+        run: mvn -B install -DskipTests
+      - name: Checkout a2a-tck
+        uses: actions/checkout@v6
+        with:
+          repository: a2aproject/a2a-tck
+          path: a2a-tck
+          ref: ${{ env.TCK_VERSION_0_3 }}
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "a2a-tck/pyproject.toml"
+      - name: Install uv and Python dependencies
+        run: |
+          pip install uv
+          uv pip install -e .
+        working-directory: a2a-tck
+      - name: Start SUT
+        run: mvn -B quarkus:dev ${{ matrix.profile && format('-P{0}', matrix.profile) || '' }} -Dquarkus.console.enabled=false &
+        working-directory: compat-0.3/tck
+      - name: Wait for SUT to start
+        run: |
+          URL="${{ env.SUT_URL }}/.well-known/agent-card.json"
+          EXPECTED_STATUS=200
+          TIMEOUT=120
+          RETRY_INTERVAL=2
+          START_TIME=$(date +%s)
+
+          while true; do
+            CURRENT_TIME=$(date +%s)
+            ELAPSED_TIME=$((CURRENT_TIME - START_TIME))
+
+            if [ "$ELAPSED_TIME" -ge "$TIMEOUT" ]; then
+                echo "Timeout: Server did not respond with status $EXPECTED_STATUS within $TIMEOUT seconds."
+                exit 1
+            fi
+
+            HTTP_STATUS=$(curl --output /dev/null --silent --write-out "%{http_code}" "$URL") || true
+
+            if [ "$HTTP_STATUS" -eq "$EXPECTED_STATUS" ]; then
+                echo "Server is up! Received status $HTTP_STATUS after $ELAPSED_TIME seconds."
+                break;
+            fi
+
+            echo "Server not ready (status: $HTTP_STATUS). Retrying in $RETRY_INTERVAL seconds..."
+            sleep "$RETRY_INTERVAL"
+          done
+      - name: Run TCK
+        id: run-tck
+        timeout-minutes: 5
+        env:
+          TCK_STREAMING_TIMEOUT: ${{ env.TCK_STREAMING_TIMEOUT_0_3 }}
+        run: |
+          set -o pipefail
+          ./run_tck.py --sut-url ${{ env.SUT_URL }} --category all --transports jsonrpc,grpc,rest --compliance-report report.json 2>&1 | tee tck-output.log
+        working-directory: a2a-tck
+      - name: TCK Summary
+        if: always() && steps.run-tck.outcome != 'skipped'
+        run: |
+          if [ -f a2a-tck/tck-output.log ]; then
+            SUMMARY=$(sed -n '/^═══/,$p' a2a-tck/tck-output.log)
+            if [ -n "$SUMMARY" ]; then
+              echo '### TCK 0.3 Results (Java ${{ matrix.java-version }}${{ matrix.profile && format(', {0}', matrix.profile) || '' }})' >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+            fi
+          fi
+      - name: Stop SUT
+        if: always()
+        run: |
+          pkill -f "quarkus:dev" || true
+          sleep 2
+      - name: Upload TCK Reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tck-0.3-reports-java-${{ matrix.java-version }}${{ matrix.profile && format('-{0}', matrix.profile) || '' }}
+          path: |
+            a2a-tck/reports/
+            a2a-tck/report.json
           retention-days: 14
           if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -345,7 +345,33 @@ These are a convenience — they transitively include all the individual compat 
 
 - **JSON-RPC and REST**: When serving multiple protocol versions, version routing inspects the `A2A-Version` HTTP header on each request. If the header is `"1.0"`, the request is routed to the v1.0 handler. If it is `"0.3"` or absent, the request is routed to the v0.3 handler.
 - **gRPC**: Version dispatch is implicit — v0.3 clients use the `a2a.v1` protobuf package and v1.0 clients use `lf.a2a.v1`, so requests are routed to the correct service automatically.
-- **Agent card**: The agent card is served in v1.0 format only. Older clients must be able to parse the v1.0 agent card.
+- **Agent card**: When both v1.0 and v0.3 are enabled, the v1.0 `AgentCard` takes precedence and is served at `/.well-known/agent-card.json`. The v0.3 `AgentCard_v0_3` is ignored. If only v0.3 is enabled, the v0.3 agent card is used. If only v1.0 is enabled, the v1.0 agent card is used as-is.
+
+#### Making the v1.0 Agent Card Compatible with v0.3 Clients
+
+When serving both protocol versions, you need to ensure the v1.0 agent card contains fields that v0.3 clients expect. Existing v0.3 client implementations (in any language) look for `url`, `preferredTransport`, and `additionalInterfaces` with `transport`/`url` entries — fields that don't exist in the v1.0 format by default.
+
+To make your v1.0 `AgentCard` parsable by v0.3 clients, set these fields on the builder:
+
+```java
+AgentCard card = AgentCard.builder()
+        .name("My Agent")
+        // ... other v1.0 fields ...
+        .supportedInterfaces(List.of(
+                new AgentInterface("jsonrpc", "http://localhost:9999")))
+        // v0.3 backward-compatibility fields:
+        .url("http://localhost:9999")
+        .preferredTransport("jsonrpc")
+        .additionalInterfaces(List.of(
+                new Legacy_0_3_AgentInterface("jsonrpc", "http://localhost:9999")))
+        .build();
+```
+
+The two interface lists serve different clients:
+
+- `supportedInterfaces` — used by **v1.0 clients** to discover endpoints (uses `AgentInterface` with `protocolBinding`/`url`/`tenant` fields)
+- `additionalInterfaces` — used by **v0.3 clients** to discover endpoints (uses `Legacy_0_3_AgentInterface` with v0.3 field names: `transport`/`url`)
+- `url` and `preferredTransport` — top-level fields that v0.3 clients use to discover the primary endpoint
 
 ## A2A Client
 

--- a/common/src/main/java/org/a2aproject/sdk/util/Assert.java
+++ b/common/src/main/java/org/a2aproject/sdk/util/Assert.java
@@ -27,9 +27,9 @@ public final class Assert {
         }
     }
 
-    public static void isNullOrStringOrInteger(@Nullable Object value) {
-        if (! (value == null || value instanceof String || value instanceof Integer)) {
-            throw new IllegalArgumentException("Id must be null, a String, or an Integer");
+    public static void isValidJsonRpcId(@Nullable Object value) {
+        if (! (value == null || value instanceof String || value instanceof Number)) {
+            throw new IllegalArgumentException("JSON-RPC id must be null, a String, or a Number");
         }
     }
 

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/CancelTaskRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/CancelTaskRequest_v0_3.java
@@ -23,7 +23,7 @@ public final class CancelTaskRequest_v0_3 extends NonStreamingJSONRPCRequest_v0_
             throw new IllegalArgumentException("Invalid CancelTaskRequest method");
         }
         Assert.checkNotNullParam("params", params);
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         this.jsonrpc = defaultIfNull(jsonrpc, JSONRPC_VERSION);
         this.id = id;
         this.method = method;

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/DeleteTaskPushNotificationConfigRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/DeleteTaskPushNotificationConfigRequest_v0_3.java
@@ -20,7 +20,7 @@ public final class DeleteTaskPushNotificationConfigRequest_v0_3 extends NonStrea
         if (! method.equals(METHOD)) {
             throw new IllegalArgumentException("Invalid DeleteTaskPushNotificationConfigRequest method");
         }
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         this.jsonrpc = Utils_v0_3.defaultIfNull(jsonrpc, JSONRPC_VERSION);
         this.id = id;
         this.method = method;

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetAuthenticatedExtendedCardRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetAuthenticatedExtendedCardRequest_v0_3.java
@@ -21,7 +21,7 @@ public final class GetAuthenticatedExtendedCardRequest_v0_3 extends NonStreaming
         if (! method.equals(METHOD)) {
             throw new IllegalArgumentException("Invalid GetAuthenticatedExtendedCardRequest method");
         }
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         this.jsonrpc = Utils_v0_3.defaultIfNull(jsonrpc, JSONRPC_VERSION);
         this.id = id;
         this.method = method;

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetTaskPushNotificationConfigRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetTaskPushNotificationConfigRequest_v0_3.java
@@ -20,7 +20,7 @@ public final class GetTaskPushNotificationConfigRequest_v0_3 extends NonStreamin
         if (! method.equals(METHOD)) {
             throw new IllegalArgumentException("Invalid GetTaskPushNotificationRequest method");
         }
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         this.jsonrpc = Utils_v0_3.defaultIfNull(jsonrpc, JSONRPC_VERSION);
         this.id = id;
         this.method = method;

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetTaskRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetTaskRequest_v0_3.java
@@ -23,7 +23,7 @@ public final class GetTaskRequest_v0_3 extends NonStreamingJSONRPCRequest_v0_3<T
             throw new IllegalArgumentException("Invalid GetTaskRequest method");
         }
         Assert.checkNotNullParam("params", params);
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         this.jsonrpc = defaultIfNull(jsonrpc, JSONRPC_VERSION);
         this.id = id;
         this.method = method;

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/JSONRPCRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/JSONRPCRequest_v0_3.java
@@ -20,7 +20,7 @@ public abstract sealed class JSONRPCRequest_v0_3<T> implements JSONRPCMessage_v0
     public JSONRPCRequest_v0_3(String jsonrpc, Object id, String method, T params) {
         Assert.checkNotNullParam("jsonrpc", jsonrpc);
         Assert.checkNotNullParam("method", method);
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         this.jsonrpc = defaultIfNull(jsonrpc, JSONRPC_VERSION);
         this.id = id;
         this.method = method;

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/JSONRPCResponse_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/JSONRPCResponse_v0_3.java
@@ -30,7 +30,7 @@ public abstract sealed class JSONRPCResponse_v0_3<T> implements JSONRPCMessage_v
         if (error == null && result == null && ! Void.class.equals(resultType)) {
             throw new IllegalArgumentException("Invalid JSON-RPC success response");
         }
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         this.jsonrpc = defaultIfNull(jsonrpc, JSONRPC_VERSION);
         this.id = id;
         this.result = result;

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/ListTaskPushNotificationConfigRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/ListTaskPushNotificationConfigRequest_v0_3.java
@@ -20,7 +20,7 @@ public final class ListTaskPushNotificationConfigRequest_v0_3 extends NonStreami
         if (! method.equals(METHOD)) {
             throw new IllegalArgumentException("Invalid ListTaskPushNotificationConfigRequest method");
         }
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         this.jsonrpc = Utils_v0_3.defaultIfNull(jsonrpc, JSONRPC_VERSION);
         this.id = id;
         this.method = method;

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SendMessageRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SendMessageRequest_v0_3.java
@@ -37,7 +37,7 @@ public final class SendMessageRequest_v0_3 extends NonStreamingJSONRPCRequest_v0
             throw new IllegalArgumentException("Invalid SendMessageRequest method");
         }
         Assert.checkNotNullParam("params", params);
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         this.jsonrpc = defaultIfNull(jsonrpc, JSONRPC_VERSION);
         this.id = id;
         this.method = method;
@@ -56,7 +56,7 @@ public final class SendMessageRequest_v0_3 extends NonStreamingJSONRPCRequest_v0
             throw new IllegalArgumentException("Invalid SendMessageRequest method");
         }
         Assert.checkNotNullParam("params", params);
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         params.check();
     }
 

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SendStreamingMessageRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SendStreamingMessageRequest_v0_3.java
@@ -22,7 +22,7 @@ public final class SendStreamingMessageRequest_v0_3 extends StreamingJSONRPCRequ
             throw new IllegalArgumentException("Invalid SendStreamingMessageRequest method");
         }
         Assert.checkNotNullParam("params", params);
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         this.jsonrpc = defaultIfNull(jsonrpc, JSONRPC_VERSION);
         this.id = id;
         this.method = method;
@@ -38,7 +38,7 @@ public final class SendStreamingMessageRequest_v0_3 extends StreamingJSONRPCRequ
             throw new IllegalArgumentException("Invalid SendStreamingMessageRequest method");
         }
         Assert.checkNotNullParam("params", params);
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         params.check();
     }
 

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SetTaskPushNotificationConfigRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SetTaskPushNotificationConfigRequest_v0_3.java
@@ -22,7 +22,7 @@ public final class SetTaskPushNotificationConfigRequest_v0_3 extends NonStreamin
             throw new IllegalArgumentException("Invalid SetTaskPushNotificationRequest method");
         }
         Assert.checkNotNullParam("params", params);
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         this.jsonrpc = defaultIfNull(jsonrpc, JSONRPC_VERSION);
         this.id = id;
         this.method = method;

--- a/compat-0.3/tck/pom.xml
+++ b/compat-0.3/tck/pom.xml
@@ -49,6 +49,56 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>multi-mode</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.a2aproject.sdk</groupId>
+                    <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.a2aproject.sdk</groupId>
+                    <artifactId>a2a-java-sdk-reference-grpc</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.a2aproject.sdk</groupId>
+                    <artifactId>a2a-java-sdk-reference-rest</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.a2aproject.sdk</groupId>
+                    <artifactId>a2a-java-sdk-reference-multiversion-jsonrpc</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.a2aproject.sdk</groupId>
+                    <artifactId>a2a-java-sdk-reference-multiversion-rest</artifactId>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-multi-mode-source</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/multi-mode/java</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>

--- a/compat-0.3/tck/src/multi-mode/java/org/a2aproject/sdk/compat03/tck/server/DerivedAgentCardProducer.java
+++ b/compat-0.3/tck/src/multi-mode/java/org/a2aproject/sdk/compat03/tck/server/DerivedAgentCardProducer.java
@@ -1,0 +1,66 @@
+package org.a2aproject.sdk.compat03.tck.server;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+
+import org.a2aproject.sdk.compat03.spec.AgentCard_v0_3;
+import org.a2aproject.sdk.compat03.spec.AgentSkill_v0_3;
+import org.a2aproject.sdk.server.PublicAgentCard;
+import org.a2aproject.sdk.spec.AgentCapabilities;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.AgentInterface;
+import org.a2aproject.sdk.spec.AgentSkill;
+import org.a2aproject.sdk.spec.Compat03Fields;
+
+/**
+ * Produces a v1.0 {@link AgentCard} derived from the v0.3 {@link AgentCard_v0_3}
+ * when the multi-mode profile adds v1.0 reference dependencies to the classpath.
+ * Overrides the {@code @DefaultBean} in {@code DefaultProducers}.
+ */
+@ApplicationScoped
+public class DerivedAgentCardProducer {
+
+    @Inject
+    @PublicAgentCard
+    AgentCard_v0_3 v03Card;
+
+    @Produces
+    @PublicAgentCard
+    public AgentCard createDerivedAgentCard() {
+        List<AgentInterface> interfaces = v03Card.additionalInterfaces().stream()
+                .map(iface -> new AgentInterface(iface.transport(), iface.url()))
+                .toList();
+
+        AgentCard.Builder builder = AgentCard.builder()
+                .name(v03Card.name())
+                .description(v03Card.description())
+                .version(v03Card.version())
+                .capabilities(AgentCapabilities.builder()
+                        .streaming(v03Card.capabilities().streaming())
+                        .pushNotifications(v03Card.capabilities().pushNotifications())
+                        .build())
+                .defaultInputModes(v03Card.defaultInputModes())
+                .defaultOutputModes(v03Card.defaultOutputModes())
+                .skills(v03Card.skills().stream()
+                        .map(DerivedAgentCardProducer::toSkill10)
+                        .toList())
+                .supportedInterfaces(interfaces);
+
+        Compat03Fields.addCompat03FieldsIfAvailable(builder, interfaces, v03Card.url(), v03Card.preferredTransport());
+
+        return builder.build();
+    }
+
+    private static AgentSkill toSkill10(AgentSkill_v0_3 skill) {
+        return AgentSkill.builder()
+                .id(skill.id())
+                .name(skill.name())
+                .description(skill.description())
+                .tags(skill.tags())
+                .examples(skill.examples() != null ? skill.examples() : List.of())
+                .build();
+    }
+}

--- a/extras/opentelemetry/integration-tests/src/main/java/org/a2aproject/sdk/extras/opentelemetry/it/A2ATestRoutes.java
+++ b/extras/opentelemetry/integration-tests/src/main/java/org/a2aproject/sdk/extras/opentelemetry/it/A2ATestRoutes.java
@@ -51,6 +51,7 @@ public class A2ATestRoutes {
     void setupRoutes(@Observes Router router) {
         router.post("/test/task")
             .consumes(APPLICATION_JSON)
+            .handler(BodyHandler.create())
             .blockingHandler(ctx -> saveTask(ctx.body().asString(), ctx));
 
         router.get("/test/task/:taskId")

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/A2ARequest.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/A2ARequest.java
@@ -98,7 +98,7 @@ public abstract sealed class A2ARequest<T> implements A2AMessage permits NonStre
         }
         Assert.checkNotNullParam("method", method);
         this.method = method;
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         this.id = id;
         if (paramsIsRequired) {
             Assert.checkNotNullParam("params", params);

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/A2AResponse.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/A2AResponse.java
@@ -46,7 +46,7 @@ public abstract sealed class A2AResponse<T> implements A2AMessage permits Cancel
         if (error == null && result == null && ! Void.class.equals(resultType)) {
             throw new IllegalArgumentException("Invalid JSON-RPC success response");
         }
-        Assert.isNullOrStringOrInteger(id);
+        Assert.isValidJsonRpcId(id);
         this.jsonrpc = defaultIfNull(jsonrpc, JSONRPC_VERSION);
         this.id = id;
         this.result = result;

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,16 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>a2a-java-sdk-reference-multiversion-jsonrpc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>a2a-java-sdk-reference-multiversion-rest</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.a2aproject.sdk</groupId>
                 <artifactId>a2a-java-sdk-opentelemetry</artifactId>
                 <version>${project.version}</version>

--- a/reference/jsonrpc/src/main/java/org/a2aproject/sdk/server/apps/quarkus/A2AServerRoutes.java
+++ b/reference/jsonrpc/src/main/java/org/a2aproject/sdk/server/apps/quarkus/A2AServerRoutes.java
@@ -204,13 +204,12 @@ public class A2AServerRoutes {
      * @param router the Vert.x Web Router instance to configure
      */
     void setupRoutes(@Observes Router router) {
-        // Add BodyHandler to parse request bodies
-        router.route().handler(BodyHandler.create());
-
         // Main JSON-RPC endpoint: POST /
+        // BodyHandler is per-route (not global) to avoid interfering with gRPC routes
         // ordered=false: delegation via Vert.x WebClient can share the same event loop context as the outer request; ordered=true would serialize them, causing a 30s deadlock.
         router.post("/")
             .consumes(APPLICATION_JSON)
+            .handler(BodyHandler.create())
             .blockingHandler(ctx -> {
                 try {
                     vertxSecurityHelper.runInRequestContext(ctx, () -> {

--- a/reference/jsonrpc/src/test/java/org/a2aproject/sdk/server/apps/quarkus/A2ATestRoutes.java
+++ b/reference/jsonrpc/src/test/java/org/a2aproject/sdk/server/apps/quarkus/A2ATestRoutes.java
@@ -43,6 +43,7 @@ public class A2ATestRoutes {
         // Save task: POST /test/task
         router.post("/test/task")
             .consumes(APPLICATION_JSON)
+            .handler(BodyHandler.create())
             .blockingHandler(ctx -> {
                 String body = ctx.body().asString();
                 saveTask(body, ctx);
@@ -113,6 +114,7 @@ public class A2ATestRoutes {
 
         // Save task push notification config: POST /test/task/:taskId
         router.post("/test/task/:taskId")
+            .handler(BodyHandler.create())
             .blockingHandler(ctx -> {
                 String taskId = ctx.pathParam("taskId");
                 String body = ctx.body().asString();

--- a/spec-grpc/src/main/java/org/a2aproject/sdk/grpc/mapper/AgentCardMapper.java
+++ b/spec-grpc/src/main/java/org/a2aproject/sdk/grpc/mapper/AgentCardMapper.java
@@ -32,5 +32,6 @@ public interface AgentCardMapper {
     @Mapping(target = "iconUrl", source = "iconUrl", conditionExpression = "java(!proto.getIconUrl().isEmpty())")
     @Mapping(target = "url", ignore = true)
     @Mapping(target = "preferredTransport", ignore = true)
+    @Mapping(target = "additionalInterfaces", ignore = true)
     org.a2aproject.sdk.spec.AgentCard fromProto(org.a2aproject.sdk.grpc.AgentCard proto);
 }

--- a/spec/src/main/java/org/a2aproject/sdk/spec/AgentCard.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/AgentCard.java
@@ -58,7 +58,8 @@ public record AgentCard(
         List<AgentInterface> supportedInterfaces,
         @Nullable List<AgentCardSignature> signatures,
         @Nullable String url,
-        @Nullable String preferredTransport) {
+        @Nullable String preferredTransport,
+        @Nullable List<Legacy_0_3_AgentInterface> additionalInterfaces) {
 
     /**
      * Compact constructor that validates required fields.
@@ -160,6 +161,7 @@ public record AgentCard(
         private @Nullable List<AgentCardSignature> signatures;
         private @Nullable String url;
         private @Nullable String preferredTransport;
+        private @Nullable List<Legacy_0_3_AgentInterface> additionalInterfaces;
 
         /**
          * Creates a new Builder with all fields unset.
@@ -192,6 +194,7 @@ public record AgentCard(
             this.signatures = card.signatures() != null ? new ArrayList<>(card.signatures()) : null;
             this.url =  card.url();
             this.preferredTransport= card.preferredTransport();
+            this.additionalInterfaces = card.additionalInterfaces() != null ? new ArrayList<>(card.additionalInterfaces()) : null;
         }
 
         /**
@@ -392,6 +395,11 @@ public record AgentCard(
             return this;
         }
 
+        public Builder additionalInterfaces(List<Legacy_0_3_AgentInterface> additionalInterfaces) {
+            this.additionalInterfaces = additionalInterfaces;
+            return this;
+        }
+
         /**
          * Builds an immutable {@link AgentCard} from the current builder state.
          * <p>
@@ -417,7 +425,8 @@ public record AgentCard(
                     Assert.checkNotNullParam("supportedInterfaces", supportedInterfaces),
                     signatures,
                     url,
-                    preferredTransport == null ?  "JSONRPC" : preferredTransport);
+                    preferredTransport == null ?  "JSONRPC" : preferredTransport,
+                    additionalInterfaces);
         }
     }
 }

--- a/spec/src/main/java/org/a2aproject/sdk/spec/Compat03Fields.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/Compat03Fields.java
@@ -1,0 +1,35 @@
+package org.a2aproject.sdk.spec;
+
+import java.util.List;
+
+public final class Compat03Fields {
+
+    private static final boolean COMPAT_03_AVAILABLE;
+
+    static {
+        boolean available;
+        try {
+            Class.forName("org.a2aproject.sdk.compat03.spec.AgentCard_v0_3");
+            available = true;
+        } catch (ClassNotFoundException e) {
+            available = false;
+        }
+        COMPAT_03_AVAILABLE = available;
+    }
+
+    private Compat03Fields() {
+    }
+
+    public static void addCompat03FieldsIfAvailable(AgentCard.Builder builder,
+            List<AgentInterface> supportedInterfaces, String url, String preferredTransport) {
+        if (!COMPAT_03_AVAILABLE) {
+            return;
+        }
+        builder.url(url)
+                .preferredTransport(preferredTransport)
+                .additionalInterfaces(
+                        supportedInterfaces.stream()
+                                .map(iface -> new Legacy_0_3_AgentInterface(iface.protocolBinding(), iface.url()))
+                                .toList());
+    }
+}

--- a/spec/src/main/java/org/a2aproject/sdk/spec/Legacy_0_3_AgentInterface.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/Legacy_0_3_AgentInterface.java
@@ -1,0 +1,24 @@
+package org.a2aproject.sdk.spec;
+
+import org.a2aproject.sdk.util.Assert;
+
+/**
+ * A legacy (v0.3) representation of an agent interface, using the v0.3 field names
+ * ({@code transport} and {@code url}) for backward compatibility with older clients.
+ * <p>
+ * When included in the {@link AgentCard#additionalInterfaces()} field, this record
+ * serializes with the JSON shape expected by v0.3 clients:
+ * <pre>
+ * {"transport": "GRPC", "url": "http://localhost:9999"}
+ * </pre>
+ *
+ * @param transport the transport protocol (e.g., "JSONRPC", "GRPC", "HTTP+JSON")
+ * @param url the endpoint URL
+ */
+public record Legacy_0_3_AgentInterface(String transport, String url) {
+
+    public Legacy_0_3_AgentInterface {
+        Assert.checkNotNullParam("transport", transport);
+        Assert.checkNotNullParam("url", url);
+    }
+}

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -45,6 +45,59 @@
 
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>multi-mode</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.a2aproject.sdk</groupId>
+                    <artifactId>a2a-java-sdk-compat-0.3-reference-jsonrpc</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.a2aproject.sdk</groupId>
+                    <artifactId>a2a-java-sdk-compat-0.3-reference-grpc</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.a2aproject.sdk</groupId>
+                    <artifactId>a2a-java-sdk-compat-0.3-reference-rest</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.a2aproject.sdk</groupId>
+                    <artifactId>a2a-java-sdk-reference-multiversion-jsonrpc</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.a2aproject.sdk</groupId>
+                    <artifactId>a2a-java-sdk-reference-multiversion-rest</artifactId>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-multi-mode-source</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/multi-mode/java</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>

--- a/tck/src/multi-mode/java/org/a2aproject/sdk/sut/StubAgentCardProducer_v0_3.java
+++ b/tck/src/multi-mode/java/org/a2aproject/sdk/sut/StubAgentCardProducer_v0_3.java
@@ -1,0 +1,43 @@
+package org.a2aproject.sdk.sut;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.quarkus.arc.DefaultBean;
+
+import org.a2aproject.sdk.compat03.spec.AgentCapabilities_v0_3;
+import org.a2aproject.sdk.compat03.spec.AgentCard_v0_3;
+import org.a2aproject.sdk.compat03.spec.AgentSkill_v0_3;
+import org.a2aproject.sdk.server.PublicAgentCard;
+
+/**
+ * Stub producer that satisfies the v0.3 handler CDI requirements when the
+ * multi-mode profile adds compat-0.3 dependencies to the classpath.
+ * This will be replaced by a proper translation layer in the future.
+ */
+@ApplicationScoped
+public class StubAgentCardProducer_v0_3 {
+
+    @Produces
+    @PublicAgentCard
+    @DefaultBean
+    public AgentCard_v0_3 createStubAgentCard() {
+        return new AgentCard_v0_3.Builder()
+                .name("stub")
+                .description("Stub agent card for multi-mode testing")
+                .url("http://localhost:9999")
+                .version("0.0.0")
+                .capabilities(new AgentCapabilities_v0_3.Builder().build())
+                .defaultInputModes(List.of("text"))
+                .defaultOutputModes(List.of("text"))
+                .skills(List.of(new AgentSkill_v0_3.Builder()
+                        .id("stub")
+                        .name("stub")
+                        .description("stub")
+                        .tags(List.of())
+                        .build()))
+                .build();
+    }
+}

--- a/tests/reference/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multiversion/jsonrpc/A2ATestRoutes.java
+++ b/tests/reference/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multiversion/jsonrpc/A2ATestRoutes.java
@@ -46,6 +46,7 @@ public class A2ATestRoutes {
     void setupRoutes(@Observes Router router) {
         router.post("/test/task")
             .consumes(APPLICATION_JSON)
+            .handler(BodyHandler.create())
             .blockingHandler(ctx -> {
                 String body = ctx.body().asString();
                 saveTask(body, ctx);
@@ -105,6 +106,7 @@ public class A2ATestRoutes {
             });
 
         router.post("/test/task/:taskId")
+            .handler(BodyHandler.create())
             .blockingHandler(ctx -> {
                 String taskId = ctx.pathParam("taskId");
                 String body = ctx.body().asString();

--- a/tests/reference/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multiversion/jsonrpc/MultiVersionJSONRPC_v0_3_Test.java
+++ b/tests/reference/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multiversion/jsonrpc/MultiVersionJSONRPC_v0_3_Test.java
@@ -6,8 +6,6 @@ import org.a2aproject.sdk.compat03.client.transport.jsonrpc.JSONRPCTransport_v0_
 import org.a2aproject.sdk.compat03.client.transport.jsonrpc.JSONRPCTransportConfigBuilder_v0_3;
 import org.a2aproject.sdk.compat03.conversion.AbstractA2AServerServerTest_v0_3;
 import org.a2aproject.sdk.compat03.spec.TransportProtocol_v0_3;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 public class MultiVersionJSONRPC_v0_3_Test extends AbstractA2AServerServerTest_v0_3 {
@@ -29,11 +27,5 @@ public class MultiVersionJSONRPC_v0_3_Test extends AbstractA2AServerServerTest_v
     @Override
     protected void configureTransport(ClientBuilder_v0_3 builder) {
         builder.withTransport(JSONRPCTransport_v0_3.class, new JSONRPCTransportConfigBuilder_v0_3());
-    }
-
-    @Test
-    @Override
-    @Disabled("Agent card is v1.0 format in multi-version mode")
-    public void testGetAgentCard() {
     }
 }

--- a/tests/reference/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multiversion/jsonrpc/MultiVersionJSONRPC_v0_3_WithAuthTest.java
+++ b/tests/reference/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multiversion/jsonrpc/MultiVersionJSONRPC_v0_3_WithAuthTest.java
@@ -8,8 +8,6 @@ import org.a2aproject.sdk.compat03.client.transport.jsonrpc.JSONRPCTransportConf
 import org.a2aproject.sdk.compat03.client.transport.spi.interceptors.auth.AuthInterceptor_v0_3;
 import org.a2aproject.sdk.compat03.conversion.AbstractA2AServerWithAuthTest_v0_3;
 import org.a2aproject.sdk.compat03.spec.TransportProtocol_v0_3;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 @TestProfile(AuthTestProfile.class)
@@ -45,9 +43,4 @@ public class MultiVersionJSONRPC_v0_3_WithAuthTest extends AbstractA2AServerWith
         builder.withTransport(JSONRPCTransport_v0_3.class, new JSONRPCTransportConfigBuilder_v0_3());
     }
 
-    @Test
-    @Override
-    @Disabled("Agent card is v1.0 format in multi-version mode")
-    public void testGetAgentCardIsPublic() {
-    }
 }

--- a/tests/reference/rest/src/test/java/org/a2aproject/sdk/tests/multiversion/rest/MultiVersion_v0_3_RestTest.java
+++ b/tests/reference/rest/src/test/java/org/a2aproject/sdk/tests/multiversion/rest/MultiVersion_v0_3_RestTest.java
@@ -6,8 +6,6 @@ import org.a2aproject.sdk.compat03.client.transport.rest.RestTransport_v0_3;
 import org.a2aproject.sdk.compat03.client.transport.rest.RestTransportConfigBuilder_v0_3;
 import org.a2aproject.sdk.compat03.conversion.AbstractA2AServerServerTest_v0_3;
 import org.a2aproject.sdk.compat03.spec.TransportProtocol_v0_3;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 public class MultiVersion_v0_3_RestTest extends AbstractA2AServerServerTest_v0_3 {
@@ -29,11 +27,5 @@ public class MultiVersion_v0_3_RestTest extends AbstractA2AServerServerTest_v0_3
     @Override
     protected void configureTransport(ClientBuilder_v0_3 builder) {
         builder.withTransport(RestTransport_v0_3.class, new RestTransportConfigBuilder_v0_3());
-    }
-
-    @Test
-    @Override
-    @Disabled("Agent card is v1.0 format in multi-version mode")
-    public void testGetAgentCard() {
     }
 }

--- a/tests/reference/rest/src/test/java/org/a2aproject/sdk/tests/multiversion/rest/MultiVersion_v0_3_RestWithAuthTest.java
+++ b/tests/reference/rest/src/test/java/org/a2aproject/sdk/tests/multiversion/rest/MultiVersion_v0_3_RestWithAuthTest.java
@@ -8,7 +8,6 @@ import org.a2aproject.sdk.compat03.client.transport.rest.RestTransportConfigBuil
 import org.a2aproject.sdk.compat03.client.transport.spi.interceptors.auth.AuthInterceptor_v0_3;
 import org.a2aproject.sdk.compat03.conversion.AbstractA2AServerWithAuthTest_v0_3;
 import org.a2aproject.sdk.compat03.spec.TransportProtocol_v0_3;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -43,12 +42,6 @@ public class MultiVersion_v0_3_RestWithAuthTest extends AbstractA2AServerWithAut
     @Override
     protected void configureTransport(ClientBuilder_v0_3 builder) {
         builder.withTransport(RestTransport_v0_3.class, new RestTransportConfigBuilder_v0_3());
-    }
-
-    @Test
-    @Override
-    @Disabled("Agent card is v1.0 format in multi-version mode")
-    public void testGetAgentCardIsPublic() {
     }
 
     @Test

--- a/tests/server-common/src/test/java/org/a2aproject/sdk/server/apps/common/AgentCardProducer.java
+++ b/tests/server-common/src/test/java/org/a2aproject/sdk/server/apps/common/AgentCardProducer.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -18,6 +19,7 @@ import org.a2aproject.sdk.server.PublicAgentCard;
 import org.a2aproject.sdk.spec.AgentCapabilities;
 import org.a2aproject.sdk.spec.AgentCard;
 import org.a2aproject.sdk.spec.AgentInterface;
+import org.a2aproject.sdk.spec.Compat03Fields;
 import org.a2aproject.sdk.spec.HTTPAuthSecurityScheme;
 import org.a2aproject.sdk.spec.SecurityRequirement;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -45,6 +47,8 @@ public class AgentCardProducer {
         String preferredTransport = loadPreferredTransportFromProperties();
         String transportUrl = GRPC.toString().equals(preferredTransport) ? "localhost:" + port : "http://localhost:" + port;
 
+        List<AgentInterface> interfaces = Collections.singletonList(new AgentInterface(preferredTransport, transportUrl));
+
         AgentCard.Builder builder = AgentCard.builder()
                 .name("test-card")
                 .description("A test agent card")
@@ -58,9 +62,9 @@ public class AgentCardProducer {
                 .defaultInputModes(Collections.singletonList("text"))
                 .defaultOutputModes(Collections.singletonList("text"))
                 .skills(new ArrayList<>())
-                .supportedInterfaces(Collections.singletonList(new AgentInterface(preferredTransport, transportUrl)))
-                .url(transportUrl)
-                .preferredTransport(preferredTransport);
+                .supportedInterfaces(interfaces);
+
+        Compat03Fields.addCompat03FieldsIfAvailable(builder, interfaces, transportUrl, preferredTransport);
 
         // Add security configuration if enabled (for authentication tests)
         if (securityEnabled) {


### PR DESCRIPTION
Add CI for 0.3 TCK, and multi-mode testing (v1.0 + v0.3 together) for both TCK servers.

- Add Legacy_0_3_AgentInterface and additionalInterfaces to AgentCard so v1.0 cards are parsable by v0.3 clients
- Add DerivedAgentCardProducer in compat-0.3/tck to convert v0.3 AgentCard to v1.0 format for multi-mode
- Add multiversion dispatcher deps to both TCK multi-mode profiles
- Fix global BodyHandler consuming gRPC request bodies by moving to per-route BodyHandler in A2AServerRoutes
- Ignore additionalInterfaces in gRPC AgentCardMapper
- Add Compat03Fields utility to selectively add v0.3 fields to v1.0 AgentCard producers when running in a multi-version setup
- Enable previously @Disabled multiversion agent card tests
- Allow Long JSON-RPC request ids
