### PR TITLE
fix: Remove unneeded grpc version workaround

### DIFF
--- a/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
+++ b/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
@@ -689,9 +689,6 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
             // Extract requested protocol version from gRPC context (set by interceptor)
             // Default to current version since gRPC only handles 1.0 protocol
             String requestedVersion = getVersionFromContext();
-            if (requestedVersion == null) {
-                requestedVersion = AgentInterface.CURRENT_PROTOCOL_VERSION;
-            }
 
             // Extract requested extensions from gRPC context (set by interceptor)
             Set<String> requestedExtensions = new HashSet<>();


### PR DESCRIPTION
The workaround was introduced in #874. However, WildFly does support interceptors https://github.com/wildfly-extras/a2a-java-sdk-server-jakarta/pull/61

The assumption is that gRPC implementations will be able to get this information.