### PR TITLE
feat!: Convert spec classes to records

### DIFF
--- a/compat-0.3/client/base/src/main/java/org/a2aproject/sdk/compat03/client/ClientTaskManager_v0_3.java
+++ b/compat-0.3/client/base/src/main/java/org/a2aproject/sdk/compat03/client/ClientTaskManager_v0_3.java
@@ -52,10 +52,10 @@ public class ClientTaskManager_v0_3 {
 
     public Task_v0_3 saveTaskEvent(TaskStatusUpdateEvent_v0_3 taskStatusUpdateEvent) throws A2AClientError_v0_3 {
         if (taskId == null) {
-            taskId = taskStatusUpdateEvent.getTaskId();
+            taskId = taskStatusUpdateEvent.taskId();
         }
         if (contextId == null) {
-            contextId = taskStatusUpdateEvent.getContextId();
+            contextId = taskStatusUpdateEvent.contextId();
         }
         Task_v0_3 task = currentTask;
         if (task == null) {
@@ -67,31 +67,27 @@ public class ClientTaskManager_v0_3 {
         }
 
         Task_v0_3.Builder taskBuilder = new Task_v0_3.Builder(task);
-        if (taskStatusUpdateEvent.getStatus().message() != null) {
-            if (task.getHistory() == null) {
-                taskBuilder.history(taskStatusUpdateEvent.getStatus().message());
-            } else {
-                List<Message_v0_3> history = new ArrayList<>(task.getHistory());
-                history.add(taskStatusUpdateEvent.getStatus().message());
-                taskBuilder.history(history);
-            }
+        if (taskStatusUpdateEvent.status().message() != null) {
+            List<Message_v0_3> history = new ArrayList<>(task.history());
+            history.add(taskStatusUpdateEvent.status().message());
+            taskBuilder.history(history);
         }
-        if (taskStatusUpdateEvent.getMetadata() != null) {
-            Map<String, Object> newMetadata = task.getMetadata() != null ? new HashMap<>(task.getMetadata()) : new HashMap<>();
-            newMetadata.putAll(taskStatusUpdateEvent.getMetadata());
+        if (taskStatusUpdateEvent.metadata() != null) {
+            Map<String, Object> newMetadata = task.metadata() != null ? new HashMap<>(task.metadata()) : new HashMap<>();
+            newMetadata.putAll(taskStatusUpdateEvent.metadata());
             taskBuilder.metadata(newMetadata);
         }
-        taskBuilder.status(taskStatusUpdateEvent.getStatus());
+        taskBuilder.status(taskStatusUpdateEvent.status());
         currentTask = taskBuilder.build();
         return currentTask;
     }
 
     public Task_v0_3 saveTaskEvent(TaskArtifactUpdateEvent_v0_3 taskArtifactUpdateEvent) {
         if (taskId == null) {
-            taskId = taskArtifactUpdateEvent.getTaskId();
+            taskId = taskArtifactUpdateEvent.taskId();
         }
         if (contextId == null) {
-            contextId = taskArtifactUpdateEvent.getContextId();
+            contextId = taskArtifactUpdateEvent.contextId();
         }
         Task_v0_3 task = currentTask;
         if (task == null) {
@@ -115,13 +111,10 @@ public class ClientTaskManager_v0_3 {
      */
     public Task_v0_3 updateWithMessage(Message_v0_3 message, Task_v0_3 task) {
         Task_v0_3.Builder taskBuilder = new Task_v0_3.Builder(task);
-        List<Message_v0_3> history = task.getHistory();
-        if (history == null) {
-            history = new ArrayList<>();
-        }
-        if (task.getStatus().message() != null) {
-            history.add(task.getStatus().message());
-            taskBuilder.status(new TaskStatus_v0_3(task.getStatus().state(), null, task.getStatus().timestamp()));
+        List<Message_v0_3> history = new ArrayList<>(task.history());
+        if (task.status().message() != null) {
+            history.add(task.status().message());
+            taskBuilder.status(new TaskStatus_v0_3(task.status().state(), null, task.status().timestamp()));
         }
         history.add(message);
         taskBuilder.history(history);
@@ -132,8 +125,8 @@ public class ClientTaskManager_v0_3 {
     private void saveTask(Task_v0_3 task) {
         currentTask = task;
         if (taskId == null) {
-            taskId = currentTask.getId();
-            contextId = currentTask.getContextId();
+            taskId = currentTask.id();
+            contextId = currentTask.contextId();
         }
     }
 }

--- a/compat-0.3/client/base/src/test/java/org/a2aproject/sdk/compat03/A2A_v0_3_Test.java
+++ b/compat-0.3/client/base/src/test/java/org/a2aproject/sdk/compat03/A2A_v0_3_Test.java
@@ -20,12 +20,12 @@ public class A2A_v0_3_Test {
         String text = "Hello, world!";
         Message_v0_3 message = A2A_v0_3.toUserMessage(text);
         
-        assertEquals(Message_v0_3.Role.USER, message.getRole());
-        assertEquals(1, message.getParts().size());
-        assertEquals(text, ((TextPart_v0_3) message.getParts().get(0)).getText());
-        assertNotNull(message.getMessageId());
-        assertNull(message.getContextId());
-        assertNull(message.getTaskId());
+        assertEquals(Message_v0_3.Role.USER, message.role());
+        assertEquals(1, message.parts().size());
+        assertEquals(text, ((TextPart_v0_3) message.parts().get(0)).text());
+        assertNotNull(message.messageId());
+        assertNull(message.contextId());
+        assertNull(message.taskId());
     }
 
     @Test
@@ -34,8 +34,8 @@ public class A2A_v0_3_Test {
         String messageId = "test-message-id";
         Message_v0_3 message = A2A_v0_3.toUserMessage(text, messageId);
         
-        assertEquals(Message_v0_3.Role.USER, message.getRole());
-        assertEquals(messageId, message.getMessageId());
+        assertEquals(Message_v0_3.Role.USER, message.role());
+        assertEquals(messageId, message.messageId());
     }
 
     @Test
@@ -43,10 +43,10 @@ public class A2A_v0_3_Test {
         String text = "Hello, I'm an agent!";
         Message_v0_3 message = A2A_v0_3.toAgentMessage(text);
         
-        assertEquals(Message_v0_3.Role.AGENT, message.getRole());
-        assertEquals(1, message.getParts().size());
-        assertEquals(text, ((TextPart_v0_3) message.getParts().get(0)).getText());
-        assertNotNull(message.getMessageId());
+        assertEquals(Message_v0_3.Role.AGENT, message.role());
+        assertEquals(1, message.parts().size());
+        assertEquals(text, ((TextPart_v0_3) message.parts().get(0)).text());
+        assertNotNull(message.messageId());
     }
 
     @Test
@@ -55,8 +55,8 @@ public class A2A_v0_3_Test {
         String messageId = "agent-message-id";
         Message_v0_3 message = A2A_v0_3.toAgentMessage(text, messageId);
         
-        assertEquals(Message_v0_3.Role.AGENT, message.getRole());
-        assertEquals(messageId, message.getMessageId());
+        assertEquals(Message_v0_3.Role.AGENT, message.role());
+        assertEquals(messageId, message.messageId());
     }
 
     @Test
@@ -67,14 +67,14 @@ public class A2A_v0_3_Test {
         
         Message_v0_3 message = A2A_v0_3.createUserTextMessage(text, contextId, taskId);
         
-        assertEquals(Message_v0_3.Role.USER, message.getRole());
-        assertEquals(contextId, message.getContextId());
-        assertEquals(taskId, message.getTaskId());
-        assertEquals(1, message.getParts().size());
-        assertEquals(text, ((TextPart_v0_3) message.getParts().get(0)).getText());
-        assertNotNull(message.getMessageId());
-        assertNull(message.getMetadata());
-        assertNull(message.getReferenceTaskIds());
+        assertEquals(Message_v0_3.Role.USER, message.role());
+        assertEquals(contextId, message.contextId());
+        assertEquals(taskId, message.taskId());
+        assertEquals(1, message.parts().size());
+        assertEquals(text, ((TextPart_v0_3) message.parts().get(0)).text());
+        assertNotNull(message.messageId());
+        assertNull(message.metadata());
+        assertNull(message.referenceTaskIds());
     }
 
     @Test
@@ -83,11 +83,11 @@ public class A2A_v0_3_Test {
         
         Message_v0_3 message = A2A_v0_3.createUserTextMessage(text, null, null);
         
-        assertEquals(Message_v0_3.Role.USER, message.getRole());
-        assertNull(message.getContextId());
-        assertNull(message.getTaskId());
-        assertEquals(1, message.getParts().size());
-        assertEquals(text, ((TextPart_v0_3) message.getParts().get(0)).getText());
+        assertEquals(Message_v0_3.Role.USER, message.role());
+        assertNull(message.contextId());
+        assertNull(message.taskId());
+        assertEquals(1, message.parts().size());
+        assertEquals(text, ((TextPart_v0_3) message.parts().get(0)).text());
     }
 
     @Test
@@ -98,12 +98,12 @@ public class A2A_v0_3_Test {
         
         Message_v0_3 message = A2A_v0_3.createAgentTextMessage(text, contextId, taskId);
         
-        assertEquals(Message_v0_3.Role.AGENT, message.getRole());
-        assertEquals(contextId, message.getContextId());
-        assertEquals(taskId, message.getTaskId());
-        assertEquals(1, message.getParts().size());
-        assertEquals(text, ((TextPart_v0_3) message.getParts().get(0)).getText());
-        assertNotNull(message.getMessageId());
+        assertEquals(Message_v0_3.Role.AGENT, message.role());
+        assertEquals(contextId, message.contextId());
+        assertEquals(taskId, message.taskId());
+        assertEquals(1, message.parts().size());
+        assertEquals(text, ((TextPart_v0_3) message.parts().get(0)).text());
+        assertNotNull(message.messageId());
     }
 
     @Test
@@ -117,12 +117,12 @@ public class A2A_v0_3_Test {
         
         Message_v0_3 message = A2A_v0_3.createAgentPartsMessage(parts, contextId, taskId);
         
-        assertEquals(Message_v0_3.Role.AGENT, message.getRole());
-        assertEquals(contextId, message.getContextId());
-        assertEquals(taskId, message.getTaskId());
-        assertEquals(2, message.getParts().size());
-        assertEquals("Part 1", ((TextPart_v0_3) message.getParts().get(0)).getText());
-        assertEquals("Part 2", ((TextPart_v0_3) message.getParts().get(1)).getText());
+        assertEquals(Message_v0_3.Role.AGENT, message.role());
+        assertEquals(contextId, message.contextId());
+        assertEquals(taskId, message.taskId());
+        assertEquals(2, message.parts().size());
+        assertEquals("Part 1", ((TextPart_v0_3) message.parts().get(0)).text());
+        assertEquals("Part 2", ((TextPart_v0_3) message.parts().get(1)).text());
     }
 
     @Test

--- a/compat-0.3/client/transport/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/client/transport/jsonrpc/sse/SSEEventListener_v0_3.java
+++ b/compat-0.3/client/transport/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/client/transport/jsonrpc/sse/SSEEventListener_v0_3.java
@@ -77,7 +77,7 @@ public class SSEEventListener_v0_3 {
             String resultJson = jsonObject.get("result").toString();
             StreamingEventKind_v0_3 event = JsonUtil_v0_3.fromJson(resultJson, StreamingEventKind_v0_3.class);
             eventHandler.accept(event);
-            if (event instanceof TaskStatusUpdateEvent_v0_3 && ((TaskStatusUpdateEvent_v0_3) event).isFinal()) {
+            if (event instanceof TaskStatusUpdateEvent_v0_3 tsue && tsue.isFinal()) {
                 future.cancel(true); // close SSE channel
             }
         } else {

--- a/compat-0.3/client/transport/jsonrpc/src/test/java/org/a2aproject/sdk/compat03/client/transport/jsonrpc/JSONRPCTransportStreaming_v0_3_Test.java
+++ b/compat-0.3/client/transport/jsonrpc/src/test/java/org/a2aproject/sdk/compat03/client/transport/jsonrpc/JSONRPCTransportStreaming_v0_3_Test.java
@@ -74,8 +74,8 @@ public class JSONRPCTransportStreaming_v0_3_Test {
         assertNotNull(params);
         assertEquals(message, params.message());
         assertEquals(configuration, params.configuration());
-        assertEquals(Message_v0_3.Role.USER, params.message().getRole());
-        assertEquals("test message", ((TextPart_v0_3) params.message().getParts().get(0)).getText());
+        assertEquals(Message_v0_3.Role.USER, params.message().role());
+        assertEquals("test message", ((TextPart_v0_3) params.message().parts().get(0)).text());
     }
 
     @Test
@@ -159,16 +159,16 @@ public class JSONRPCTransportStreaming_v0_3_Test {
         assertNotNull(eventKind);
         assertInstanceOf(Task_v0_3.class, eventKind);
         Task_v0_3 task = (Task_v0_3) eventKind;
-        assertEquals("2", task.getId());
-        assertEquals("context-1234", task.getContextId());
-        assertEquals(TaskState_v0_3.COMPLETED, task.getStatus().state());
-        List<Artifact_v0_3> artifacts = task.getArtifacts();
+        assertEquals("2", task.id());
+        assertEquals("context-1234", task.contextId());
+        assertEquals(TaskState_v0_3.COMPLETED, task.status().state());
+        List<Artifact_v0_3> artifacts = task.artifacts();
         assertEquals(1, artifacts.size());
         Artifact_v0_3 artifact = artifacts.get(0);
         assertEquals("artifact-1", artifact.artifactId());
         assertEquals("joke", artifact.name());
         Part_v0_3<?> part = artifact.parts().get(0);
-        assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-        assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart_v0_3) part).getText());
+        assertEquals(Part_v0_3.Kind.TEXT, ((TextPart_v0_3) part).kind());
+        assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart_v0_3) part).text());
     }
 } 

--- a/compat-0.3/client/transport/jsonrpc/src/test/java/org/a2aproject/sdk/compat03/client/transport/jsonrpc/JSONRPCTransport_v0_3_Test.java
+++ b/compat-0.3/client/transport/jsonrpc/src/test/java/org/a2aproject/sdk/compat03/client/transport/jsonrpc/JSONRPCTransport_v0_3_Test.java
@@ -121,18 +121,18 @@ public class JSONRPCTransport_v0_3_Test {
         EventKind_v0_3 result = client.sendMessage(params, null);
         assertInstanceOf(Task_v0_3.class, result);
         Task_v0_3 task = (Task_v0_3) result;
-        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.getId());
-        assertNotNull(task.getContextId());
-        assertEquals(TaskState_v0_3.COMPLETED,task.getStatus().state());
-        assertEquals(1, task.getArtifacts().size());
-        Artifact_v0_3 artifact = task.getArtifacts().get(0);
+        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
+        assertNotNull(task.contextId());
+        assertEquals(TaskState_v0_3.COMPLETED,task.status().state());
+        assertEquals(1, task.artifacts().size());
+        Artifact_v0_3 artifact = task.artifacts().get(0);
         assertEquals("artifact-1", artifact.artifactId());
         assertEquals("joke", artifact.name());
         assertEquals(1, artifact.parts().size());
         Part_v0_3<?> part = artifact.parts().get(0);
-        assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-        assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart_v0_3) part).getText());
-        assertTrue(task.getMetadata().isEmpty());
+        assertEquals(Part_v0_3.Kind.TEXT, ((TextPart_v0_3) part).kind());
+        assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart_v0_3) part).text());
+        assertTrue(task.metadata().isEmpty());
     }
 
     @Test
@@ -169,11 +169,11 @@ public class JSONRPCTransport_v0_3_Test {
         EventKind_v0_3 result = client.sendMessage(params, null);
         assertInstanceOf(Message_v0_3.class, result);
         Message_v0_3 agentMessage = (Message_v0_3) result;
-        assertEquals(Message_v0_3.Role.AGENT, agentMessage.getRole());
-        Part_v0_3<?> part = agentMessage.getParts().get(0);
-        assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-        assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart_v0_3) part).getText());
-        assertEquals("msg-456", agentMessage.getMessageId());
+        assertEquals(Message_v0_3.Role.AGENT, agentMessage.role());
+        Part_v0_3<?> part = agentMessage.parts().get(0);
+        assertEquals(Part_v0_3.Kind.TEXT, ((TextPart_v0_3) part).kind());
+        assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart_v0_3) part).text());
+        assertEquals("msg-456", agentMessage.messageId());
     }
 
 
@@ -234,39 +234,39 @@ public class JSONRPCTransport_v0_3_Test {
         JSONRPCTransport_v0_3 client = new JSONRPCTransport_v0_3("http://localhost:4001");
         Task_v0_3 task = client.getTask(new TaskQueryParams_v0_3("de38c76d-d54c-436c-8b9f-4c2703648d64",
                 10), null);
-        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.getId());
-        assertEquals("c295ea44-7543-4f78-b524-7a38915ad6e4", task.getContextId());
-        assertEquals(TaskState_v0_3.COMPLETED, task.getStatus().state());
-        assertEquals(1, task.getArtifacts().size());
-        Artifact_v0_3 artifact = task.getArtifacts().get(0);
+        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
+        assertEquals("c295ea44-7543-4f78-b524-7a38915ad6e4", task.contextId());
+        assertEquals(TaskState_v0_3.COMPLETED, task.status().state());
+        assertEquals(1, task.artifacts().size());
+        Artifact_v0_3 artifact = task.artifacts().get(0);
         assertEquals(1, artifact.parts().size());
         assertEquals("artifact-1", artifact.artifactId());
         Part_v0_3<?> part = artifact.parts().get(0);
-        assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-        assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart_v0_3) part).getText());
-        assertTrue(task.getMetadata().isEmpty());
-        List<Message_v0_3> history = task.getHistory();
+        assertEquals(Part_v0_3.Kind.TEXT, ((TextPart_v0_3) part).kind());
+        assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart_v0_3) part).text());
+        assertTrue(task.metadata().isEmpty());
+        List<Message_v0_3> history = task.history();
         assertNotNull(history);
         assertEquals(1, history.size());
         Message_v0_3 message = history.get(0);
-        assertEquals(Message_v0_3.Role.USER, message.getRole());
-        List<Part_v0_3<?>> parts = message.getParts();
+        assertEquals(Message_v0_3.Role.USER, message.role());
+        List<Part_v0_3<?>> parts = message.parts();
         assertNotNull(parts);
         assertEquals(3, parts.size());
         part = parts.get(0);
-        assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-        assertEquals("tell me a joke", ((TextPart_v0_3)part).getText());
+        assertEquals(Part_v0_3.Kind.TEXT, ((TextPart_v0_3) part).kind());
+        assertEquals("tell me a joke", ((TextPart_v0_3)part).text());
         part = parts.get(1);
-        assertEquals(Part_v0_3.Kind.FILE, part.getKind());
-        FileContent_v0_3 filePart = ((FilePart_v0_3) part).getFile();
+        assertEquals(Part_v0_3.Kind.FILE, ((FilePart_v0_3) part).kind());
+        FileContent_v0_3 filePart = ((FilePart_v0_3) part).file();
         assertEquals("file:///path/to/file.txt", ((FileWithUri_v0_3) filePart).uri());
         assertEquals("text/plain", filePart.mimeType());
         part = parts.get(2);
-        assertEquals(Part_v0_3.Kind.FILE, part.getKind());
-        filePart = ((FilePart_v0_3) part).getFile();
+        assertEquals(Part_v0_3.Kind.FILE, ((FilePart_v0_3) part).kind());
+        filePart = ((FilePart_v0_3) part).file();
         assertEquals("aGVsbG8=", ((FileWithBytes_v0_3) filePart).bytes());
         assertEquals("hello.txt", filePart.name());
-        assertTrue(task.getMetadata().isEmpty());
+        assertTrue(task.metadata().isEmpty());
     }
 
     @Test
@@ -287,10 +287,10 @@ public class JSONRPCTransport_v0_3_Test {
         JSONRPCTransport_v0_3 client = new JSONRPCTransport_v0_3("http://localhost:4001");
         Task_v0_3 task = client.cancelTask(new TaskIdParams_v0_3("de38c76d-d54c-436c-8b9f-4c2703648d64",
                 new HashMap<>()), null);
-        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.getId());
-        assertEquals("c295ea44-7543-4f78-b524-7a38915ad6e4", task.getContextId());
-        assertEquals(TaskState_v0_3.CANCELED, task.getStatus().state());
-        assertTrue(task.getMetadata().isEmpty());
+        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
+        assertEquals("c295ea44-7543-4f78-b524-7a38915ad6e4", task.contextId());
+        assertEquals(TaskState_v0_3.CANCELED, task.status().state());
+        assertTrue(task.metadata().isEmpty());
     }
 
     @Test
@@ -380,8 +380,8 @@ public class JSONRPCTransport_v0_3_Test {
         Map<String, SecurityScheme_v0_3> securitySchemes = agentCard.securitySchemes();
         assertNotNull(securitySchemes);
         OpenIdConnectSecurityScheme_v0_3 google = (OpenIdConnectSecurityScheme_v0_3) securitySchemes.get("google");
-        assertEquals("openIdConnect", google.getType());
-        assertEquals("https://accounts.google.com/.well-known/openid-configuration", google.getOpenIdConnectUrl());
+        assertEquals("openIdConnect", google.type());
+        assertEquals("https://accounts.google.com/.well-known/openid-configuration", google.openIdConnectUrl());
         List<Map<String, List<String>>> security = agentCard.security();
         assertEquals(1, security.size());
         Map<String, List<String>> securityMap = security.get(0);
@@ -469,8 +469,8 @@ public class JSONRPCTransport_v0_3_Test {
         Map<String, SecurityScheme_v0_3> securitySchemes = agentCard.securitySchemes();
         assertNotNull(securitySchemes);
         OpenIdConnectSecurityScheme_v0_3 google = (OpenIdConnectSecurityScheme_v0_3) securitySchemes.get("google");
-        assertEquals("openIdConnect", google.getType());
-        assertEquals("https://accounts.google.com/.well-known/openid-configuration", google.getOpenIdConnectUrl());
+        assertEquals("openIdConnect", google.type());
+        assertEquals("https://accounts.google.com/.well-known/openid-configuration", google.openIdConnectUrl());
         List<Map<String, List<String>>> security = agentCard.security();
         assertEquals(1, security.size());
         Map<String, List<String>> securityMap = security.get(0);
@@ -551,18 +551,18 @@ public class JSONRPCTransport_v0_3_Test {
         EventKind_v0_3 result = client.sendMessage(params, null);
         assertInstanceOf(Task_v0_3.class, result);
         Task_v0_3 task = (Task_v0_3) result;
-        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.getId());
-        assertNotNull(task.getContextId());
-        assertEquals(TaskState_v0_3.COMPLETED, task.getStatus().state());
-        assertEquals(1, task.getArtifacts().size());
-        Artifact_v0_3 artifact = task.getArtifacts().get(0);
+        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
+        assertNotNull(task.contextId());
+        assertEquals(TaskState_v0_3.COMPLETED, task.status().state());
+        assertEquals(1, task.artifacts().size());
+        Artifact_v0_3 artifact = task.artifacts().get(0);
         assertEquals("artifact-1", artifact.artifactId());
         assertEquals("image-analysis", artifact.name());
         assertEquals(1, artifact.parts().size());
         Part_v0_3<?> part = artifact.parts().get(0);
-        assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-        assertEquals("This is an image of a cat sitting on a windowsill.", ((TextPart_v0_3) part).getText());
-        assertTrue(task.getMetadata().isEmpty());
+        assertEquals(Part_v0_3.Kind.TEXT, ((TextPart_v0_3) part).kind());
+        assertEquals("This is an image of a cat sitting on a windowsill.", ((TextPart_v0_3) part).text());
+        assertTrue(task.metadata().isEmpty());
     }
 
     @Test
@@ -609,18 +609,18 @@ public class JSONRPCTransport_v0_3_Test {
         EventKind_v0_3 result = client.sendMessage(params, null);
         assertInstanceOf(Task_v0_3.class, result);
         Task_v0_3 task = (Task_v0_3) result;
-        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.getId());
-        assertNotNull(task.getContextId());
-        assertEquals(TaskState_v0_3.COMPLETED, task.getStatus().state());
-        assertEquals(1, task.getArtifacts().size());
-        Artifact_v0_3 artifact = task.getArtifacts().get(0);
+        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
+        assertNotNull(task.contextId());
+        assertEquals(TaskState_v0_3.COMPLETED, task.status().state());
+        assertEquals(1, task.artifacts().size());
+        Artifact_v0_3 artifact = task.artifacts().get(0);
         assertEquals("artifact-1", artifact.artifactId());
         assertEquals("data-analysis", artifact.name());
         assertEquals(1, artifact.parts().size());
         Part_v0_3<?> part = artifact.parts().get(0);
-        assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-        assertEquals("Processed weather data: Temperature is 25.5°C, humidity is 60.2% in San Francisco.", ((TextPart_v0_3) part).getText());
-        assertTrue(task.getMetadata().isEmpty());
+        assertEquals(Part_v0_3.Kind.TEXT, ((TextPart_v0_3) part).kind());
+        assertEquals("Processed weather data: Temperature is 25.5°C, humidity is 60.2% in San Francisco.", ((TextPart_v0_3) part).text());
+        assertTrue(task.metadata().isEmpty());
     }
 
     @Test
@@ -667,17 +667,17 @@ public class JSONRPCTransport_v0_3_Test {
         EventKind_v0_3 result = client.sendMessage(params, null);
         assertInstanceOf(Task_v0_3.class, result);
         Task_v0_3 task = (Task_v0_3) result;
-        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.getId());
-        assertNotNull(task.getContextId());
-        assertEquals(TaskState_v0_3.COMPLETED, task.getStatus().state());
-        assertEquals(1, task.getArtifacts().size());
-        Artifact_v0_3 artifact = task.getArtifacts().get(0);
+        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
+        assertNotNull(task.contextId());
+        assertEquals(TaskState_v0_3.COMPLETED, task.status().state());
+        assertEquals(1, task.artifacts().size());
+        Artifact_v0_3 artifact = task.artifacts().get(0);
         assertEquals("artifact-1", artifact.artifactId());
         assertEquals("mixed-analysis", artifact.name());
         assertEquals(1, artifact.parts().size());
         Part_v0_3<?> part = artifact.parts().get(0);
-        assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-        assertEquals("Analyzed chart image and data: Bar chart showing quarterly data with values [10, 20, 30, 40].", ((TextPart_v0_3) part).getText());
-        assertTrue(task.getMetadata().isEmpty());
+        assertEquals(Part_v0_3.Kind.TEXT, ((TextPart_v0_3) part).kind());
+        assertEquals("Analyzed chart image and data: Bar chart showing quarterly data with values [10, 20, 30, 40].", ((TextPart_v0_3) part).text());
+        assertTrue(task.metadata().isEmpty());
     }
 }

--- a/compat-0.3/client/transport/jsonrpc/src/test/java/org/a2aproject/sdk/compat03/client/transport/jsonrpc/sse/SSEEventListener_v0_3_Test.java
+++ b/compat-0.3/client/transport/jsonrpc/src/test/java/org/a2aproject/sdk/compat03/client/transport/jsonrpc/sse/SSEEventListener_v0_3_Test.java
@@ -49,9 +49,9 @@ public class SSEEventListener_v0_3_Test {
         assertNotNull(receivedEvent.get());
         assertTrue(receivedEvent.get() instanceof Task_v0_3);
         Task_v0_3 task = (Task_v0_3) receivedEvent.get();
-        assertEquals("task-123", task.getId());
-        assertEquals("context-456", task.getContextId());
-        assertEquals(TaskState_v0_3.WORKING, task.getStatus().state());
+        assertEquals("task-123", task.id());
+        assertEquals("context-456", task.contextId());
+        assertEquals(TaskState_v0_3.WORKING, task.status().state());
     }
 
     @Test
@@ -74,12 +74,12 @@ public class SSEEventListener_v0_3_Test {
         assertNotNull(receivedEvent.get());
         assertTrue(receivedEvent.get() instanceof Message_v0_3);
         Message_v0_3 message = (Message_v0_3) receivedEvent.get();
-        assertEquals(Message_v0_3.Role.AGENT, message.getRole());
-        assertEquals("msg-123", message.getMessageId());
-        assertEquals("context-456", message.getContextId());
-        assertEquals(1, message.getParts().size());
-        assertTrue(message.getParts().get(0) instanceof TextPart_v0_3);
-        assertEquals("Hello, world!", ((TextPart_v0_3) message.getParts().get(0)).getText());
+        assertEquals(Message_v0_3.Role.AGENT, message.role());
+        assertEquals("msg-123", message.messageId());
+        assertEquals("context-456", message.contextId());
+        assertEquals(1, message.parts().size());
+        assertTrue(message.parts().get(0) instanceof TextPart_v0_3);
+        assertEquals("Hello, world!", ((TextPart_v0_3) message.parts().get(0)).text());
     }
 
     @Test
@@ -102,10 +102,10 @@ public class SSEEventListener_v0_3_Test {
         assertNotNull(receivedEvent.get());
         assertTrue(receivedEvent.get() instanceof TaskStatusUpdateEvent_v0_3);
         TaskStatusUpdateEvent_v0_3 taskStatusUpdateEvent = (TaskStatusUpdateEvent_v0_3) receivedEvent.get();
-        assertEquals("1", taskStatusUpdateEvent.getTaskId());
-        assertEquals("2", taskStatusUpdateEvent.getContextId());
+        assertEquals("1", taskStatusUpdateEvent.taskId());
+        assertEquals("2", taskStatusUpdateEvent.contextId());
         assertFalse(taskStatusUpdateEvent.isFinal());
-        assertEquals(TaskState_v0_3.SUBMITTED, taskStatusUpdateEvent.getStatus().state());
+        assertEquals(TaskState_v0_3.SUBMITTED, taskStatusUpdateEvent.status().state());
     }
 
     @Test
@@ -129,15 +129,15 @@ public class SSEEventListener_v0_3_Test {
         assertTrue(receivedEvent.get() instanceof TaskArtifactUpdateEvent_v0_3);
 
         TaskArtifactUpdateEvent_v0_3 taskArtifactUpdateEvent = (TaskArtifactUpdateEvent_v0_3) receivedEvent.get();
-        assertEquals("1", taskArtifactUpdateEvent.getTaskId());
-        assertEquals("2", taskArtifactUpdateEvent.getContextId());
-        assertFalse(taskArtifactUpdateEvent.isAppend());
-        assertTrue(taskArtifactUpdateEvent.isLastChunk());
-        Artifact_v0_3 artifact = taskArtifactUpdateEvent.getArtifact();
+        assertEquals("1", taskArtifactUpdateEvent.taskId());
+        assertEquals("2", taskArtifactUpdateEvent.contextId());
+        assertFalse(taskArtifactUpdateEvent.append());
+        assertTrue(taskArtifactUpdateEvent.lastChunk());
+        Artifact_v0_3 artifact = taskArtifactUpdateEvent.artifact();
         assertEquals("artifact-1", artifact.artifactId());
         assertEquals(1, artifact.parts().size());
-        assertEquals(Part_v0_3.Kind.TEXT, artifact.parts().get(0).getKind());
-        assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart_v0_3) artifact.parts().get(0)).getText());
+        assertEquals(Part_v0_3.Kind.TEXT, ((TextPart_v0_3) artifact.parts().get(0)).kind());
+        assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart_v0_3) artifact.parts().get(0)).text());
     }
 
     @Test
@@ -223,10 +223,10 @@ public class SSEEventListener_v0_3_Test {
         assertNotNull(receivedEvent.get());
         assertTrue(receivedEvent.get() instanceof TaskStatusUpdateEvent_v0_3);
         TaskStatusUpdateEvent_v0_3 taskStatusUpdateEvent = (TaskStatusUpdateEvent_v0_3) receivedEvent.get();
-        assertEquals("1", taskStatusUpdateEvent.getTaskId());
-        assertEquals("2", taskStatusUpdateEvent.getContextId());
+        assertEquals("1", taskStatusUpdateEvent.taskId());
+        assertEquals("2", taskStatusUpdateEvent.contextId());
         assertTrue(taskStatusUpdateEvent.isFinal());
-        assertEquals(TaskState_v0_3.COMPLETED, taskStatusUpdateEvent.getStatus().state());
+        assertEquals(TaskState_v0_3.COMPLETED, taskStatusUpdateEvent.status().state());
 
         assertTrue(future.cancelHandlerCalled);
     }

--- a/compat-0.3/client/transport/rest/src/test/java/org/a2aproject/sdk/compat03/client/transport/rest/RestTransport_v0_3_Test.java
+++ b/compat-0.3/client/transport/rest/src/test/java/org/a2aproject/sdk/compat03/client/transport/rest/RestTransport_v0_3_Test.java
@@ -131,26 +131,26 @@ public class RestTransport_v0_3_Test {
         
         RestTransport_v0_3 instance = new RestTransport_v0_3(CARD);
         EventKind_v0_3 result = instance.sendMessage(messageSendParams, context);
-        assertEquals("task", result.getKind());
+        assertEquals("task", result.kind());
         Task_v0_3 task = (Task_v0_3) result;
-        assertEquals("9b511af4-b27c-47fa-aecf-2a93c08a44f8", task.getId());
-        assertEquals("context-1234", task.getContextId());
-        assertEquals(TaskState_v0_3.SUBMITTED, task.getStatus().state());
-        assertNull(task.getStatus().message());
-        assertNull(task.getMetadata());
-        assertEquals(true, task.getArtifacts().isEmpty());
-        assertEquals(1, task.getHistory().size());
-        Message_v0_3 history = task.getHistory().get(0);
-        assertEquals("message", history.getKind());
-        assertEquals(Message_v0_3.Role.USER, history.getRole());
-        assertEquals("context-1234", history.getContextId());
-        assertEquals("message-1234", history.getMessageId());
-        assertEquals("9b511af4-b27c-47fa-aecf-2a93c08a44f8", history.getTaskId());
-        assertEquals(1, history.getParts().size());
-        assertEquals(Kind.TEXT, history.getParts().get(0).getKind());
-        assertEquals("tell me a joke", ((TextPart_v0_3) history.getParts().get(0)).getText());
-        assertNull(history.getMetadata());
-        assertNull(history.getReferenceTaskIds());
+        assertEquals("9b511af4-b27c-47fa-aecf-2a93c08a44f8", task.id());
+        assertEquals("context-1234", task.contextId());
+        assertEquals(TaskState_v0_3.SUBMITTED, task.status().state());
+        assertNull(task.status().message());
+        assertNull(task.metadata());
+        assertEquals(true, task.artifacts().isEmpty());
+        assertEquals(1, task.history().size());
+        Message_v0_3 history = task.history().get(0);
+        assertEquals("message", history.kind());
+        assertEquals(Message_v0_3.Role.USER, history.role());
+        assertEquals("context-1234", history.contextId());
+        assertEquals("message-1234", history.messageId());
+        assertEquals("9b511af4-b27c-47fa-aecf-2a93c08a44f8", history.taskId());
+        assertEquals(1, history.parts().size());
+        assertEquals(Kind.TEXT, ((TextPart_v0_3) history.parts().get(0)).kind());
+        assertEquals("tell me a joke", ((TextPart_v0_3) history.parts().get(0)).text());
+        assertNull(history.metadata());
+        assertNull(history.referenceTaskIds());
     }
 
     /**
@@ -173,10 +173,10 @@ public class RestTransport_v0_3_Test {
         RestTransport_v0_3 instance = new RestTransport_v0_3(CARD);
         Task_v0_3 task = instance.cancelTask(new TaskIdParams_v0_3("de38c76d-d54c-436c-8b9f-4c2703648d64",
                 new HashMap<>()), context);
-        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.getId());
-        assertEquals(TaskState_v0_3.CANCELED, task.getStatus().state());
-        assertNull(task.getStatus().message());
-        assertNull(task.getMetadata());
+        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
+        assertEquals(TaskState_v0_3.CANCELED, task.status().state());
+        assertNull(task.status().message());
+        assertNull(task.metadata());
     }
 
     /**
@@ -198,36 +198,36 @@ public class RestTransport_v0_3_Test {
         TaskQueryParams_v0_3 request = new TaskQueryParams_v0_3("de38c76d-d54c-436c-8b9f-4c2703648d64", 10);
         RestTransport_v0_3 instance = new RestTransport_v0_3(CARD);
         Task_v0_3 task = instance.getTask(request, context);
-        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.getId());
-        assertEquals(TaskState_v0_3.COMPLETED, task.getStatus().state());
-        assertNull(task.getStatus().message());
-        assertNull(task.getMetadata());
-        assertEquals(false, task.getArtifacts().isEmpty());
-        assertEquals(1, task.getArtifacts().size());
-        Artifact_v0_3 artifact = task.getArtifacts().get(0);
+        assertEquals("de38c76d-d54c-436c-8b9f-4c2703648d64", task.id());
+        assertEquals(TaskState_v0_3.COMPLETED, task.status().state());
+        assertNull(task.status().message());
+        assertNull(task.metadata());
+        assertEquals(false, task.artifacts().isEmpty());
+        assertEquals(1, task.artifacts().size());
+        Artifact_v0_3 artifact = task.artifacts().get(0);
         assertEquals("artifact-1", artifact.artifactId());
         assertEquals("", artifact.name());
         assertEquals(false, artifact.parts().isEmpty());
-        assertEquals(Kind.TEXT, artifact.parts().get(0).getKind());
-        assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart_v0_3) artifact.parts().get(0)).getText());
-        assertEquals(1, task.getHistory().size());
-        Message_v0_3 history = task.getHistory().get(0);
-        assertEquals("message", history.getKind());
-        assertEquals(Message_v0_3.Role.USER, history.getRole());
-        assertEquals("message-123", history.getMessageId());
-        assertEquals(3, history.getParts().size());
-        assertEquals(Kind.TEXT, history.getParts().get(0).getKind());
-        assertEquals("tell me a joke", ((TextPart_v0_3) history.getParts().get(0)).getText());
-        assertEquals(Kind.FILE, history.getParts().get(1).getKind());
-        FilePart_v0_3 part = (FilePart_v0_3) history.getParts().get(1);
-        assertEquals("text/plain", part.getFile().mimeType());
-        assertEquals("file:///path/to/file.txt", ((FileWithUri_v0_3) part.getFile()).uri());
-        part = (FilePart_v0_3) history.getParts().get(2);
-        assertEquals(Kind.FILE, part.getKind());
-        assertEquals("text/plain", part.getFile().mimeType());
-        assertEquals("hello", ((FileWithBytes_v0_3) part.getFile()).bytes());
-        assertNull(history.getMetadata());
-        assertNull(history.getReferenceTaskIds());
+        assertEquals(Kind.TEXT, ((TextPart_v0_3) artifact.parts().get(0)).kind());
+        assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart_v0_3) artifact.parts().get(0)).text());
+        assertEquals(1, task.history().size());
+        Message_v0_3 history = task.history().get(0);
+        assertEquals("message", history.kind());
+        assertEquals(Message_v0_3.Role.USER, history.role());
+        assertEquals("message-123", history.messageId());
+        assertEquals(3, history.parts().size());
+        assertEquals(Kind.TEXT, ((TextPart_v0_3) history.parts().get(0)).kind());
+        assertEquals("tell me a joke", ((TextPart_v0_3) history.parts().get(0)).text());
+        assertEquals(Kind.FILE, ((FilePart_v0_3) history.parts().get(1)).kind());
+        FilePart_v0_3 part = (FilePart_v0_3) history.parts().get(1);
+        assertEquals("text/plain", part.file().mimeType());
+        assertEquals("file:///path/to/file.txt", ((FileWithUri_v0_3) part.file()).uri());
+        part = (FilePart_v0_3) history.parts().get(2);
+        assertEquals(Kind.FILE, part.kind());
+        assertEquals("text/plain", part.file().mimeType());
+        assertEquals("hello", ((FileWithBytes_v0_3) part.file()).bytes());
+        assertNull(history.metadata());
+        assertNull(history.referenceTaskIds());
     }
 
     /**
@@ -276,9 +276,9 @@ public class RestTransport_v0_3_Test {
         boolean eventReceived = latch.await(10, TimeUnit.SECONDS);
         assertTrue(eventReceived);
         assertNotNull(receivedEvent.get());
-        assertEquals("task", receivedEvent.get().getKind());
+        assertEquals("task", receivedEvent.get().kind());
         Task_v0_3 task = (Task_v0_3) receivedEvent.get();
-        assertEquals("2", task.getId());
+        assertEquals("2", task.id());
     }
 
     /**
@@ -437,16 +437,16 @@ public class RestTransport_v0_3_Test {
         assertNotNull(eventKind);
         assertInstanceOf(Task_v0_3.class, eventKind);
         Task_v0_3 task = (Task_v0_3) eventKind;
-        assertEquals("2", task.getId());
-        assertEquals("context-1234", task.getContextId());
-        assertEquals(TaskState_v0_3.COMPLETED, task.getStatus().state());
-        List<Artifact_v0_3> artifacts = task.getArtifacts();
+        assertEquals("2", task.id());
+        assertEquals("context-1234", task.contextId());
+        assertEquals(TaskState_v0_3.COMPLETED, task.status().state());
+        List<Artifact_v0_3> artifacts = task.artifacts();
         assertEquals(1, artifacts.size());
         Artifact_v0_3 artifact = artifacts.get(0);
         assertEquals("artifact-1", artifact.artifactId());
         assertEquals("joke", artifact.name());
         Part_v0_3<?> part = artifact.parts().get(0);
-        assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-        assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart_v0_3) part).getText());
+        assertEquals(Part_v0_3.Kind.TEXT, ((TextPart_v0_3) part).kind());
+        assertEquals("Why did the chicken cross the road? To get to the other side!", ((TextPart_v0_3) part).text());
     }
 }

--- a/compat-0.3/client/transport/spi/src/main/java/org/a2aproject/sdk/compat03/client/transport/spi/interceptors/auth/AuthInterceptor_v0_3.java
+++ b/compat-0.3/client/transport/spi/src/main/java/org/a2aproject/sdk/compat03/client/transport/spi/interceptors/auth/AuthInterceptor_v0_3.java
@@ -49,7 +49,7 @@ public class AuthInterceptor_v0_3 extends ClientCallInterceptor_v0_3 {
                         continue;
                     }
                     if (securityScheme instanceof HTTPAuthSecurityScheme_v0_3 httpAuthSecurityScheme) {
-                        String scheme = httpAuthSecurityScheme.getScheme().toLowerCase(Locale.ROOT);
+                        String scheme = httpAuthSecurityScheme.scheme().toLowerCase(Locale.ROOT);
                         if (scheme.equals(BEARER_SCHEME)) {
                             updatedHeaders.put(AUTHORIZATION, getBearerValue(credential));
                             return new PayloadAndHeaders_v0_3(payload, updatedHeaders);
@@ -62,7 +62,7 @@ public class AuthInterceptor_v0_3 extends ClientCallInterceptor_v0_3 {
                         updatedHeaders.put(AUTHORIZATION, getBearerValue(credential));
                         return new PayloadAndHeaders_v0_3(payload, updatedHeaders);
                     } else if (securityScheme instanceof APIKeySecurityScheme_v0_3 apiKeySecurityScheme) {
-                        updatedHeaders.put(apiKeySecurityScheme.getName(), credential);
+                        updatedHeaders.put(apiKeySecurityScheme.name(), credential);
                         return new PayloadAndHeaders_v0_3(payload, updatedHeaders);
                     }
                 }

--- a/compat-0.3/client/transport/spi/src/test/java/org/a2aproject/sdk/compat03/client/transport/spi/interceptors/auth/AuthInterceptor_v0_3_Test.java
+++ b/compat-0.3/client/transport/spi/src/test/java/org/a2aproject/sdk/compat03/client/transport/spi/interceptors/auth/AuthInterceptor_v0_3_Test.java
@@ -77,7 +77,7 @@ public class AuthInterceptor_v0_3_Test {
         AuthTestCase authTestCase = new AuthTestCase(
                 "http://agent.com/rpc",
                 "session-id",
-                APIKeySecurityScheme_v0_3.API_KEY,
+                APIKeySecurityScheme_v0_3.TYPE,
                 "secret-api-key",
                 new APIKeySecurityScheme_v0_3("header", "x-api-key", "API Key authentication"),
                 "x-api-key",
@@ -91,7 +91,7 @@ public class AuthInterceptor_v0_3_Test {
         AuthTestCase authTestCase = new AuthTestCase(
                 "http://agent.com/rpc",
                 "session-id",
-                OAuth2SecurityScheme_v0_3.OAUTH2,
+                OAuth2SecurityScheme_v0_3.TYPE,
                 "secret-oauth-access-token",
                 new OAuth2SecurityScheme_v0_3(new OAuthFlows_v0_3.Builder().build(), "OAuth2 authentication", null),
                 "Authorization",
@@ -105,7 +105,7 @@ public class AuthInterceptor_v0_3_Test {
         AuthTestCase authTestCase = new AuthTestCase(
                 "http://agent.com/rpc",
                 "session-id",
-                OpenIdConnectSecurityScheme_v0_3.OPENID_CONNECT,
+                OpenIdConnectSecurityScheme_v0_3.TYPE,
                 "secret-oidc-id-token",
                 new OpenIdConnectSecurityScheme_v0_3("http://provider.com/.well-known/openid-configuration", "OIDC authentication"),
                 "Authorization",

--- a/compat-0.3/reference/grpc/src/main/java/org/a2aproject/sdk/compat03/server/grpc/quarkus/QuarkusGrpcHandler_v0_3.java
+++ b/compat-0.3/reference/grpc/src/main/java/org/a2aproject/sdk/compat03/server/grpc/quarkus/QuarkusGrpcHandler_v0_3.java
@@ -24,6 +24,20 @@ public class QuarkusGrpcHandler_v0_3 extends GrpcHandler_v0_3 {
     private final Instance<CallContextFactory_v0_3> callContextFactoryInstance;
     private final Executor executor;
 
+    @SuppressWarnings("NullAway.Init")
+    public QuarkusGrpcHandler_v0_3() {
+        // No-args constructor needed for spec-compliant CDI environments
+        this.agentCard = null;
+        this.callContextFactoryInstance = null;
+        this.executor = null;
+    }
+
+    public QuarkusGrpcHandler_v0_3(AgentCard_v0_3 agentCard, Instance<CallContextFactory_v0_3> callContextFactoryInstance, Executor executor) {
+        this.agentCard = agentCard;
+        this.callContextFactoryInstance = callContextFactoryInstance;
+        this.executor = executor;
+    }
+
     @Inject
     public QuarkusGrpcHandler_v0_3(@PublicAgentCard AgentCard_v0_3 agentCard,
                                    Convert_v0_3_To10RequestHandler requestHandler,

--- a/compat-0.3/reference/rest/src/test/java/org/a2aproject/sdk/compat03/server/rest/quarkus/QuarkusA2ARest_v0_3_WithAuthAndroidTest.java
+++ b/compat-0.3/reference/rest/src/test/java/org/a2aproject/sdk/compat03/server/rest/quarkus/QuarkusA2ARest_v0_3_WithAuthAndroidTest.java
@@ -54,10 +54,10 @@ public class QuarkusA2ARest_v0_3_WithAuthAndroidTest extends AbstractA2AServerWi
         saveTaskInTaskStore(MINIMAL_TASK);
 
         givenAuthenticated()
-                .get("/v1/tasks/" + MINIMAL_TASK.getId())
+                .get("/v1/tasks/" + MINIMAL_TASK.id())
                 .then()
                 .statusCode(200);
 
-        deleteTaskInTaskStore(MINIMAL_TASK.getId());
+        deleteTaskInTaskStore(MINIMAL_TASK.id());
     }
 }

--- a/compat-0.3/reference/rest/src/test/java/org/a2aproject/sdk/compat03/server/rest/quarkus/QuarkusA2ARest_v0_3_WithAuthTest.java
+++ b/compat-0.3/reference/rest/src/test/java/org/a2aproject/sdk/compat03/server/rest/quarkus/QuarkusA2ARest_v0_3_WithAuthTest.java
@@ -54,10 +54,10 @@ public class QuarkusA2ARest_v0_3_WithAuthTest extends AbstractA2AServerWithAuthT
         saveTaskInTaskStore(MINIMAL_TASK);
 
         givenAuthenticated()
-                .get("/v1/tasks/" + MINIMAL_TASK.getId())
+                .get("/v1/tasks/" + MINIMAL_TASK.id())
                 .then()
                 .statusCode(200);
 
-        deleteTaskInTaskStore(MINIMAL_TASK.getId());
+        deleteTaskInTaskStore(MINIMAL_TASK.id());
     }
 }

--- a/compat-0.3/reference/rest/src/test/java/org/a2aproject/sdk/compat03/server/rest/quarkus/QuarkusA2ARest_v0_3_WithAuthVertxTest.java
+++ b/compat-0.3/reference/rest/src/test/java/org/a2aproject/sdk/compat03/server/rest/quarkus/QuarkusA2ARest_v0_3_WithAuthVertxTest.java
@@ -59,10 +59,10 @@ public class QuarkusA2ARest_v0_3_WithAuthVertxTest extends AbstractA2AServerWith
         saveTaskInTaskStore(MINIMAL_TASK);
 
         givenAuthenticated()
-                .get("/v1/tasks/" + MINIMAL_TASK.getId())
+                .get("/v1/tasks/" + MINIMAL_TASK.id())
                 .then()
                 .statusCode(200);
 
-        deleteTaskInTaskStore(MINIMAL_TASK.getId());
+        deleteTaskInTaskStore(MINIMAL_TASK.id());
     }
 }

--- a/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/Convert_v0_3_To10RequestHandler.java
+++ b/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/Convert_v0_3_To10RequestHandler.java
@@ -72,6 +72,12 @@ public class Convert_v0_3_To10RequestHandler {
      */
     private final RequestHandler v10Handler;
 
+    @SuppressWarnings("NullAway.Init")
+    public Convert_v0_3_To10RequestHandler() {
+        // No-args constructor needed for spec-compliant CDI environments
+        this.v10Handler = null;
+    }
+
     @Inject
     public Convert_v0_3_To10RequestHandler(org.a2aproject.sdk.server.requesthandlers.RequestHandler v10Handler) {
         this.v10Handler = v10Handler;

--- a/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/MessageMapper_v0_3.java
+++ b/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/MessageMapper_v0_3.java
@@ -16,7 +16,7 @@ import org.mapstruct.Mapper;
  * <p>
  * Key differences:
  * <ul>
- *   <li>v0.3: Message is a class with getter methods (e.g., {@code getRole()}, {@code getParts()})</li>
+ *   <li>v0.3: Message is a record with accessor methods (e.g., {@code role()}, {@code parts()})</li>
  *   <li>v1.0: Message is a record with accessor methods (e.g., {@code role()}, {@code parts()})</li>
  *   <li>Role enum values have "ROLE_" prefix in v1.0</li>
  *   <li>Part types (TextPart, FilePart, DataPart) changed from classes to records in v1.0</li>
@@ -46,20 +46,20 @@ public interface MessageMapper_v0_3 {
             return null;
         }
 
-        Message.Role role = RoleMapper_v0_3.INSTANCE.toV10(v03.getRole());
-        List<Part<?>> parts = v03.getParts().stream()
+        Message.Role role = RoleMapper_v0_3.INSTANCE.toV10(v03.role());
+        List<Part<?>> parts = v03.parts().stream()
             .map(PartMapper_v0_3.INSTANCE::toV10)
             .collect(Collectors.toList());
 
         return new Message(
             role,
             parts,
-            v03.getMessageId(),
-            v03.getContextId(),
-            v03.getTaskId(),
-            v03.getReferenceTaskIds(),
-            v03.getMetadata(),
-            v03.getExtensions()
+            v03.messageId(),
+            v03.contextId(),
+            v03.taskId(),
+            v03.referenceTaskIds(),
+            v03.metadata(),
+            v03.extensions()
         );
     }
 

--- a/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/PartMapper_v0_3.java
+++ b/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/PartMapper_v0_3.java
@@ -25,7 +25,7 @@ import org.mapstruct.Mapper;
  * <p>
  * Key differences:
  * <ul>
- *   <li>v0.3: Part types are classes with getter methods (e.g., {@code getText()}, {@code getMetadata()})</li>
+ *   <li>v0.3: Part types are records with accessor methods (e.g., {@code text()}, {@code metadata()})</li>
  *   <li>v1.0: Part types are records with accessor methods (e.g., {@code text()}, {@code metadata()})</li>
  * </ul>
  * <p>
@@ -54,14 +54,14 @@ public interface PartMapper_v0_3 {
         }
 
         if (v03 instanceof TextPart_v0_3 v03Text) {
-            return new TextPart(v03Text.getText(), v03Text.getMetadata());
+            return new TextPart(v03Text.text(), v03Text.metadata());
         } else if (v03 instanceof FilePart_v0_3 v03File) {
             return new FilePart(
-                FileContentMapper_v0_3.INSTANCE.toV10(v03File.getFile()),
-                v03File.getMetadata()
+                FileContentMapper_v0_3.INSTANCE.toV10(v03File.file()),
+                v03File.metadata()
             );
         } else if (v03 instanceof DataPart_v0_3 v03Data) {
-            return new DataPart(v03Data.getData(), v03Data.getMetadata());
+            return new DataPart(v03Data.data(), v03Data.metadata());
         }
 
         throw new InvalidRequestError(null, "Unrecognized Part type: " + v03.getClass().getName(), null);

--- a/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/TaskArtifactUpdateEventMapper_v0_3.java
+++ b/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/TaskArtifactUpdateEventMapper_v0_3.java
@@ -11,7 +11,7 @@ import org.mapstruct.Mapper;
  * <p>
  * Key differences:
  * <ul>
- *   <li>v0.3: TaskArtifactUpdateEvent is a class with getter methods (e.g., {@code getTaskId()}, {@code isAppend()})</li>
+ *   <li>v0.3: TaskArtifactUpdateEvent is a record with accessor methods (e.g., {@code taskId()}, {@code append()})</li>
  *   <li>v1.0: TaskArtifactUpdateEvent is a record with accessor methods (e.g., {@code taskId()}, {@code append()})</li>
  * </ul>
  * <p>
@@ -40,12 +40,12 @@ public interface TaskArtifactUpdateEventMapper_v0_3 {
         }
 
         return new TaskArtifactUpdateEvent(
-            v03.getTaskId(),
-            ArtifactMapper_v0_3.INSTANCE.toV10(v03.getArtifact()),
-            v03.getContextId(),
-            v03.isAppend(),
-            v03.isLastChunk(),
-            v03.getMetadata()
+            v03.taskId(),
+            ArtifactMapper_v0_3.INSTANCE.toV10(v03.artifact()),
+            v03.contextId(),
+            v03.append(),
+            v03.lastChunk(),
+            v03.metadata()
         );
     }
 

--- a/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/TaskMapper_v0_3.java
+++ b/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/TaskMapper_v0_3.java
@@ -18,9 +18,9 @@ import org.mapstruct.Mapper;
  * <p>
  * Key differences:
  * <ul>
- *   <li>v0.3: Task is a class with getter methods (e.g., {@code getId()}, {@code getStatus()})</li>
+ *   <li>v0.3: Task is a record with accessor methods (e.g., {@code id()}, {@code status()})</li>
  *   <li>v1.0: Task is a record with accessor methods (e.g., {@code id()}, {@code status()})</li>
- *   <li>v0.3 has a {@code kind} field with {@code getKind()} method</li>
+ *   <li>v0.3 has a {@code kind} field with {@code kind()} method</li>
  *   <li>v1.0 has a {@code kind()} method from the {@link org.a2aproject.sdk.spec.StreamingEventKind} interface</li>
  * </ul>
  * <p>
@@ -52,25 +52,25 @@ public interface TaskMapper_v0_3 {
             return null;
         }
 
-        List<Artifact> artifacts = v03.getArtifacts() != null
-            ? v03.getArtifacts().stream()
+        List<Artifact> artifacts = v03.artifacts() != null
+            ? v03.artifacts().stream()
                 .map(ArtifactMapper_v0_3.INSTANCE::toV10)
                 .collect(Collectors.toList())
             : null;
 
-        List<Message> history = v03.getHistory() != null
-            ? v03.getHistory().stream()
+        List<Message> history = v03.history() != null
+            ? v03.history().stream()
                 .map(MessageMapper_v0_3.INSTANCE::toV10)
                 .collect(Collectors.toList())
             : null;
 
         return new Task(
-            v03.getId(),
-            v03.getContextId(),
-            TaskStatusMapper_v0_3.INSTANCE.toV10(v03.getStatus()),
+            v03.id(),
+            v03.contextId(),
+            TaskStatusMapper_v0_3.INSTANCE.toV10(v03.status()),
             artifacts,
             history,
-            v03.getMetadata()
+            v03.metadata()
         );
     }
 

--- a/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/TaskStatusUpdateEventMapper_v0_3.java
+++ b/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/TaskStatusUpdateEventMapper_v0_3.java
@@ -40,10 +40,10 @@ public interface TaskStatusUpdateEventMapper_v0_3 {
         }
 
         return new TaskStatusUpdateEvent(
-            v03.getTaskId(),
-            TaskStatusMapper_v0_3.INSTANCE.toV10(v03.getStatus()),
-            v03.getContextId(),
-            v03.getMetadata()
+            v03.taskId(),
+            TaskStatusMapper_v0_3.INSTANCE.toV10(v03.status()),
+            v03.contextId(),
+            v03.metadata()
         );
     }
 

--- a/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/AbstractA2AServerServerTest_v0_3.java
+++ b/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/AbstractA2AServerServerTest_v0_3.java
@@ -181,13 +181,13 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
     public void testTaskStoreMethodsSanityTest() throws Exception {
         Task_v0_3 task = new Task_v0_3.Builder(MINIMAL_TASK).id("abcde").build();
         saveTaskInTaskStore(task);
-        Task_v0_3 saved = getTaskFromTaskStore(task.getId());
-        assertEquals(task.getId(), saved.getId());
-        assertEquals(task.getContextId(), saved.getContextId());
-        assertEquals(task.getStatus().state(), saved.getStatus().state());
+        Task_v0_3 saved = getTaskFromTaskStore(task.id());
+        assertEquals(task.id(), saved.id());
+        assertEquals(task.contextId(), saved.contextId());
+        assertEquals(task.status().state(), saved.status().state());
 
-        deleteTaskInTaskStore(task.getId());
-        Task_v0_3 saved2 = getTaskFromTaskStore(task.getId());
+        deleteTaskInTaskStore(task.id());
+        Task_v0_3 saved2 = getTaskFromTaskStore(task.id());
         assertNull(saved2);
     }
 
@@ -203,14 +203,14 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
     private void testGetTask(String mediaType) throws Exception {
         saveTaskInTaskStore(MINIMAL_TASK);
         try {
-            Task_v0_3 response = getClient().getTask(new TaskQueryParams_v0_3(MINIMAL_TASK.getId()));
-            assertEquals("task-123", response.getId());
-            assertEquals("session-xyz", response.getContextId());
-            assertEquals(TaskState_v0_3.SUBMITTED, response.getStatus().state());
+            Task_v0_3 response = getClient().getTask(new TaskQueryParams_v0_3(MINIMAL_TASK.id()));
+            assertEquals("task-123", response.id());
+            assertEquals("session-xyz", response.contextId());
+            assertEquals(TaskState_v0_3.SUBMITTED, response.status().state());
         } catch (A2AClientException_v0_3 e) {
             fail("Unexpected exception during getTask: " + e.getMessage(), e);
         } finally {
-            deleteTaskInTaskStore(MINIMAL_TASK.getId());
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
         }
     }
 
@@ -230,14 +230,14 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
     public void testCancelTaskSuccess() throws Exception {
         saveTaskInTaskStore(CANCEL_TASK);
         try {
-            Task_v0_3 task = getClient().cancelTask(new TaskIdParams_v0_3(CANCEL_TASK.getId()));
-            assertEquals(CANCEL_TASK.getId(), task.getId());
-            assertEquals(CANCEL_TASK.getContextId(), task.getContextId());
-            assertEquals(TaskState_v0_3.CANCELED, task.getStatus().state());
+            Task_v0_3 task = getClient().cancelTask(new TaskIdParams_v0_3(CANCEL_TASK.id()));
+            assertEquals(CANCEL_TASK.id(), task.id());
+            assertEquals(CANCEL_TASK.contextId(), task.contextId());
+            assertEquals(TaskState_v0_3.CANCELED, task.status().state());
         } catch (A2AClientException_v0_3 e) {
             fail("Unexpected exception during cancel task: " + e.getMessage(), e);
         } finally {
-            deleteTaskInTaskStore(CANCEL_TASK.getId());
+            deleteTaskInTaskStore(CANCEL_TASK.id());
         }
     }
 
@@ -245,13 +245,13 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
     public void testCancelTaskNotSupported() throws Exception {
         saveTaskInTaskStore(CANCEL_TASK_NOT_SUPPORTED);
         try {
-            getClient().cancelTask(new TaskIdParams_v0_3(CANCEL_TASK_NOT_SUPPORTED.getId()));
+            getClient().cancelTask(new TaskIdParams_v0_3(CANCEL_TASK_NOT_SUPPORTED.id()));
             fail("Expected A2AClientException for unsupported cancel operation");
         } catch (A2AClientException_v0_3 e) {
             // Expected - the client should throw an exception for unsupported operations
             assertInstanceOf(UnsupportedOperationError_v0_3.class, e.getCause());
         } finally {
-            deleteTaskInTaskStore(CANCEL_TASK_NOT_SUPPORTED.getId());
+            deleteTaskInTaskStore(CANCEL_TASK_NOT_SUPPORTED.id());
         }
     }
 
@@ -294,11 +294,11 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
         assertFalse(wasUnexpectedEvent.get());
         Message_v0_3 messageResponse = receivedMessage.get();
         assertNotNull(messageResponse);
-        assertEquals(MESSAGE.getMessageId(), messageResponse.getMessageId());
-        assertEquals(MESSAGE.getRole(), messageResponse.getRole());
-        Part_v0_3<?> part = messageResponse.getParts().get(0);
-        assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-        assertEquals("test message", ((TextPart_v0_3) part).getText());
+        assertEquals(MESSAGE.messageId(), messageResponse.messageId());
+        assertEquals(MESSAGE.role(), messageResponse.role());
+        Part_v0_3<?> part = messageResponse.parts().get(0);
+        assertInstanceOf(TextPart_v0_3.class, part);
+        assertEquals("test message", ((TextPart_v0_3) part).text());
     }
 
     @Test
@@ -316,7 +316,7 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
         getNonStreamingClient().sendMessage(message, List.of((event, agentCard) -> {
             if (event instanceof TaskEvent_v0_3 te) {
                 receivedTask.set(te.getTask());
-                if (te.getTask().getStatus().state() == TaskState_v0_3.COMPLETED) {
+                if (te.getTask().status().state() == TaskState_v0_3.COMPLETED) {
                     latch.countDown();
                 }
             }
@@ -330,13 +330,13 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
 
         Task_v0_3 task = receivedTask.get();
         assertNotNull(task, "Should have received a task");
-        assertEquals(TaskState_v0_3.COMPLETED, task.getStatus().state());
-        assertNotNull(task.getArtifacts());
-        assertFalse(task.getArtifacts().isEmpty());
+        assertEquals(TaskState_v0_3.COMPLETED, task.status().state());
+        assertNotNull(task.artifacts());
+        assertFalse(task.artifacts().isEmpty());
 
-        Part_v0_3<?> part = task.getArtifacts().get(0).parts().get(0);
-        assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-        assertEquals("request-scoped:request-scoped-value", ((TextPart_v0_3) part).getText());
+        Part_v0_3<?> part = task.artifacts().get(0).parts().get(0);
+        assertEquals(Part_v0_3.Kind.TEXT, ((TextPart_v0_3) part).kind());
+        assertEquals("request-scoped:request-scoped-value", ((TextPart_v0_3) part).text());
     }
 
     @Test
@@ -344,8 +344,8 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
         saveTaskInTaskStore(MINIMAL_TASK);
         try {
             Message_v0_3 message = new Message_v0_3.Builder(MESSAGE)
-                    .taskId(MINIMAL_TASK.getId())
-                    .contextId(MINIMAL_TASK.getContextId())
+                    .taskId(MINIMAL_TASK.id())
+                    .contextId(MINIMAL_TASK.contextId())
                     .build();
 
             CountDownLatch latch = new CountDownLatch(1);
@@ -370,15 +370,15 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
             assertTrue(latch.await(10, TimeUnit.SECONDS));
             Message_v0_3 messageResponse = receivedMessage.get();
             assertNotNull(messageResponse);
-            assertEquals(MESSAGE.getMessageId(), messageResponse.getMessageId());
-            assertEquals(MESSAGE.getRole(), messageResponse.getRole());
-            Part_v0_3<?> part = messageResponse.getParts().get(0);
-            assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-            assertEquals("test message", ((TextPart_v0_3) part).getText());
+            assertEquals(MESSAGE.messageId(), messageResponse.messageId());
+            assertEquals(MESSAGE.role(), messageResponse.role());
+            Part_v0_3<?> part = messageResponse.parts().get(0);
+            assertInstanceOf(TextPart_v0_3.class, part);
+            assertEquals("test message", ((TextPart_v0_3) part).text());
         } catch (A2AClientException_v0_3 e) {
             fail("Unexpected exception during sendMessage: " + e.getMessage(), e);
         } finally {
-            deleteTaskInTaskStore(MINIMAL_TASK.getId());
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
         }
     }
 
@@ -388,15 +388,15 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
         try {
             TaskPushNotificationConfig_v0_3 taskPushConfig =
                     new TaskPushNotificationConfig_v0_3(
-                            MINIMAL_TASK.getId(), new PushNotificationConfig_v0_3.Builder().url("http://example.com").build());
+                            MINIMAL_TASK.id(), new PushNotificationConfig_v0_3.Builder().url("http://example.com").build());
             TaskPushNotificationConfig_v0_3 config = getClient().setTaskPushNotificationConfiguration(taskPushConfig);
-            assertEquals(MINIMAL_TASK.getId(), config.taskId());
+            assertEquals(MINIMAL_TASK.id(), config.taskId());
             assertEquals("http://example.com", config.pushNotificationConfig().url());
         } catch (A2AClientException_v0_3 e) {
             fail("Unexpected exception during set push notification test: " + e.getMessage(), e);
         } finally {
-            deletePushNotificationConfigInStore(MINIMAL_TASK.getId(), MINIMAL_TASK.getId());
-            deleteTaskInTaskStore(MINIMAL_TASK.getId());
+            deletePushNotificationConfigInStore(MINIMAL_TASK.id(), MINIMAL_TASK.id());
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
         }
     }
 
@@ -406,20 +406,20 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
         try {
             TaskPushNotificationConfig_v0_3 taskPushConfig =
                     new TaskPushNotificationConfig_v0_3(
-                            MINIMAL_TASK.getId(), new PushNotificationConfig_v0_3.Builder().url("http://example.com").build());
+                            MINIMAL_TASK.id(), new PushNotificationConfig_v0_3.Builder().url("http://example.com").build());
 
             TaskPushNotificationConfig_v0_3 setResult = getClient().setTaskPushNotificationConfiguration(taskPushConfig);
             assertNotNull(setResult);
 
             TaskPushNotificationConfig_v0_3 config = getClient().getTaskPushNotificationConfiguration(
-                    new GetTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId()));
-            assertEquals(MINIMAL_TASK.getId(), config.taskId());
+                    new GetTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id()));
+            assertEquals(MINIMAL_TASK.id(), config.taskId());
             assertEquals("http://example.com", config.pushNotificationConfig().url());
         } catch (A2AClientException_v0_3 e) {
             fail("Unexpected exception during get push notification test: " + e.getMessage(), e);
         } finally {
-            deletePushNotificationConfigInStore(MINIMAL_TASK.getId(), MINIMAL_TASK.getId());
-            deleteTaskInTaskStore(MINIMAL_TASK.getId());
+            deletePushNotificationConfigInStore(MINIMAL_TASK.id(), MINIMAL_TASK.id());
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
         }
     }
 
@@ -428,8 +428,8 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
         saveTaskInTaskStore(SEND_MESSAGE_NOT_SUPPORTED);
         try {
             Message_v0_3 message = new Message_v0_3.Builder(MESSAGE)
-                    .taskId(SEND_MESSAGE_NOT_SUPPORTED.getId())
-                    .contextId(SEND_MESSAGE_NOT_SUPPORTED.getContextId())
+                    .taskId(SEND_MESSAGE_NOT_SUPPORTED.id())
+                    .contextId(SEND_MESSAGE_NOT_SUPPORTED.contextId())
                     .build();
 
             try {
@@ -442,7 +442,7 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
                 assertInstanceOf(UnsupportedOperationError_v0_3.class, e.getCause());
             }
         } finally {
-            deleteTaskInTaskStore(SEND_MESSAGE_NOT_SUPPORTED.getId());
+            deleteTaskInTaskStore(SEND_MESSAGE_NOT_SUPPORTED.id());
         }
     }
 
@@ -480,7 +480,7 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
             // attempting to send a streaming message instead of explicitly calling queueManager#createOrTap
             // does not work because after the message is sent, the queue becomes null but task resubscription
             // requires the queue to still be active
-            ensureQueueForTask(MINIMAL_TASK.getId());
+            ensureQueueForTask(MINIMAL_TASK.id());
 
             CountDownLatch eventLatch = new CountDownLatch(2);
             AtomicReference<TaskArtifactUpdateEvent_v0_3> artifactUpdateEvent = new AtomicReference<>();
@@ -526,7 +526,7 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
                     .whenComplete((unused, throwable) -> subscriptionLatch.countDown());
 
             // Resubscribe to the task with specific consumer and error handler
-            getClient().resubscribe(new TaskIdParams_v0_3(MINIMAL_TASK.getId()), List.of(consumer), errorHandler);
+            getClient().resubscribe(new TaskIdParams_v0_3(MINIMAL_TASK.id()), List.of(consumer), errorHandler);
 
             // Wait for subscription to be established
             assertTrue(subscriptionLatch.await(15, TimeUnit.SECONDS));
@@ -534,16 +534,16 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
             // Enqueue events on the server
             List<Event_v0_3> events = List.of(
                     new TaskArtifactUpdateEvent_v0_3.Builder()
-                            .taskId(MINIMAL_TASK.getId())
-                            .contextId(MINIMAL_TASK.getContextId())
+                            .taskId(MINIMAL_TASK.id())
+                            .contextId(MINIMAL_TASK.contextId())
                             .artifact(new Artifact_v0_3.Builder()
                                     .artifactId("11")
                                     .parts(new TextPart_v0_3("text"))
                                     .build())
                             .build(),
                     new TaskStatusUpdateEvent_v0_3.Builder()
-                            .taskId(MINIMAL_TASK.getId())
-                            .contextId(MINIMAL_TASK.getContextId())
+                            .taskId(MINIMAL_TASK.id())
+                            .contextId(MINIMAL_TASK.contextId())
                             .status(new TaskStatus_v0_3(TaskState_v0_3.COMPLETED))
                             .isFinal(true)
                             .build());
@@ -560,21 +560,21 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
             // Verify artifact update event
             TaskArtifactUpdateEvent_v0_3 receivedArtifactEvent = artifactUpdateEvent.get();
             assertNotNull(receivedArtifactEvent);
-            assertEquals(MINIMAL_TASK.getId(), receivedArtifactEvent.getTaskId());
-            assertEquals(MINIMAL_TASK.getContextId(), receivedArtifactEvent.getContextId());
-            Part_v0_3<?> part = receivedArtifactEvent.getArtifact().parts().get(0);
-            assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-            assertEquals("text", ((TextPart_v0_3) part).getText());
+            assertEquals(MINIMAL_TASK.id(), receivedArtifactEvent.taskId());
+            assertEquals(MINIMAL_TASK.contextId(), receivedArtifactEvent.contextId());
+            Part_v0_3<?> part = receivedArtifactEvent.artifact().parts().get(0);
+            assertInstanceOf(TextPart_v0_3.class, part);
+            assertEquals("text", ((TextPart_v0_3) part).text());
 
             // Verify status update event
             TaskStatusUpdateEvent_v0_3 receivedStatusEvent = statusUpdateEvent.get();
             assertNotNull(receivedStatusEvent);
-            assertEquals(MINIMAL_TASK.getId(), receivedStatusEvent.getTaskId());
-            assertEquals(MINIMAL_TASK.getContextId(), receivedStatusEvent.getContextId());
-            assertEquals(TaskState_v0_3.COMPLETED, receivedStatusEvent.getStatus().state());
-            assertNotNull(receivedStatusEvent.getStatus().timestamp());
+            assertEquals(MINIMAL_TASK.id(), receivedStatusEvent.taskId());
+            assertEquals(MINIMAL_TASK.contextId(), receivedStatusEvent.contextId());
+            assertEquals(TaskState_v0_3.COMPLETED, receivedStatusEvent.status().state());
+            assertNotNull(receivedStatusEvent.status().timestamp());
         } finally {
-            deleteTaskInTaskStore(MINIMAL_TASK.getId());
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
         }
     }
 
@@ -645,7 +645,7 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
         saveTaskInTaskStore(MINIMAL_TASK);
         try {
             // 1. Ensure queue exists for the task
-            ensureQueueForTask(MINIMAL_TASK.getId());
+            ensureQueueForTask(MINIMAL_TASK.id());
 
             // 2. First consumer subscribes and receives initial event
             CountDownLatch firstConsumerLatch = new CountDownLatch(1);
@@ -681,7 +681,7 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
             awaitStreamingSubscription()
                     .whenComplete((unused, throwable) -> firstSubscriptionLatch.countDown());
 
-            getClient().resubscribe(new TaskIdParams_v0_3(MINIMAL_TASK.getId()),
+            getClient().resubscribe(new TaskIdParams_v0_3(MINIMAL_TASK.id()),
                     List.of(firstConsumer),
                     firstErrorHandler);
 
@@ -689,8 +689,8 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
 
             // Enqueue first event
             TaskArtifactUpdateEvent_v0_3 event1 = new TaskArtifactUpdateEvent_v0_3.Builder()
-                    .taskId(MINIMAL_TASK.getId())
-                    .contextId(MINIMAL_TASK.getContextId())
+                    .taskId(MINIMAL_TASK.id())
+                    .contextId(MINIMAL_TASK.contextId())
                     .artifact(new Artifact_v0_3.Builder()
                             .artifactId("artifact-1")
                             .parts(new TextPart_v0_3("First artifact"))
@@ -705,7 +705,7 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
             assertNotNull(firstConsumerEvent.get());
 
             // Verify we have multiple child queues (ensureQueue + first resubscribe)
-            int childCountBeforeSecond = getChildQueueCount(MINIMAL_TASK.getId());
+            int childCountBeforeSecond = getChildQueueCount(MINIMAL_TASK.id());
             assertTrue(childCountBeforeSecond >= 2, "Should have at least 2 child queues");
 
             // 3. Second consumer resubscribes while first is still active
@@ -747,21 +747,21 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
 
             // This should succeed with reference counting because MainQueue stays alive
             // while first consumer's ChildQueue exists
-            getClient().resubscribe(new TaskIdParams_v0_3(MINIMAL_TASK.getId()),
+            getClient().resubscribe(new TaskIdParams_v0_3(MINIMAL_TASK.id()),
                     List.of(secondConsumer),
                     secondErrorHandler);
 
             assertTrue(secondSubscriptionLatch.await(15, TimeUnit.SECONDS), "Second subscription should be established");
 
             // Verify child queue count increased (now ensureQueue + first + second)
-            int childCountAfterSecond = getChildQueueCount(MINIMAL_TASK.getId());
+            int childCountAfterSecond = getChildQueueCount(MINIMAL_TASK.id());
             assertTrue(childCountAfterSecond > childCountBeforeSecond,
                     "Child queue count should increase after second resubscription");
 
             // 4. Enqueue second event - both consumers should receive it
             TaskArtifactUpdateEvent_v0_3 event2 = new TaskArtifactUpdateEvent_v0_3.Builder()
-                    .taskId(MINIMAL_TASK.getId())
-                    .contextId(MINIMAL_TASK.getContextId())
+                    .taskId(MINIMAL_TASK.id())
+                    .contextId(MINIMAL_TASK.contextId())
                     .artifact(new Artifact_v0_3.Builder()
                             .artifactId("artifact-2")
                             .parts(new TextPart_v0_3("Second artifact"))
@@ -777,11 +777,11 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
 
             TaskArtifactUpdateEvent_v0_3 receivedEvent = secondConsumerEvent.get();
             assertNotNull(receivedEvent);
-            assertEquals("artifact-2", receivedEvent.getArtifact().artifactId());
-            assertEquals("Second artifact", ((TextPart_v0_3) receivedEvent.getArtifact().parts().get(0)).getText());
+            assertEquals("artifact-2", receivedEvent.artifact().artifactId());
+            assertEquals("Second artifact", ((TextPart_v0_3) receivedEvent.artifact().parts().get(0)).text());
 
         } finally {
-            deleteTaskInTaskStore(MINIMAL_TASK.getId());
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
         }
     }
 
@@ -823,21 +823,21 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
                         .url("http://example.com")
                         .id("config2")
                         .build();
-        savePushNotificationConfigInStore(MINIMAL_TASK.getId(), notificationConfig1);
-        savePushNotificationConfigInStore(MINIMAL_TASK.getId(), notificationConfig2);
+        savePushNotificationConfigInStore(MINIMAL_TASK.id(), notificationConfig1);
+        savePushNotificationConfigInStore(MINIMAL_TASK.id(), notificationConfig2);
 
         try {
             List<TaskPushNotificationConfig_v0_3> result = getClient().listTaskPushNotificationConfigurations(
-                    new ListTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId()));
+                    new ListTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id()));
             assertEquals(2, result.size());
-            assertEquals(new TaskPushNotificationConfig_v0_3(MINIMAL_TASK.getId(), notificationConfig1), result.get(0));
-            assertEquals(new TaskPushNotificationConfig_v0_3(MINIMAL_TASK.getId(), notificationConfig2), result.get(1));
+            assertEquals(new TaskPushNotificationConfig_v0_3(MINIMAL_TASK.id(), notificationConfig1), result.get(0));
+            assertEquals(new TaskPushNotificationConfig_v0_3(MINIMAL_TASK.id(), notificationConfig2), result.get(1));
         } catch (Exception e) {
             fail();
         } finally {
-            deletePushNotificationConfigInStore(MINIMAL_TASK.getId(), "config1");
-            deletePushNotificationConfigInStore(MINIMAL_TASK.getId(), "config2");
-            deleteTaskInTaskStore(MINIMAL_TASK.getId());
+            deletePushNotificationConfigInStore(MINIMAL_TASK.id(), "config1");
+            deletePushNotificationConfigInStore(MINIMAL_TASK.id(), "config2");
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
         }
     }
 
@@ -852,26 +852,26 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
                 new PushNotificationConfig_v0_3.Builder()
                         .url("http://2.example.com")
                         .build();
-        savePushNotificationConfigInStore(MINIMAL_TASK.getId(), notificationConfig1);
+        savePushNotificationConfigInStore(MINIMAL_TASK.id(), notificationConfig1);
 
         // will overwrite the previous one
-        savePushNotificationConfigInStore(MINIMAL_TASK.getId(), notificationConfig2);
+        savePushNotificationConfigInStore(MINIMAL_TASK.id(), notificationConfig2);
         try {
             List<TaskPushNotificationConfig_v0_3> result = getClient().listTaskPushNotificationConfigurations(
-                    new ListTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId()));
+                    new ListTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id()));
             assertEquals(1, result.size());
 
             PushNotificationConfig_v0_3 expectedNotificationConfig = new PushNotificationConfig_v0_3.Builder()
                     .url("http://2.example.com")
-                    .id(MINIMAL_TASK.getId())
+                    .id(MINIMAL_TASK.id())
                     .build();
-            assertEquals(new TaskPushNotificationConfig_v0_3(MINIMAL_TASK.getId(), expectedNotificationConfig),
+            assertEquals(new TaskPushNotificationConfig_v0_3(MINIMAL_TASK.id(), expectedNotificationConfig),
                     result.get(0));
         } catch (Exception e) {
             fail();
         } finally {
-            deletePushNotificationConfigInStore(MINIMAL_TASK.getId(), MINIMAL_TASK.getId());
-            deleteTaskInTaskStore(MINIMAL_TASK.getId());
+            deletePushNotificationConfigInStore(MINIMAL_TASK.id(), MINIMAL_TASK.id());
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
         }
     }
 
@@ -891,12 +891,12 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
         saveTaskInTaskStore(MINIMAL_TASK);
         try {
             List<TaskPushNotificationConfig_v0_3> result = getClient().listTaskPushNotificationConfigurations(
-                    new ListTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId()));
+                    new ListTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id()));
             assertEquals(0, result.size());
         } catch (Exception e) {
             fail(e.getMessage());
         } finally {
-            deleteTaskInTaskStore(MINIMAL_TASK.getId());
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
         }
     }
 
@@ -919,18 +919,18 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
                         .url("http://example.com")
                         .id("config2")
                         .build();
-        savePushNotificationConfigInStore(MINIMAL_TASK.getId(), notificationConfig1);
-        savePushNotificationConfigInStore(MINIMAL_TASK.getId(), notificationConfig2);
+        savePushNotificationConfigInStore(MINIMAL_TASK.id(), notificationConfig1);
+        savePushNotificationConfigInStore(MINIMAL_TASK.id(), notificationConfig2);
         savePushNotificationConfigInStore("task-456", notificationConfig1);
 
         try {
             // specify the config ID to delete
             getClient().deleteTaskPushNotificationConfigurations(
-                    new DeleteTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId(), "config1"));
+                    new DeleteTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id(), "config1"));
 
             // should now be 1 left
             List<TaskPushNotificationConfig_v0_3> result = getClient().listTaskPushNotificationConfigurations(
-                    new ListTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId()));
+                    new ListTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id()));
             assertEquals(1, result.size());
 
             // should remain unchanged, this is a different task
@@ -940,10 +940,10 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
         } catch (Exception e) {
             fail(e.getMessage());
         } finally {
-            deletePushNotificationConfigInStore(MINIMAL_TASK.getId(), "config1");
-            deletePushNotificationConfigInStore(MINIMAL_TASK.getId(), "config2");
+            deletePushNotificationConfigInStore(MINIMAL_TASK.id(), "config1");
+            deletePushNotificationConfigInStore(MINIMAL_TASK.id(), "config2");
             deletePushNotificationConfigInStore("task-456", "config1");
-            deleteTaskInTaskStore(MINIMAL_TASK.getId());
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
             deleteTaskInTaskStore("task-456");
         }
     }
@@ -961,23 +961,23 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
                         .url("http://example.com")
                         .id("config2")
                         .build();
-        savePushNotificationConfigInStore(MINIMAL_TASK.getId(), notificationConfig1);
-        savePushNotificationConfigInStore(MINIMAL_TASK.getId(), notificationConfig2);
+        savePushNotificationConfigInStore(MINIMAL_TASK.id(), notificationConfig1);
+        savePushNotificationConfigInStore(MINIMAL_TASK.id(), notificationConfig2);
 
         try {
             getClient().deleteTaskPushNotificationConfigurations(
-                    new DeleteTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId(), "non-existent-config-id"));
+                    new DeleteTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id(), "non-existent-config-id"));
 
             // should remain unchanged
             List<TaskPushNotificationConfig_v0_3> result = getClient().listTaskPushNotificationConfigurations(
-                    new ListTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId()));
+                    new ListTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id()));
             assertEquals(2, result.size());
         } catch (Exception e) {
             fail();
         } finally {
-            deletePushNotificationConfigInStore(MINIMAL_TASK.getId(), "config1");
-            deletePushNotificationConfigInStore(MINIMAL_TASK.getId(), "config2");
-            deleteTaskInTaskStore(MINIMAL_TASK.getId());
+            deletePushNotificationConfigInStore(MINIMAL_TASK.id(), "config1");
+            deletePushNotificationConfigInStore(MINIMAL_TASK.id(), "config2");
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
         }
     }
 
@@ -1004,24 +1004,24 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
                 new PushNotificationConfig_v0_3.Builder()
                         .url("http://2.example.com")
                         .build();
-        savePushNotificationConfigInStore(MINIMAL_TASK.getId(), notificationConfig1);
+        savePushNotificationConfigInStore(MINIMAL_TASK.id(), notificationConfig1);
 
         // this one will overwrite the previous one
-        savePushNotificationConfigInStore(MINIMAL_TASK.getId(), notificationConfig2);
+        savePushNotificationConfigInStore(MINIMAL_TASK.id(), notificationConfig2);
 
         try {
             getClient().deleteTaskPushNotificationConfigurations(
-                    new DeleteTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId(), MINIMAL_TASK.getId()));
+                    new DeleteTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id(), MINIMAL_TASK.id()));
 
             // should now be 0
             List<TaskPushNotificationConfig_v0_3> result = getClient().listTaskPushNotificationConfigurations(
-                    new ListTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId()), null);
+                    new ListTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id()), null);
             assertEquals(0, result.size());
         } catch (Exception e) {
             fail();
         } finally {
-            deletePushNotificationConfigInStore(MINIMAL_TASK.getId(), MINIMAL_TASK.getId());
-            deleteTaskInTaskStore(MINIMAL_TASK.getId());
+            deletePushNotificationConfigInStore(MINIMAL_TASK.id(), MINIMAL_TASK.id());
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
         }
     }
 
@@ -1041,10 +1041,10 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
 
         BiConsumer<ClientEvent_v0_3, AgentCard_v0_3> firstMessageConsumer = (event, agentCard) -> {
             if (event instanceof TaskEvent_v0_3 te) {
-                taskIdRef.set(te.getTask().getId());
+                taskIdRef.set(te.getTask().id());
                 firstTaskLatch.countDown();
             } else if (event instanceof TaskUpdateEvent_v0_3 tue && tue.getUpdateEvent() instanceof TaskStatusUpdateEvent_v0_3 status) {
-                taskIdRef.set(status.getTaskId());
+                taskIdRef.set(status.taskId());
                 firstTaskLatch.countDown();
             }
         };
@@ -1174,18 +1174,18 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
                 .filter(e -> e instanceof TaskArtifactUpdateEvent_v0_3)
                 .findFirst()
                 .orElseThrow();
-        assertEquals("artifact-2", resubArtifact.getArtifact().artifactId());
+        assertEquals("artifact-2", resubArtifact.artifact().artifactId());
         assertEquals("Second message artifact",
-                ((TextPart_v0_3) resubArtifact.getArtifact().parts().get(0)).getText());
+                ((TextPart_v0_3) resubArtifact.artifact().parts().get(0)).text());
 
         // Verify artifact-2 details from streaming
         TaskArtifactUpdateEvent_v0_3 streamArtifact = (TaskArtifactUpdateEvent_v0_3) streamReceivedEvents.stream()
                 .filter(e -> e instanceof TaskArtifactUpdateEvent_v0_3)
                 .findFirst()
                 .orElseThrow();
-        assertEquals("artifact-2", streamArtifact.getArtifact().artifactId());
+        assertEquals("artifact-2", streamArtifact.artifact().artifactId());
         assertEquals("Second message artifact",
-                ((TextPart_v0_3) streamArtifact.getArtifact().parts().get(0)).getText());
+                ((TextPart_v0_3) streamArtifact.artifact().parts().get(0)).text());
         } finally {
             String taskId = generatedTaskIdRef.get();
             if (taskId != null) {
@@ -1368,8 +1368,8 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
         saveTaskInTaskStore(MINIMAL_TASK);
         try {
         Message_v0_3 message = new Message_v0_3.Builder(MESSAGE)
-                .taskId(MINIMAL_TASK.getId())
-                .contextId(MINIMAL_TASK.getContextId())
+                .taskId(MINIMAL_TASK.id())
+                .contextId(MINIMAL_TASK.contextId())
                 .build();
         SendStreamingMessageRequest_v0_3 request = new SendStreamingMessageRequest_v0_3(
                 "1", new MessageSendParams_v0_3(message, null, null));
@@ -1389,11 +1389,11 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
                     if (jsonResponse != null) {
                         assertNull(jsonResponse.getError());
                         Message_v0_3 messageResponse = (Message_v0_3) jsonResponse.getResult();
-                        assertEquals(MESSAGE.getMessageId(), messageResponse.getMessageId());
-                        assertEquals(MESSAGE.getRole(), messageResponse.getRole());
-                        Part_v0_3<?> part = messageResponse.getParts().get(0);
-                        assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-                        assertEquals("test message", ((TextPart_v0_3) part).getText());
+                        assertEquals(MESSAGE.messageId(), messageResponse.messageId());
+                        assertEquals(MESSAGE.role(), messageResponse.role());
+                        Part_v0_3<?> part = messageResponse.parts().get(0);
+                        assertInstanceOf(TextPart_v0_3.class, part);
+                        assertEquals("test message", ((TextPart_v0_3) part).text());
                         latch.countDown();
                     }
                 } catch (JsonProcessingException_v0_3 e) {
@@ -1413,7 +1413,7 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
         Assertions.assertNull(errorRef.get());
 
         } finally {
-            deleteTaskInTaskStore(MINIMAL_TASK.getId());
+            deleteTaskInTaskStore(MINIMAL_TASK.id());
         }
     }
 
@@ -1424,7 +1424,7 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
         try {
             Message_v0_3.Builder messageBuilder = new Message_v0_3.Builder(MESSAGE);
             if (createTask) {
-                messageBuilder.taskId(MINIMAL_TASK.getId()).contextId(MINIMAL_TASK.getContextId());
+                messageBuilder.taskId(MINIMAL_TASK.id()).contextId(MINIMAL_TASK.contextId());
             }
             Message_v0_3 message = messageBuilder.build();
 
@@ -1460,16 +1460,16 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
 
             Message_v0_3 messageResponse = receivedMessage.get();
             assertNotNull(messageResponse);
-            assertEquals(MESSAGE.getMessageId(), messageResponse.getMessageId());
-            assertEquals(MESSAGE.getRole(), messageResponse.getRole());
-            Part_v0_3<?> part = messageResponse.getParts().get(0);
-            assertEquals(Part_v0_3.Kind.TEXT, part.getKind());
-            assertEquals("test message", ((TextPart_v0_3) part).getText());
+            assertEquals(MESSAGE.messageId(), messageResponse.messageId());
+            assertEquals(MESSAGE.role(), messageResponse.role());
+            Part_v0_3<?> part = messageResponse.parts().get(0);
+            assertInstanceOf(TextPart_v0_3.class, part);
+            assertEquals("test message", ((TextPart_v0_3) part).text());
         } catch (A2AClientException_v0_3 e) {
             fail("Unexpected exception during sendMessage: " + e.getMessage(), e);
         } finally {
             if (createTask) {
-                deleteTaskInTaskStore(MINIMAL_TASK.getId());
+                deleteTaskInTaskStore(MINIMAL_TASK.id());
             }
         }
     }
@@ -1617,10 +1617,10 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
         Object v10Event;
 
         if (event instanceof TaskArtifactUpdateEvent_v0_3 e) {
-            path = "test/queue/enqueueTaskArtifactUpdateEvent/" + e.getTaskId();
+            path = "test/queue/enqueueTaskArtifactUpdateEvent/" + e.taskId();
             v10Event = TaskArtifactUpdateEventMapper_v0_3.INSTANCE.toV10(e);
         } else if (event instanceof TaskStatusUpdateEvent_v0_3 e) {
-            path = "test/queue/enqueueTaskStatusUpdateEvent/" + e.getTaskId();
+            path = "test/queue/enqueueTaskStatusUpdateEvent/" + e.taskId();
             v10Event = TaskStatusUpdateEventMapper_v0_3.INSTANCE.toV10(e);
         } else {
             throw new RuntimeException("Unknown event type " + event.getClass() + ". If you need the ability to" +
@@ -1983,18 +1983,18 @@ public abstract class AbstractA2AServerServerTest_v0_3 {
 
         BiConsumer<ClientEvent_v0_3, AgentCard_v0_3> consumer = (event, agentCard) -> {
             if (event instanceof TaskEvent_v0_3 te) {
-                generatedTaskId.compareAndSet(null, te.getTask().getId());
+                generatedTaskId.compareAndSet(null, te.getTask().id());
                 // Might get Task with final state
-                if (te.getTask().getStatus().state().isFinal()) {
+                if (te.getTask().status().state().isFinal()) {
                     completionLatch.countDown();
                 }
             } else if (event instanceof MessageEvent_v0_3 me) {
                 // Message is considered a final event - capture taskId from the message
-                generatedTaskId.compareAndSet(null, me.getMessage().getTaskId());
+                generatedTaskId.compareAndSet(null, me.getMessage().taskId());
                 completionLatch.countDown();
             } else if (event instanceof TaskUpdateEvent_v0_3 tue &&
                     tue.getUpdateEvent() instanceof TaskStatusUpdateEvent_v0_3 status) {
-                generatedTaskId.compareAndSet(null, status.getTaskId());
+                generatedTaskId.compareAndSet(null, status.taskId());
                 if (status.isFinal()) {
                     completionLatch.countDown();
                 }

--- a/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/AbstractA2AServerWithAuthTest_v0_3.java
+++ b/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/AbstractA2AServerWithAuthTest_v0_3.java
@@ -195,14 +195,14 @@ public abstract class AbstractA2AServerWithAuthTest_v0_3 {
 
         Client_v0_3 unauthClient = getUnauthenticatedClient();
         A2AClientException_v0_3 error = assertThrows(A2AClientException_v0_3.class, () -> {
-            unauthClient.getTask(new TaskQueryParams_v0_3(MINIMAL_TASK.getId()));
+            unauthClient.getTask(new TaskQueryParams_v0_3(MINIMAL_TASK.id()));
         });
         assertTrue(error.getMessage().contains("Authentication failed") ||
                    error.getMessage().contains("401") ||
                    error.getMessage().contains("Unauthorized"),
                 "Expected authentication error, got: " + error.getMessage());
 
-        deleteTaskInTaskStore(MINIMAL_TASK.getId());
+        deleteTaskInTaskStore(MINIMAL_TASK.id());
     }
 
     @Test
@@ -210,11 +210,11 @@ public abstract class AbstractA2AServerWithAuthTest_v0_3 {
         saveTaskInTaskStore(MINIMAL_TASK);
 
         Client_v0_3 client = getAuthenticatedClient();
-        Task_v0_3 result = client.getTask(new TaskQueryParams_v0_3(MINIMAL_TASK.getId()));
+        Task_v0_3 result = client.getTask(new TaskQueryParams_v0_3(MINIMAL_TASK.id()));
         assertNotNull(result);
-        assertEquals(MINIMAL_TASK.getId(), result.getId());
+        assertEquals(MINIMAL_TASK.id(), result.id());
 
-        deleteTaskInTaskStore(MINIMAL_TASK.getId());
+        deleteTaskInTaskStore(MINIMAL_TASK.id());
     }
 
     @Test
@@ -231,11 +231,11 @@ public abstract class AbstractA2AServerWithAuthTest_v0_3 {
 
         givenAuthenticated()
                 .contentType("application/json")
-                .body("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tasks/get\",\"params\":{\"id\":\"" + MINIMAL_TASK.getId() + "\"}}")
+                .body("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tasks/get\",\"params\":{\"id\":\"" + MINIMAL_TASK.id() + "\"}}")
                 .post("/")
                 .then()
                 .statusCode(200);
 
-        deleteTaskInTaskStore(MINIMAL_TASK.getId());
+        deleteTaskInTaskStore(MINIMAL_TASK.id());
     }
 }

--- a/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/TaskMapper_v0_3_Test.java
+++ b/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/TaskMapper_v0_3_Test.java
@@ -125,14 +125,14 @@ class TaskMapper_v0_3_Test {
 
         // Verify round-trip conversion
         assertNotNull(v03TaskRoundTrip);
-        assertEquals("task-001", v03TaskRoundTrip.getId());
-        assertEquals("ctx-001", v03TaskRoundTrip.getContextId());
-        assertEquals(TaskState_v0_3.WORKING, v03TaskRoundTrip.getStatus().state());
-        assertEquals("msg-001", v03TaskRoundTrip.getStatus().message().getMessageId());
-        assertEquals(1, v03TaskRoundTrip.getArtifacts().size());
-        assertEquals("artifact-001", v03TaskRoundTrip.getArtifacts().get(0).artifactId());
-        assertEquals(1, v03TaskRoundTrip.getHistory().size());
-        assertEquals("msg-002", v03TaskRoundTrip.getHistory().get(0).getMessageId());
+        assertEquals("task-001", v03TaskRoundTrip.id());
+        assertEquals("ctx-001", v03TaskRoundTrip.contextId());
+        assertEquals(TaskState_v0_3.WORKING, v03TaskRoundTrip.status().state());
+        assertEquals("msg-001", v03TaskRoundTrip.status().message().messageId());
+        assertEquals(1, v03TaskRoundTrip.artifacts().size());
+        assertEquals("artifact-001", v03TaskRoundTrip.artifacts().get(0).artifactId());
+        assertEquals(1, v03TaskRoundTrip.history().size());
+        assertEquals("msg-002", v03TaskRoundTrip.history().get(0).messageId());
     }
 
     @Test
@@ -173,8 +173,8 @@ class TaskMapper_v0_3_Test {
         // Round trip
         Task_v0_3 v03TaskRoundTrip = TaskMapper_v0_3.INSTANCE.fromV10(v10Task);
         assertNotNull(v03TaskRoundTrip);
-        assertEquals("task-minimal", v03TaskRoundTrip.getId());
-        assertEquals(TaskState_v0_3.SUBMITTED, v03TaskRoundTrip.getStatus().state());
+        assertEquals("task-minimal", v03TaskRoundTrip.id());
+        assertEquals(TaskState_v0_3.SUBMITTED, v03TaskRoundTrip.status().state());
     }
 
     @Test

--- a/compat-0.3/spec-grpc/src/main/java/org/a2aproject/sdk/compat03/grpc/utils/ProtoUtils_v0_3.java
+++ b/compat-0.3/spec-grpc/src/main/java/org/a2aproject/sdk/compat03/grpc/utils/ProtoUtils_v0_3.java
@@ -136,33 +136,33 @@ public class ProtoUtils_v0_3 {
 
         public static org.a2aproject.sdk.compat03.grpc.Task task(Task_v0_3 task) {
             org.a2aproject.sdk.compat03.grpc.Task.Builder builder = org.a2aproject.sdk.compat03.grpc.Task.newBuilder();
-            builder.setId(task.getId());
-            builder.setContextId(task.getContextId());
-            builder.setStatus(taskStatus(task.getStatus()));
-            if (task.getArtifacts() != null) {
-                builder.addAllArtifacts(task.getArtifacts().stream().map(ToProto::artifact).collect(Collectors.toList()));
+            builder.setId(task.id());
+            builder.setContextId(task.contextId());
+            builder.setStatus(taskStatus(task.status()));
+            if (task.artifacts() != null) {
+                builder.addAllArtifacts(task.artifacts().stream().map(ToProto::artifact).collect(Collectors.toList()));
             }
-            if (task.getHistory() != null) {
-                builder.addAllHistory(task.getHistory().stream().map(ToProto::message).collect(Collectors.toList()));
+            if (task.history() != null) {
+                builder.addAllHistory(task.history().stream().map(ToProto::message).collect(Collectors.toList()));
             }
-            builder.setMetadata(struct(task.getMetadata()));
+            builder.setMetadata(struct(task.metadata()));
             return builder.build();
         }
 
         public static org.a2aproject.sdk.compat03.grpc.Message message(Message_v0_3 message) {
             org.a2aproject.sdk.compat03.grpc.Message.Builder builder = org.a2aproject.sdk.compat03.grpc.Message.newBuilder();
-            builder.setMessageId(message.getMessageId());
-            if (message.getContextId() != null) {
-                builder.setContextId(message.getContextId());
+            builder.setMessageId(message.messageId());
+            if (message.contextId() != null) {
+                builder.setContextId(message.contextId());
             }
-            if (message.getTaskId() != null) {
-                builder.setTaskId(message.getTaskId());
+            if (message.taskId() != null) {
+                builder.setTaskId(message.taskId());
             }
-            builder.setRole(role(message.getRole()));
-            if (message.getParts() != null) {
-                builder.addAllContent(message.getParts().stream().map(ToProto::part).collect(Collectors.toList()));
+            builder.setRole(role(message.role()));
+            if (message.parts() != null) {
+                builder.addAllContent(message.parts().stream().map(ToProto::part).collect(Collectors.toList()));
             }
-            builder.setMetadata(struct(message.getMetadata()));
+            builder.setMetadata(struct(message.metadata()));
             return builder.build();
         }
 
@@ -193,29 +193,29 @@ public class ProtoUtils_v0_3 {
 
         public static org.a2aproject.sdk.compat03.grpc.TaskArtifactUpdateEvent taskArtifactUpdateEvent(TaskArtifactUpdateEvent_v0_3 event) {
             org.a2aproject.sdk.compat03.grpc.TaskArtifactUpdateEvent.Builder builder = org.a2aproject.sdk.compat03.grpc.TaskArtifactUpdateEvent.newBuilder();
-            builder.setTaskId(event.getTaskId());
-            builder.setContextId(event.getContextId());
-            builder.setArtifact(artifact(event.getArtifact()));
-            if (event.isAppend() != null) {
-                builder.setAppend(event.isAppend());
+            builder.setTaskId(event.taskId());
+            builder.setContextId(event.contextId());
+            builder.setArtifact(artifact(event.artifact()));
+            if (event.append() != null) {
+                builder.setAppend(event.append());
             }
-            if (event.isLastChunk() != null) {
-                builder.setLastChunk(event.isLastChunk());
+            if (event.lastChunk() != null) {
+                builder.setLastChunk(event.lastChunk());
             }
-            if (event.getMetadata() != null) {
-                builder.setMetadata(struct(event.getMetadata()));
+            if (event.metadata() != null) {
+                builder.setMetadata(struct(event.metadata()));
             }
             return builder.build();
         }
 
         public static org.a2aproject.sdk.compat03.grpc.TaskStatusUpdateEvent taskStatusUpdateEvent(TaskStatusUpdateEvent_v0_3 event) {
             org.a2aproject.sdk.compat03.grpc.TaskStatusUpdateEvent.Builder builder = org.a2aproject.sdk.compat03.grpc.TaskStatusUpdateEvent.newBuilder();
-            builder.setTaskId(event.getTaskId());
-            builder.setContextId(event.getContextId());
-            builder.setStatus(taskStatus(event.getStatus()));
+            builder.setTaskId(event.taskId());
+            builder.setContextId(event.contextId());
+            builder.setStatus(taskStatus(event.status()));
             builder.setFinal(event.isFinal());
-            if (event.getMetadata() != null) {
-                builder.setMetadata(struct(event.getMetadata()));
+            if (event.metadata() != null) {
+                builder.setMetadata(struct(event.metadata()));
             }
             return builder.build();
         }
@@ -242,19 +242,19 @@ public class ProtoUtils_v0_3 {
 
         private static org.a2aproject.sdk.compat03.grpc.Part part(Part_v0_3<?> part) {
             org.a2aproject.sdk.compat03.grpc.Part.Builder builder = org.a2aproject.sdk.compat03.grpc.Part.newBuilder();
-            if (part instanceof TextPart_v0_3) {
-                builder.setText(((TextPart_v0_3) part).getText());
-            } else if (part instanceof FilePart_v0_3) {
-                builder.setFile(filePart((FilePart_v0_3) part));
-            } else if (part instanceof DataPart_v0_3) {
-                builder.setData(dataPart((DataPart_v0_3) part));
+            if (part instanceof TextPart_v0_3 textPart) {
+                builder.setText(textPart.text());
+            } else if (part instanceof FilePart_v0_3 fp) {
+                builder.setFile(filePart(fp));
+            } else if (part instanceof DataPart_v0_3 dp) {
+                builder.setData(dataPart(dp));
             }
             return builder.build();
         }
 
         private static org.a2aproject.sdk.compat03.grpc.FilePart filePart(FilePart_v0_3 filePart) {
             org.a2aproject.sdk.compat03.grpc.FilePart.Builder builder = org.a2aproject.sdk.compat03.grpc.FilePart.newBuilder();
-            FileContent_v0_3 fileContent = filePart.getFile();
+            FileContent_v0_3 fileContent = filePart.file();
             if (fileContent instanceof FileWithBytes_v0_3) {
                 builder.setFileWithBytes(ByteString.copyFrom(((FileWithBytes_v0_3) fileContent).bytes(), StandardCharsets.UTF_8));
             } else if (fileContent instanceof FileWithUri_v0_3) {
@@ -265,8 +265,8 @@ public class ProtoUtils_v0_3 {
 
         private static org.a2aproject.sdk.compat03.grpc.DataPart dataPart(DataPart_v0_3 dataPart) {
             org.a2aproject.sdk.compat03.grpc.DataPart.Builder builder = org.a2aproject.sdk.compat03.grpc.DataPart.newBuilder();
-            if (dataPart.getData() != null) {
-                builder.setData(struct(dataPart.getData()));
+            if (dataPart.data() != null) {
+                builder.setData(struct(dataPart.data()));
             }
             return builder.build();
         }
@@ -458,42 +458,42 @@ public class ProtoUtils_v0_3 {
 
         private static org.a2aproject.sdk.compat03.grpc.APIKeySecurityScheme apiKeySecurityScheme(APIKeySecurityScheme_v0_3 apiKeySecurityScheme) {
             org.a2aproject.sdk.compat03.grpc.APIKeySecurityScheme.Builder builder = org.a2aproject.sdk.compat03.grpc.APIKeySecurityScheme.newBuilder();
-            if (apiKeySecurityScheme.getDescription() != null) {
-                builder.setDescription(apiKeySecurityScheme.getDescription());
+            if (apiKeySecurityScheme.description() != null) {
+                builder.setDescription(apiKeySecurityScheme.description());
             }
-            if (apiKeySecurityScheme.getIn() != null) {
-                builder.setLocation(apiKeySecurityScheme.getIn());
+            if (apiKeySecurityScheme.in() != null) {
+                builder.setLocation(apiKeySecurityScheme.in());
             }
-            if (apiKeySecurityScheme.getName() != null) {
-                builder.setName(apiKeySecurityScheme.getName());
+            if (apiKeySecurityScheme.name() != null) {
+                builder.setName(apiKeySecurityScheme.name());
             }
             return builder.build();
         }
 
         private static org.a2aproject.sdk.compat03.grpc.HTTPAuthSecurityScheme httpAuthSecurityScheme(HTTPAuthSecurityScheme_v0_3 httpAuthSecurityScheme) {
             org.a2aproject.sdk.compat03.grpc.HTTPAuthSecurityScheme.Builder builder = org.a2aproject.sdk.compat03.grpc.HTTPAuthSecurityScheme.newBuilder();
-            if (httpAuthSecurityScheme.getBearerFormat() != null) {
-                builder.setBearerFormat(httpAuthSecurityScheme.getBearerFormat());
+            if (httpAuthSecurityScheme.bearerFormat() != null) {
+                builder.setBearerFormat(httpAuthSecurityScheme.bearerFormat());
             }
-            if (httpAuthSecurityScheme.getDescription() != null) {
-                builder.setDescription(httpAuthSecurityScheme.getDescription());
+            if (httpAuthSecurityScheme.description() != null) {
+                builder.setDescription(httpAuthSecurityScheme.description());
             }
-            if (httpAuthSecurityScheme.getScheme() != null) {
-                builder.setScheme(httpAuthSecurityScheme.getScheme());
+            if (httpAuthSecurityScheme.scheme() != null) {
+                builder.setScheme(httpAuthSecurityScheme.scheme());
             }
             return builder.build();
         }
 
         private static org.a2aproject.sdk.compat03.grpc.OAuth2SecurityScheme oauthSecurityScheme(OAuth2SecurityScheme_v0_3 oauth2SecurityScheme) {
             org.a2aproject.sdk.compat03.grpc.OAuth2SecurityScheme.Builder builder = org.a2aproject.sdk.compat03.grpc.OAuth2SecurityScheme.newBuilder();
-            if (oauth2SecurityScheme.getDescription() != null) {
-                builder.setDescription(oauth2SecurityScheme.getDescription());
+            if (oauth2SecurityScheme.description() != null) {
+                builder.setDescription(oauth2SecurityScheme.description());
             }
-            if (oauth2SecurityScheme.getFlows() != null) {
-                builder.setFlows(oauthFlows(oauth2SecurityScheme.getFlows()));
+            if (oauth2SecurityScheme.flows() != null) {
+                builder.setFlows(oauthFlows(oauth2SecurityScheme.flows()));
             }
-            if (oauth2SecurityScheme.getOauth2MetadataUrl() != null) {
-                builder.setOauth2MetadataUrl(oauth2SecurityScheme.getOauth2MetadataUrl());
+            if (oauth2SecurityScheme.oauth2MetadataUrl() != null) {
+                builder.setOauth2MetadataUrl(oauth2SecurityScheme.oauth2MetadataUrl());
             }
             return builder.build();
         }
@@ -584,19 +584,19 @@ public class ProtoUtils_v0_3 {
 
         private static org.a2aproject.sdk.compat03.grpc.OpenIdConnectSecurityScheme openIdConnectSecurityScheme(OpenIdConnectSecurityScheme_v0_3 openIdConnectSecurityScheme) {
             org.a2aproject.sdk.compat03.grpc.OpenIdConnectSecurityScheme.Builder builder = org.a2aproject.sdk.compat03.grpc.OpenIdConnectSecurityScheme.newBuilder();
-            if (openIdConnectSecurityScheme.getDescription() != null) {
-                builder.setDescription(openIdConnectSecurityScheme.getDescription());
+            if (openIdConnectSecurityScheme.description() != null) {
+                builder.setDescription(openIdConnectSecurityScheme.description());
             }
-            if (openIdConnectSecurityScheme.getOpenIdConnectUrl() != null) {
-                builder.setOpenIdConnectUrl(openIdConnectSecurityScheme.getOpenIdConnectUrl());
+            if (openIdConnectSecurityScheme.openIdConnectUrl() != null) {
+                builder.setOpenIdConnectUrl(openIdConnectSecurityScheme.openIdConnectUrl());
             }
             return builder.build();
         }
 
         private static org.a2aproject.sdk.compat03.grpc.MutualTlsSecurityScheme mutualTlsSecurityScheme(MutualTLSSecurityScheme_v0_3 mutualTlsSecurityScheme) {
             org.a2aproject.sdk.compat03.grpc.MutualTlsSecurityScheme.Builder builder = org.a2aproject.sdk.compat03.grpc.MutualTlsSecurityScheme.newBuilder();
-            if (mutualTlsSecurityScheme.getDescription() != null) {
-                builder.setDescription(mutualTlsSecurityScheme.getDescription());
+            if (mutualTlsSecurityScheme.description() != null) {
+                builder.setDescription(mutualTlsSecurityScheme.description());
             }
             return builder.build();
         }
@@ -612,7 +612,7 @@ public class ProtoUtils_v0_3 {
             return builder.build();
         }
 
-        public static Struct struct(Map<String, Object> map) {
+        public static Struct struct(@Nullable Map<String, Object> map) {
             Struct.Builder structBuilder = Struct.newBuilder();
             if (map != null) {
                 map.forEach((k, v) -> structBuilder.putFields(k, value(v)));

--- a/compat-0.3/spec-grpc/src/test/java/org/a2aproject/sdk/compat03/grpc/utils/ToProto_v0_3_Test.java
+++ b/compat-0.3/spec-grpc/src/test/java/org/a2aproject/sdk/compat03/grpc/utils/ToProto_v0_3_Test.java
@@ -284,7 +284,7 @@ public class ToProto_v0_3_Test {
 
         org.a2aproject.sdk.compat03.grpc.Task grpcTask = ProtoUtils_v0_3.ToProto.task(task);
         task = ProtoUtils_v0_3.FromProto.task(grpcTask);
-        TaskStatus_v0_3 status = task.getStatus();
+        TaskStatus_v0_3 status = task.status();
         assertEquals(TaskState_v0_3.COMPLETED, status.state());
         assertNotNull(status.timestamp());
         assertEquals(expectedTimestamp, status.timestamp());

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/json/JsonUtil_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/json/JsonUtil_v0_3.java
@@ -705,8 +705,8 @@ public class JsonUtil_v0_3 {
 
             String kind = kindElement.getAsString();
             return switch (kind) {
-                case Task_v0_3.TASK -> delegateGson.fromJson(jsonElement, Task_v0_3.class);
-                case Message_v0_3.MESSAGE -> delegateGson.fromJson(jsonElement, Message_v0_3.class);
+                case Task_v0_3.KIND -> delegateGson.fromJson(jsonElement, Task_v0_3.class);
+                case Message_v0_3.KIND -> delegateGson.fromJson(jsonElement, Message_v0_3.class);
                 default -> throw new JsonSyntaxException("Unknown EventKind kind: " + kind);
             };
         }
@@ -850,15 +850,15 @@ public class JsonUtil_v0_3 {
 
             String type = typeElement.getAsString();
             return switch (type) {
-                case APIKeySecurityScheme_v0_3.API_KEY ->
+                case APIKeySecurityScheme_v0_3.TYPE ->
                     delegateGson.fromJson(jsonElement, APIKeySecurityScheme_v0_3.class);
-                case HTTPAuthSecurityScheme_v0_3.HTTP ->
+                case HTTPAuthSecurityScheme_v0_3.TYPE ->
                     delegateGson.fromJson(jsonElement, HTTPAuthSecurityScheme_v0_3.class);
-                case OAuth2SecurityScheme_v0_3.OAUTH2 ->
+                case OAuth2SecurityScheme_v0_3.TYPE ->
                     delegateGson.fromJson(jsonElement, OAuth2SecurityScheme_v0_3.class);
-                case OpenIdConnectSecurityScheme_v0_3.OPENID_CONNECT ->
+                case OpenIdConnectSecurityScheme_v0_3.TYPE ->
                     delegateGson.fromJson(jsonElement, OpenIdConnectSecurityScheme_v0_3.class);
-                case MutualTLSSecurityScheme_v0_3.MUTUAL_TLS ->
+                case MutualTLSSecurityScheme_v0_3.TYPE ->
                     delegateGson.fromJson(jsonElement, MutualTLSSecurityScheme_v0_3.class);
                 default ->
                     throw new JsonSyntaxException("Unknown SecurityScheme type: " + type);

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/APIKeySecurityScheme_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/APIKeySecurityScheme_v0_3.java
@@ -44,15 +44,16 @@ public record APIKeySecurityScheme_v0_3(String in, String name, @Nullable String
         }
     }
 
-    public APIKeySecurityScheme_v0_3 {
+    public APIKeySecurityScheme_v0_3(String in, String name, @Nullable String description, @Nullable String type) {
         Assert.checkNotNullParam("in", in);
         Assert.checkNotNullParam("name", name);
-        if (type == null) {
-            type = TYPE;
-        }
-        if (!type.equals(TYPE)) {
+        if (type != null && !type.equals(TYPE)) {
             throw new IllegalArgumentException("Invalid type for APIKeySecurityScheme");
         }
+        this.in = in;
+        this.name = name;
+        this.description = description;
+        this.type = TYPE;
     }
 
     public APIKeySecurityScheme_v0_3(String in, String name, @Nullable String description) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/APIKeySecurityScheme_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/APIKeySecurityScheme_v0_3.java
@@ -1,17 +1,14 @@
 package org.a2aproject.sdk.compat03.spec;
 
 import org.a2aproject.sdk.util.Assert;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines a security scheme using an API key.
  */
-public final class APIKeySecurityScheme_v0_3 implements SecurityScheme_v0_3 {
+public record APIKeySecurityScheme_v0_3(String in, String name, @Nullable String description, String type) implements SecurityScheme_v0_3 {
 
-    public static final String API_KEY = "apiKey";
-    private final String in;
-    private final String name;
-    private final String type;
-    private final String description;
+    public static final String TYPE = "apiKey";
 
     /**
      * Represents the location of the API key.
@@ -47,40 +44,19 @@ public final class APIKeySecurityScheme_v0_3 implements SecurityScheme_v0_3 {
         }
     }
 
-    public APIKeySecurityScheme_v0_3(String in, String name, String description) {
-        this(in, name, description, API_KEY);
-    }
-
-    public APIKeySecurityScheme_v0_3(String in, String name,
-                                     String description, String type) {
+    public APIKeySecurityScheme_v0_3 {
         Assert.checkNotNullParam("in", in);
         Assert.checkNotNullParam("name", name);
-        Assert.checkNotNullParam("type", type);
-        if (! type.equals(API_KEY)) {
+        if (type == null) {
+            type = TYPE;
+        }
+        if (!type.equals(TYPE)) {
             throw new IllegalArgumentException("Invalid type for APIKeySecurityScheme");
         }
-        this.in = in;
-        this.name = name;
-        this.description = description;
-        this.type = type;
     }
 
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-
-    public String getIn() {
-        return in;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getType() {
-        return type;
+    public APIKeySecurityScheme_v0_3(String in, String name, @Nullable String description) {
+        this(in, name, description, TYPE);
     }
 
     public static class Builder {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/Artifact_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/Artifact_v0_3.java
@@ -31,12 +31,12 @@ public record Artifact_v0_3(String artifactId, String name, String description, 
         }
 
         public Builder(Artifact_v0_3 existingArtifact) {
-            artifactId = existingArtifact.artifactId;
-            name = existingArtifact.name;
-            description = existingArtifact.description;
-            parts = existingArtifact.parts;
-            metadata = existingArtifact.metadata;
-            extensions = existingArtifact.extensions;
+            artifactId = existingArtifact.artifactId();
+            name = existingArtifact.name();
+            description = existingArtifact.description();
+            parts = existingArtifact.parts();
+            metadata = existingArtifact.metadata();
+            extensions = existingArtifact.extensions();
         }
 
         public Builder artifactId(String artifactId) {
@@ -56,7 +56,7 @@ public record Artifact_v0_3(String artifactId, String name, String description, 
         }
 
         public Builder parts(List<Part_v0_3<?>> parts) {
-            this.parts = parts;
+            this.parts = List.copyOf(parts);
             return this;
         }
 
@@ -66,12 +66,12 @@ public record Artifact_v0_3(String artifactId, String name, String description, 
         }
 
         public Builder metadata(Map<String, Object> metadata) {
-            this.metadata = metadata;
+            this.metadata = Map.copyOf(metadata);
             return this;
         }
 
         public Builder extensions(List<String> extensions) {
-            this.extensions = (extensions == null) ? null : List.copyOf(extensions);
+            this.extensions = List.copyOf(extensions);
             return this;
         }
 

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/DataPart_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/DataPart_v0_3.java
@@ -12,14 +12,14 @@ public record DataPart_v0_3(Map<String, Object> data, @Nullable Map<String, Obje
 
     public static final String DATA = "data";
 
-    public DataPart_v0_3 {
+    public DataPart_v0_3(Map<String, Object> data, @Nullable Map<String, Object> metadata, Kind kind) {
         Assert.checkNotNullParam("data", data);
-        if (kind == null) {
-            kind = Kind.DATA;
-        }
         if (kind != Kind.DATA) {
             throw new IllegalArgumentException("Invalid DataPart kind: " + kind);
         }
+        this.data = Map.copyOf(data);
+        this.metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+        this.kind = kind;
     }
 
     public DataPart_v0_3(Map<String, Object> data) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/DataPart_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/DataPart_v0_3.java
@@ -3,41 +3,30 @@ package org.a2aproject.sdk.compat03.spec;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
-
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a structured data segment (e.g., JSON) within a message or artifact.
  */
-public class DataPart_v0_3 extends Part_v0_3<Map<String, Object>> {
+public record DataPart_v0_3(Map<String, Object> data, @Nullable Map<String, Object> metadata, Kind kind) implements Part_v0_3<Map<String, Object>> {
 
     public static final String DATA = "data";
-    private final Map<String, Object> data;
-    private final Map<String, Object> metadata;
-    private final Kind kind;
+
+    public DataPart_v0_3 {
+        Assert.checkNotNullParam("data", data);
+        if (kind == null) {
+            kind = Kind.DATA;
+        }
+        if (kind != Kind.DATA) {
+            throw new IllegalArgumentException("Invalid DataPart kind: " + kind);
+        }
+    }
 
     public DataPart_v0_3(Map<String, Object> data) {
-        this(data, null);
+        this(data, null, Kind.DATA);
     }
 
-    public DataPart_v0_3(Map<String, Object> data, Map<String, Object> metadata) {
-        Assert.checkNotNullParam("data", data);
-        this.data = data;
-        this.metadata = metadata;
-        this.kind = Kind.DATA;
+    public DataPart_v0_3(Map<String, Object> data, @Nullable Map<String, Object> metadata) {
+        this(data, metadata, Kind.DATA);
     }
-
-    @Override
-    public Kind getKind() {
-        return kind;
-    }
-
-    public Map<String, Object> getData() {
-        return data;
-    }
-
-    @Override
-    public Map<String, Object> getMetadata() {
-        return metadata;
-    }
-
 }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/EventKind_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/EventKind_v0_3.java
@@ -21,5 +21,5 @@ package org.a2aproject.sdk.compat03.spec;
  */
 public interface EventKind_v0_3 {
 
-    String getKind();
+    String kind();
 }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/FilePart_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/FilePart_v0_3.java
@@ -3,41 +3,31 @@ package org.a2aproject.sdk.compat03.spec;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a file segment within a message or artifact. The file content can be
  * provided either directly as bytes or as a URI.
  */
-public class FilePart_v0_3 extends Part_v0_3<FileContent_v0_3> {
+public record FilePart_v0_3(FileContent_v0_3 file, @Nullable Map<String, Object> metadata, Kind kind) implements Part_v0_3<FileContent_v0_3> {
 
     public static final String FILE = "file";
-    private final FileContent_v0_3 file;
-    private final Map<String, Object> metadata;
-    private final Kind kind;
+
+    public FilePart_v0_3 {
+        Assert.checkNotNullParam("file", file);
+        if (kind == null) {
+            kind = Kind.FILE;
+        }
+        if (kind != Kind.FILE) {
+            throw new IllegalArgumentException("Invalid FilePart kind: " + kind);
+        }
+    }
 
     public FilePart_v0_3(FileContent_v0_3 file) {
-        this(file, null);
+        this(file, null, Kind.FILE);
     }
 
-    public FilePart_v0_3(FileContent_v0_3 file, Map<String, Object> metadata) {
-        Assert.checkNotNullParam("file", file);
-        this.file = file;
-        this.metadata = metadata;
-        this.kind = Kind.FILE;
+    public FilePart_v0_3(FileContent_v0_3 file, @Nullable Map<String, Object> metadata) {
+        this(file, metadata, Kind.FILE);
     }
-
-    @Override
-    public Kind getKind() {
-        return kind;
-    }
-
-    public FileContent_v0_3 getFile() {
-        return file;
-    }
-
-    @Override
-    public Map<String, Object> getMetadata() {
-        return metadata;
-    }
-
 }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/FilePart_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/FilePart_v0_3.java
@@ -9,18 +9,18 @@ import org.jspecify.annotations.Nullable;
  * Represents a file segment within a message or artifact. The file content can be
  * provided either directly as bytes or as a URI.
  */
-public record FilePart_v0_3(FileContent_v0_3 file, @Nullable Map<String, Object> metadata, Kind kind) implements Part_v0_3<FileContent_v0_3> {
+public record FilePart_v0_3(FileContent_v0_3 file, Map<String, Object> metadata, Kind kind) implements Part_v0_3<FileContent_v0_3> {
 
     public static final String FILE = "file";
 
-    public FilePart_v0_3 {
+    public FilePart_v0_3 (FileContent_v0_3 file, @Nullable Map<String, Object> metadata, Kind kind){
         Assert.checkNotNullParam("file", file);
-        if (kind == null) {
-            kind = Kind.FILE;
-        }
         if (kind != Kind.FILE) {
             throw new IllegalArgumentException("Invalid FilePart kind: " + kind);
         }
+        this.file = file;
+        this.metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+        this.kind = kind;
     }
 
     public FilePart_v0_3(FileContent_v0_3 file) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/HTTPAuthSecurityScheme_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/HTTPAuthSecurityScheme_v0_3.java
@@ -15,14 +15,15 @@ public record HTTPAuthSecurityScheme_v0_3(
 
     public static final String TYPE = "http";
 
-    public HTTPAuthSecurityScheme_v0_3 {
+    public HTTPAuthSecurityScheme_v0_3(@Nullable String bearerFormat, String scheme, @Nullable String description, @Nullable String type) {
         Assert.checkNotNullParam("scheme", scheme);
-        if (type == null) {
-            type = TYPE;
-        }
-        if (!TYPE.equals(type)) {
+        if (type != null && !TYPE.equals(type)) {
             throw new IllegalArgumentException("Invalid type for HTTPAuthSecurityScheme");
         }
+        this.bearerFormat = bearerFormat;
+        this.scheme = scheme;
+        this.description = description;
+        this.type = TYPE;
     }
 
     public HTTPAuthSecurityScheme_v0_3(@Nullable String bearerFormat, String scheme, @Nullable String description) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/HTTPAuthSecurityScheme_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/HTTPAuthSecurityScheme_v0_3.java
@@ -1,49 +1,32 @@
 package org.a2aproject.sdk.compat03.spec;
 
 import org.a2aproject.sdk.util.Assert;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines a security scheme using HTTP authentication.
  */
-public final class HTTPAuthSecurityScheme_v0_3 implements SecurityScheme_v0_3 {
+public record HTTPAuthSecurityScheme_v0_3(
+        @Nullable String bearerFormat,
+        String scheme,
+        @Nullable String description,
+        String type
+) implements SecurityScheme_v0_3 {
 
-    public static final String HTTP = "http";
-    private final String bearerFormat;
-    private final String scheme;
-    private final String description;
-    private final String type;
+    public static final String TYPE = "http";
 
-    public HTTPAuthSecurityScheme_v0_3(String bearerFormat, String scheme, String description) {
-        this(bearerFormat, scheme, description, HTTP);
-    }
-
-    public HTTPAuthSecurityScheme_v0_3(String bearerFormat, String scheme, String description, String type) {
+    public HTTPAuthSecurityScheme_v0_3 {
         Assert.checkNotNullParam("scheme", scheme);
-        Assert.checkNotNullParam("type", type);
-        if (! HTTP.equals(type)) {
+        if (type == null) {
+            type = TYPE;
+        }
+        if (!TYPE.equals(type)) {
             throw new IllegalArgumentException("Invalid type for HTTPAuthSecurityScheme");
         }
-        this.bearerFormat = bearerFormat;
-        this.scheme = scheme;
-        this.description = description;
-        this.type = type;
     }
 
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    public String getBearerFormat() {
-        return bearerFormat;
-    }
-
-    public String getScheme() {
-        return scheme;
-    }
-
-    public String getType() {
-        return type;
+    public HTTPAuthSecurityScheme_v0_3(@Nullable String bearerFormat, String scheme, @Nullable String description) {
+        this(bearerFormat, scheme, description, TYPE);
     }
 
     public static class Builder {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/IntegerJsonrpcId_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/IntegerJsonrpcId_v0_3.java
@@ -1,4 +1,0 @@
-package org.a2aproject.sdk.compat03.spec;
-
-public class IntegerJsonrpcId_v0_3 {
-}

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/MessageSendParams_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/MessageSendParams_v0_3.java
@@ -17,7 +17,6 @@ public record MessageSendParams_v0_3(Message_v0_3 message, MessageSendConfigurat
 
     public void check() {
         Assert.checkNotNullParam("message", message);
-        message.check();
     }
 
     public static class Builder {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/Message_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/Message_v0_3.java
@@ -1,5 +1,6 @@
 package org.a2aproject.sdk.compat03.spec;
 
+
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -24,22 +25,26 @@ public record Message_v0_3(
 
     public static final String KIND = "message";
 
-    public Message_v0_3 {
+    public Message_v0_3(Role role, List<Part_v0_3<?>> parts, String messageId, @Nullable String contextId,
+                        @Nullable String taskId, @Nullable List<String> referenceTaskIds,
+                        @Nullable Map<String, Object> metadata, @Nullable List<String> extensions, String kind) {
         Assert.checkNotNullParam("role", role);
         Assert.checkNotNullParam("parts", parts);
-        parts = List.copyOf(parts);
+        this.role = role;
         if (parts.isEmpty()) {
             throw new IllegalArgumentException("Parts cannot be empty");
         }
-        if (messageId == null) {
-            messageId = UUID.randomUUID().toString();
-        }
-        if (kind == null) {
-            kind = KIND;
-        }
-        if (!kind.equals(KIND)) {
+        this.parts = List.copyOf(parts);
+        this.messageId = messageId == null ? UUID.randomUUID().toString() : messageId;
+        this.kind = kind != null ? kind : KIND;
+        if (!this.kind.equals(KIND)) {
             throw new IllegalArgumentException("Invalid Message");
         }
+        this.contextId = contextId;
+        this.taskId = taskId;
+        this.referenceTaskIds = referenceTaskIds != null ? List.copyOf(referenceTaskIds) : null;
+        this.metadata = metadata != null ? Map.copyOf(metadata) : null;
+        this.extensions = extensions != null ? List.copyOf(extensions) : null;
     }
 
     public Message_v0_3(Role role, List<Part_v0_3<?>> parts, String messageId, @Nullable String contextId,

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/Message_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/Message_v0_3.java
@@ -5,110 +5,47 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.a2aproject.sdk.util.Assert;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a single message in the conversation between a user and an agent.
  */
-public final class Message_v0_3 implements EventKind_v0_3, StreamingEventKind_v0_3 {
+public record Message_v0_3(
+        Role role,
+        List<Part_v0_3<?>> parts,
+        String messageId,
+        @Nullable String contextId,
+        @Nullable String taskId,
+        @Nullable List<String> referenceTaskIds,
+        @Nullable Map<String, Object> metadata,
+        @Nullable List<String> extensions,
+        String kind
+) implements EventKind_v0_3, StreamingEventKind_v0_3 {
 
-    public static final String MESSAGE = "message";
-    private final Role role;
-    private final List<Part_v0_3<?>> parts;
-    private final String messageId;
-    private String contextId;
-    private String taskId;
-    private final Map<String, Object> metadata;
-    private final String kind;
-    private final List<String> referenceTaskIds;
-    private final List<String> extensions;
+    public static final String KIND = "message";
 
-    public Message_v0_3(Role role, List<Part_v0_3<?>> parts, String messageId, String contextId, String taskId,
-                        List<String> referenceTaskIds, Map<String, Object> metadata, List<String> extensions) {
-        this(role, parts, messageId, contextId, taskId, referenceTaskIds, metadata, extensions, MESSAGE);
-    }
-
-    public Message_v0_3(Role role, List<Part_v0_3<?>> parts,
-                        String messageId, String contextId,
-                        String taskId, List<String> referenceTaskIds,
-                        Map<String, Object> metadata, List<String> extensions,
-                        String kind) {
-        Assert.checkNotNullParam("kind", kind);
+    public Message_v0_3 {
+        Assert.checkNotNullParam("role", role);
         Assert.checkNotNullParam("parts", parts);
+        parts = List.copyOf(parts);
         if (parts.isEmpty()) {
             throw new IllegalArgumentException("Parts cannot be empty");
         }
-        Assert.checkNotNullParam("role", role);
-        if (! kind.equals(MESSAGE)) {
+        if (messageId == null) {
+            messageId = UUID.randomUUID().toString();
+        }
+        if (kind == null) {
+            kind = KIND;
+        }
+        if (!kind.equals(KIND)) {
             throw new IllegalArgumentException("Invalid Message");
         }
-        Assert.checkNotNullParam("messageId", messageId);
-        this.role = role;
-        this.parts = parts;
-        this.messageId = messageId;
-        this.contextId = contextId;
-        this.taskId = taskId;
-        this.referenceTaskIds = referenceTaskIds;
-        this.metadata = metadata;
-        this.extensions = extensions;
-        this.kind = kind;
     }
 
-    public void check() {
-        Assert.checkNotNullParam("kind", kind);
-        Assert.checkNotNullParam("parts", parts);
-        if (parts.isEmpty()) {
-            throw new IllegalArgumentException("Parts cannot be empty");
-        }
-        Assert.checkNotNullParam("role", role);
-        if (!kind.equals(MESSAGE)) {
-            throw new IllegalArgumentException("Invalid Message");
-        }
-        Assert.checkNotNullParam("messageId", messageId);
-    }
-
-    public Role getRole() {
-        return role;
-    }
-
-    public List<Part_v0_3<?>> getParts() {
-        return parts;
-    }
-
-    public String getMessageId() {
-        return messageId;
-    }
-
-    public String getContextId() {
-        return contextId;
-    }
-
-    public String getTaskId() {
-        return taskId;
-    }
-
-    public Map<String, Object> getMetadata() {
-        return metadata;
-    }
-
-    public void setTaskId(String taskId) {
-        this.taskId = taskId;
-    }
-
-    public void setContextId(String contextId) {
-        this.contextId = contextId;
-    }
-
-    public List<String> getReferenceTaskIds() {
-        return referenceTaskIds;
-    }
-
-    public List<String> getExtensions() {
-        return extensions;
-    }
-
-    @Override
-    public String getKind() {
-        return kind;
+    public Message_v0_3(Role role, List<Part_v0_3<?>> parts, String messageId, @Nullable String contextId,
+                        @Nullable String taskId, @Nullable List<String> referenceTaskIds,
+                        @Nullable Map<String, Object> metadata, @Nullable List<String> extensions) {
+        this(role, parts, messageId, contextId, taskId, referenceTaskIds, metadata, extensions, KIND);
     }
 
     public enum Role {
@@ -166,7 +103,7 @@ public final class Message_v0_3 implements EventKind_v0_3, StreamingEventKind_v0
             return this;
         }
 
-        public Builder parts(Part_v0_3<?>...parts) {
+        public Builder parts(Part_v0_3<?>... parts) {
             this.parts = List.of(parts);
             return this;
         }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/MutualTLSSecurityScheme_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/MutualTLSSecurityScheme_v0_3.java
@@ -1,40 +1,28 @@
 package org.a2aproject.sdk.compat03.spec;
 
-import org.a2aproject.sdk.util.Assert;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines a security scheme using mTLS authentication.
  */
-public final class MutualTLSSecurityScheme_v0_3 implements SecurityScheme_v0_3 {
+public record MutualTLSSecurityScheme_v0_3(@Nullable String description, String type) implements SecurityScheme_v0_3 {
 
-    public static final String MUTUAL_TLS = "mutualTLS";
-    private final String description;
-    private final String type;
+    public static final String TYPE = "mutualTLS";
 
-    public MutualTLSSecurityScheme_v0_3(String description) {
-        this(description, MUTUAL_TLS);
+    public MutualTLSSecurityScheme_v0_3 {
+        if (type == null) {
+            type = TYPE;
+        }
+        if (!type.equals(TYPE)) {
+            throw new IllegalArgumentException("Invalid type for MutualTLSSecurityScheme");
+        }
+    }
+
+    public MutualTLSSecurityScheme_v0_3(@Nullable String description) {
+        this(description, TYPE);
     }
 
     public MutualTLSSecurityScheme_v0_3() {
-        this(null, MUTUAL_TLS);
+        this(null, TYPE);
     }
-
-    public MutualTLSSecurityScheme_v0_3(String description, String type) {
-        Assert.checkNotNullParam("type", type);
-        if (!type.equals(MUTUAL_TLS)) {
-            throw new IllegalArgumentException("Invalid type for MutualTLSSecurityScheme");
-        }
-        this.description = description;
-        this.type = type;
-    }
-
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    public String getType() {
-        return type;
-    }
-
 }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/MutualTLSSecurityScheme_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/MutualTLSSecurityScheme_v0_3.java
@@ -9,13 +9,12 @@ public record MutualTLSSecurityScheme_v0_3(@Nullable String description, String 
 
     public static final String TYPE = "mutualTLS";
 
-    public MutualTLSSecurityScheme_v0_3 {
-        if (type == null) {
-            type = TYPE;
-        }
-        if (!type.equals(TYPE)) {
+    public MutualTLSSecurityScheme_v0_3(@Nullable String description, @Nullable String type) {
+        if (type != null && !type.equals(TYPE)) {
             throw new IllegalArgumentException("Invalid type for MutualTLSSecurityScheme");
         }
+        this.description = description;
+        this.type = TYPE;
     }
 
     public MutualTLSSecurityScheme_v0_3(@Nullable String description) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/OAuth2SecurityScheme_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/OAuth2SecurityScheme_v0_3.java
@@ -15,14 +15,15 @@ public record OAuth2SecurityScheme_v0_3(
 
     public static final String TYPE = "oauth2";
 
-    public OAuth2SecurityScheme_v0_3 {
+    public OAuth2SecurityScheme_v0_3(OAuthFlows_v0_3 flows, @Nullable String description, @Nullable String oauth2MetadataUrl, @Nullable String type) {
         Assert.checkNotNullParam("flows", flows);
-        if (type == null) {
-            type = TYPE;
-        }
-        if (!type.equals(TYPE)) {
+        if (type != null && !type.equals(TYPE)) {
             throw new IllegalArgumentException("Invalid type for OAuth2SecurityScheme");
         }
+        this.flows = flows;
+        this.description = description;
+        this.oauth2MetadataUrl = oauth2MetadataUrl;
+        this.type = TYPE;
     }
 
     public OAuth2SecurityScheme_v0_3(OAuthFlows_v0_3 flows, @Nullable String description, @Nullable String oauth2MetadataUrl) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/OAuth2SecurityScheme_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/OAuth2SecurityScheme_v0_3.java
@@ -1,49 +1,32 @@
 package org.a2aproject.sdk.compat03.spec;
 
 import org.a2aproject.sdk.util.Assert;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines a security scheme using OAuth 2.0.
  */
-public final class OAuth2SecurityScheme_v0_3 implements SecurityScheme_v0_3 {
+public record OAuth2SecurityScheme_v0_3(
+        OAuthFlows_v0_3 flows,
+        @Nullable String description,
+        @Nullable String oauth2MetadataUrl,
+        String type
+) implements SecurityScheme_v0_3 {
 
-    public static final String OAUTH2 = "oauth2";
-    private final OAuthFlows_v0_3 flows;
-    private final String description;
-    private final String type;
-    private final String oauth2MetadataUrl;
+    public static final String TYPE = "oauth2";
 
-    public OAuth2SecurityScheme_v0_3(OAuthFlows_v0_3 flows, String description, String oauth2MetadataUrl) {
-        this(flows, description, oauth2MetadataUrl, OAUTH2);
-    }
-
-    public OAuth2SecurityScheme_v0_3(OAuthFlows_v0_3 flows, String description, String oauth2MetadataUrl, String type) {
+    public OAuth2SecurityScheme_v0_3 {
         Assert.checkNotNullParam("flows", flows);
-        Assert.checkNotNullParam("type", type);
-        if (!type.equals(OAUTH2)) {
+        if (type == null) {
+            type = TYPE;
+        }
+        if (!type.equals(TYPE)) {
             throw new IllegalArgumentException("Invalid type for OAuth2SecurityScheme");
         }
-        this.flows = flows;
-        this.description = description;
-        this.oauth2MetadataUrl = oauth2MetadataUrl;
-        this.type = type;
     }
 
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    public OAuthFlows_v0_3 getFlows() {
-        return flows;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public String getOauth2MetadataUrl() {
-        return oauth2MetadataUrl;
+    public OAuth2SecurityScheme_v0_3(OAuthFlows_v0_3 flows, @Nullable String description, @Nullable String oauth2MetadataUrl) {
+        this(flows, description, oauth2MetadataUrl, TYPE);
     }
 
     public static class Builder {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/OpenIdConnectSecurityScheme_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/OpenIdConnectSecurityScheme_v0_3.java
@@ -1,43 +1,31 @@
 package org.a2aproject.sdk.compat03.spec;
 
 import org.a2aproject.sdk.util.Assert;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines a security scheme using OpenID Connect.
  */
-public final class OpenIdConnectSecurityScheme_v0_3 implements SecurityScheme_v0_3 {
+public record OpenIdConnectSecurityScheme_v0_3(
+        String openIdConnectUrl,
+        @Nullable String description,
+        String type
+) implements SecurityScheme_v0_3 {
 
-    public static final String OPENID_CONNECT = "openIdConnect";
-    private final String openIdConnectUrl;
-    private final String description;
-    private final String type;
+    public static final String TYPE = "openIdConnect";
 
-    public OpenIdConnectSecurityScheme_v0_3(String openIdConnectUrl, String description) {
-        this(openIdConnectUrl, description, OPENID_CONNECT);
-    }
-
-    public OpenIdConnectSecurityScheme_v0_3(String openIdConnectUrl, String description, String type) {
-        Assert.checkNotNullParam("type", type);
+    public OpenIdConnectSecurityScheme_v0_3 {
         Assert.checkNotNullParam("openIdConnectUrl", openIdConnectUrl);
-        if (!type.equals(OPENID_CONNECT)) {
+        if (type == null) {
+            type = TYPE;
+        }
+        if (!type.equals(TYPE)) {
             throw new IllegalArgumentException("Invalid type for OpenIdConnectSecurityScheme");
         }
-        this.openIdConnectUrl = openIdConnectUrl;
-        this.description = description;
-        this.type = type;
     }
 
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    public String getOpenIdConnectUrl() {
-        return openIdConnectUrl;
-    }
-
-    public String getType() {
-        return type;
+    public OpenIdConnectSecurityScheme_v0_3(String openIdConnectUrl, @Nullable String description) {
+        this(openIdConnectUrl, description, TYPE);
     }
 
     public static class Builder {
@@ -58,5 +46,4 @@ public final class OpenIdConnectSecurityScheme_v0_3 implements SecurityScheme_v0
             return new OpenIdConnectSecurityScheme_v0_3(openIdConnectUrl, description);
         }
     }
-
 }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/Part_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/Part_v0_3.java
@@ -1,13 +1,11 @@
 package org.a2aproject.sdk.compat03.spec;
 
-import java.util.Map;
-
 /**
  * A fundamental unit with a Message or Artifact.
  * @param <T> the type of unit
  */
-public abstract class Part_v0_3<T> {
-    public enum Kind {
+public sealed interface Part_v0_3<T> permits TextPart_v0_3, FilePart_v0_3, DataPart_v0_3 {
+    enum Kind {
         TEXT("text"),
         FILE("file"),
         DATA("data");
@@ -27,9 +25,4 @@ public abstract class Part_v0_3<T> {
             return this.kind;
         }
     }
-
-    public abstract Kind getKind();
-
-    public abstract Map<String, Object> getMetadata();
-
 }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SecurityScheme_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SecurityScheme_v0_3.java
@@ -7,5 +7,8 @@ package org.a2aproject.sdk.compat03.spec;
 public sealed interface SecurityScheme_v0_3 permits APIKeySecurityScheme_v0_3, HTTPAuthSecurityScheme_v0_3, OAuth2SecurityScheme_v0_3,
         OpenIdConnectSecurityScheme_v0_3, MutualTLSSecurityScheme_v0_3 {
 
-    String getDescription();
+    @org.jspecify.annotations.Nullable
+    String description();
+
+    String type();
 }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/StreamingEventKind_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/StreamingEventKind_v0_3.java
@@ -31,5 +31,5 @@ package org.a2aproject.sdk.compat03.spec;
  */
 public sealed interface StreamingEventKind_v0_3 extends Event_v0_3 permits Task_v0_3, Message_v0_3, TaskStatusUpdateEvent_v0_3, TaskArtifactUpdateEvent_v0_3 {
 
-    String getKind();
+    String kind();
 }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/StringJsonrpcId_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/StringJsonrpcId_v0_3.java
@@ -1,4 +1,0 @@
-package org.a2aproject.sdk.compat03.spec;
-
-public class StringJsonrpcId_v0_3 {
-}

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/TaskArtifactUpdateEvent_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/TaskArtifactUpdateEvent_v0_3.java
@@ -15,22 +15,27 @@ public record TaskArtifactUpdateEvent_v0_3(
         @Nullable Boolean lastChunk,
         Artifact_v0_3 artifact,
         String contextId,
-        @Nullable Map<String, Object> metadata,
+        Map<String, Object> metadata,
         String kind
 ) implements EventKind_v0_3, StreamingEventKind_v0_3, UpdateEvent_v0_3 {
 
     public static final String KIND = "artifact-update";
 
-    public TaskArtifactUpdateEvent_v0_3 {
+    public TaskArtifactUpdateEvent_v0_3 (String taskId, @Nullable Boolean append, @Nullable Boolean lastChunk,
+                                         Artifact_v0_3 artifact, String contextId,@Nullable Map<String, Object> metadata, String kind){
         Assert.checkNotNullParam("taskId", taskId);
         Assert.checkNotNullParam("artifact", artifact);
         Assert.checkNotNullParam("contextId", contextId);
-        if (kind == null) {
-            kind = KIND;
-        }
-        if (!kind.equals(KIND)) {
+        this.kind = kind != null ? kind : KIND;
+        if (!KIND.equals(this.kind)) {
             throw new IllegalArgumentException("Invalid TaskArtifactUpdateEvent");
         }
+        this.taskId = taskId;
+        this.append = append;
+        this.lastChunk = lastChunk;
+        this.artifact = artifact;
+        this.contextId = contextId;
+        this.metadata = metadata != null ? Map.copyOf(metadata) : null;
     }
 
     public TaskArtifactUpdateEvent_v0_3(String taskId, Artifact_v0_3 artifact, String contextId,

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/TaskArtifactUpdateEvent_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/TaskArtifactUpdateEvent_v0_3.java
@@ -3,70 +3,40 @@ package org.a2aproject.sdk.compat03.spec;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An event sent by the agent to notify the client that an artifact has been
  * generated or updated. This is typically used in streaming models.
  */
-public final class TaskArtifactUpdateEvent_v0_3 implements EventKind_v0_3, StreamingEventKind_v0_3, UpdateEvent_v0_3 {
+public record TaskArtifactUpdateEvent_v0_3(
+        String taskId,
+        @Nullable Boolean append,
+        @Nullable Boolean lastChunk,
+        Artifact_v0_3 artifact,
+        String contextId,
+        @Nullable Map<String, Object> metadata,
+        String kind
+) implements EventKind_v0_3, StreamingEventKind_v0_3, UpdateEvent_v0_3 {
 
-    public static final String ARTIFACT_UPDATE = "artifact-update";
-    private final String taskId;
-    private final Boolean append;
-    private final Boolean lastChunk;
-    private final Artifact_v0_3 artifact;
-    private final String contextId;
-    private final Map<String, Object> metadata;
-    private final String kind;
+    public static final String KIND = "artifact-update";
 
-    public TaskArtifactUpdateEvent_v0_3(String taskId, Artifact_v0_3 artifact, String contextId, Boolean append, Boolean lastChunk, Map<String, Object> metadata) {
-        this(taskId, artifact, contextId, append, lastChunk, metadata, ARTIFACT_UPDATE);
-    }
-
-    public TaskArtifactUpdateEvent_v0_3(String taskId, Artifact_v0_3 artifact, String contextId, Boolean append, Boolean lastChunk, Map<String, Object> metadata, String kind) {
+    public TaskArtifactUpdateEvent_v0_3 {
         Assert.checkNotNullParam("taskId", taskId);
         Assert.checkNotNullParam("artifact", artifact);
         Assert.checkNotNullParam("contextId", contextId);
-        Assert.checkNotNullParam("kind", kind);
-        if (! kind.equals(ARTIFACT_UPDATE)) {
+        if (kind == null) {
+            kind = KIND;
+        }
+        if (!kind.equals(KIND)) {
             throw new IllegalArgumentException("Invalid TaskArtifactUpdateEvent");
         }
-        this.taskId = taskId;
-        this.artifact = artifact;
-        this.contextId = contextId;
-        this.append = append;
-        this.lastChunk = lastChunk;
-        this.metadata = metadata;
-        this.kind = kind;
     }
 
-    public String getTaskId() {
-        return taskId;
-    }
-
-    public Artifact_v0_3 getArtifact() {
-        return artifact;
-    }
-
-    public String getContextId() {
-        return contextId;
-    }
-
-    public Boolean isAppend() {
-        return append;
-    }
-
-    public Boolean isLastChunk() {
-        return lastChunk;
-    }
-
-    public Map<String, Object> getMetadata() {
-        return metadata;
-    }
-
-    @Override
-    public String getKind() {
-        return kind;
+    public TaskArtifactUpdateEvent_v0_3(String taskId, Artifact_v0_3 artifact, String contextId,
+                                         @Nullable Boolean append, @Nullable Boolean lastChunk,
+                                         @Nullable Map<String, Object> metadata) {
+        this(taskId, append, lastChunk, artifact, contextId, metadata, KIND);
     }
 
     public static class Builder {
@@ -81,13 +51,13 @@ public final class TaskArtifactUpdateEvent_v0_3 implements EventKind_v0_3, Strea
         public Builder() {
         }
 
-        public Builder(TaskArtifactUpdateEvent_v0_3 existingTaskArtifactUpdateEvent) {
-            this.taskId = existingTaskArtifactUpdateEvent.taskId;
-            this.artifact = existingTaskArtifactUpdateEvent.artifact;
-            this.contextId = existingTaskArtifactUpdateEvent.contextId;
-            this.append = existingTaskArtifactUpdateEvent.append;
-            this.lastChunk = existingTaskArtifactUpdateEvent.lastChunk;
-            this.metadata = existingTaskArtifactUpdateEvent.metadata;
+        public Builder(TaskArtifactUpdateEvent_v0_3 existing) {
+            this.taskId = existing.taskId;
+            this.artifact = existing.artifact;
+            this.contextId = existing.contextId;
+            this.append = existing.append;
+            this.lastChunk = existing.lastChunk;
+            this.metadata = existing.metadata;
         }
 
         public Builder taskId(String taskId) {
@@ -111,10 +81,9 @@ public final class TaskArtifactUpdateEvent_v0_3 implements EventKind_v0_3, Strea
         }
 
         public Builder lastChunk(Boolean lastChunk) {
-            this.lastChunk  = lastChunk;
+            this.lastChunk = lastChunk;
             return this;
         }
-
 
         public Builder metadata(Map<String, Object> metadata) {
             this.metadata = metadata;

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/TaskStatusUpdateEvent_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/TaskStatusUpdateEvent_v0_3.java
@@ -15,22 +15,26 @@ public record TaskStatusUpdateEvent_v0_3(
         TaskStatus_v0_3 status,
         String contextId,
         @SerializedName("final") boolean isFinal,
-        @Nullable Map<String, Object> metadata,
+        Map<String, Object> metadata,
         String kind
 ) implements EventKind_v0_3, StreamingEventKind_v0_3, UpdateEvent_v0_3 {
 
     public static final String KIND = "status-update";
 
-    public TaskStatusUpdateEvent_v0_3 {
+    public TaskStatusUpdateEvent_v0_3 (String taskId, TaskStatus_v0_3 status, String contextId, boolean isFinal,
+                                      @Nullable Map<String, Object> metadata, String kind) {
         Assert.checkNotNullParam("taskId", taskId);
         Assert.checkNotNullParam("status", status);
         Assert.checkNotNullParam("contextId", contextId);
-        if (kind == null) {
-            kind = KIND;
-        }
-        if (!kind.equals(KIND)) {
+        this.kind = kind != null ? kind : KIND;
+        if (!KIND.equals(this.kind)) {
             throw new IllegalArgumentException("Invalid TaskStatusUpdateEvent");
         }
+        this.taskId = taskId;
+        this.status = status;
+        this.contextId = contextId;
+        this.isFinal = isFinal;
+        this.metadata = metadata != null ? Map.copyOf(metadata) : null;
     }
 
     public TaskStatusUpdateEvent_v0_3(String taskId, TaskStatus_v0_3 status, String contextId, boolean isFinal,

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/TaskStatusUpdateEvent_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/TaskStatusUpdateEvent_v0_3.java
@@ -4,67 +4,38 @@ import com.google.gson.annotations.SerializedName;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An event sent by the agent to notify the client of a change in a task's status.
  * This is typically used in streaming or subscription models.
  */
-public final class TaskStatusUpdateEvent_v0_3 implements EventKind_v0_3, StreamingEventKind_v0_3, UpdateEvent_v0_3 {
+public record TaskStatusUpdateEvent_v0_3(
+        String taskId,
+        TaskStatus_v0_3 status,
+        String contextId,
+        @SerializedName("final") boolean isFinal,
+        @Nullable Map<String, Object> metadata,
+        String kind
+) implements EventKind_v0_3, StreamingEventKind_v0_3, UpdateEvent_v0_3 {
 
-    public static final String STATUS_UPDATE = "status-update";
-    private final String taskId;
-    private final TaskStatus_v0_3 status;
-    private final String contextId;
-    @SerializedName("final")
-    private final boolean isFinal;
-    private final Map<String, Object> metadata;
-    private final String kind;
+    public static final String KIND = "status-update";
 
-
-    public TaskStatusUpdateEvent_v0_3(String taskId, TaskStatus_v0_3 status, String contextId, boolean isFinal,
-                                      Map<String, Object> metadata) {
-        this(taskId, status, contextId, isFinal, metadata, STATUS_UPDATE);
-    }
-
-    public TaskStatusUpdateEvent_v0_3(String taskId, TaskStatus_v0_3 status, String contextId, boolean isFinal, Map<String, Object> metadata, String kind) {
+    public TaskStatusUpdateEvent_v0_3 {
         Assert.checkNotNullParam("taskId", taskId);
         Assert.checkNotNullParam("status", status);
         Assert.checkNotNullParam("contextId", contextId);
-        Assert.checkNotNullParam("kind", kind);
-        if (! kind.equals(STATUS_UPDATE)) {
+        if (kind == null) {
+            kind = KIND;
+        }
+        if (!kind.equals(KIND)) {
             throw new IllegalArgumentException("Invalid TaskStatusUpdateEvent");
         }
-        this.taskId = taskId;
-        this.status = status;
-        this.contextId = contextId;
-        this.isFinal = isFinal;
-        this.metadata = metadata;
-        this.kind = kind;
     }
 
-    public String getTaskId() {
-        return taskId;
-    }
-
-    public TaskStatus_v0_3 getStatus() {
-        return status;
-    }
-
-    public String getContextId() {
-        return contextId;
-    }
-
-    public boolean isFinal() {
-        return isFinal;
-    }
-
-    public Map<String, Object> getMetadata() {
-        return metadata;
-    }
-
-    @Override
-    public String getKind() {
-        return kind;
+    public TaskStatusUpdateEvent_v0_3(String taskId, TaskStatus_v0_3 status, String contextId, boolean isFinal,
+                                      @Nullable Map<String, Object> metadata) {
+        this(taskId, status, contextId, isFinal, metadata, KIND);
     }
 
     public static class Builder {
@@ -77,13 +48,14 @@ public final class TaskStatusUpdateEvent_v0_3 implements EventKind_v0_3, Streami
         public Builder() {
         }
 
-        public Builder(TaskStatusUpdateEvent_v0_3 existingTaskStatusUpdateEvent) {
-            this.taskId = existingTaskStatusUpdateEvent.taskId;
-            this.status = existingTaskStatusUpdateEvent.status;
-            this.contextId = existingTaskStatusUpdateEvent.contextId;
-            this.isFinal = existingTaskStatusUpdateEvent.isFinal;
-            this.metadata = existingTaskStatusUpdateEvent.metadata;
+        public Builder(TaskStatusUpdateEvent_v0_3 existing) {
+            this.taskId = existing.taskId;
+            this.status = existing.status;
+            this.contextId = existing.contextId;
+            this.isFinal = existing.isFinal;
+            this.metadata = existing.metadata;
         }
+
         public Builder taskId(String id) {
             this.taskId = id;
             return this;

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/Task_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/Task_v0_3.java
@@ -21,18 +21,21 @@ public record Task_v0_3(
 
     public static final String KIND = "task";
 
-    public Task_v0_3 {
+    public Task_v0_3 (String id, String contextId, TaskStatus_v0_3 status, List<Artifact_v0_3> artifacts,
+                     List<Message_v0_3> history, @Nullable Map<String, Object> metadata, String kind){
         Assert.checkNotNullParam("id", id);
         Assert.checkNotNullParam("contextId", contextId);
         Assert.checkNotNullParam("status", status);
-        if (kind == null) {
-            kind = KIND;
-        }
-        if (!kind.equals(KIND)) {
+        this.kind = kind != null ? kind : KIND;
+        if (!KIND.equals(this.kind)) {
             throw new IllegalArgumentException("Invalid Task");
         }
-        artifacts = artifacts != null ? List.copyOf(artifacts) : List.of();
-        history = history != null ? List.copyOf(history) : List.of();
+        this.id = id;
+        this.contextId = contextId;
+        this.status = status;
+        this.artifacts = artifacts != null ? List.copyOf(artifacts) : List.of();
+        this.history = history != null ? List.copyOf(history) : List.of();
+        this.metadata = metadata != null ? Map.copyOf(metadata) : null;
     }
 
     public Task_v0_3(String id, String contextId, TaskStatus_v0_3 status, List<Artifact_v0_3> artifacts,

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/Task_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/Task_v0_3.java
@@ -4,72 +4,40 @@ import java.util.List;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a single, stateful operation or conversation between a client and an agent.
  */
-public final class Task_v0_3 implements EventKind_v0_3, StreamingEventKind_v0_3 {
+public record Task_v0_3(
+        String id,
+        String contextId,
+        TaskStatus_v0_3 status,
+        List<Artifact_v0_3> artifacts,
+        List<Message_v0_3> history,
+        @Nullable Map<String, Object> metadata,
+        String kind
+) implements EventKind_v0_3, StreamingEventKind_v0_3 {
 
-    public static final String TASK = "task";
-    private final String id;
-    private final String contextId;
-    private final TaskStatus_v0_3 status;
-    private final List<Artifact_v0_3> artifacts;
-    private final List<Message_v0_3> history;
-    private final Map<String, Object> metadata;
-    private final String kind;
+    public static final String KIND = "task";
 
-    public Task_v0_3(String id, String contextId, TaskStatus_v0_3 status, List<Artifact_v0_3> artifacts,
-                     List<Message_v0_3> history, Map<String, Object> metadata) {
-        this(id, contextId, status, artifacts, history, metadata, TASK);
-    }
-
-    public Task_v0_3(String id, String contextId, TaskStatus_v0_3 status,
-                     List<Artifact_v0_3> artifacts, List<Message_v0_3> history,
-                     Map<String, Object> metadata, String kind) {
+    public Task_v0_3 {
         Assert.checkNotNullParam("id", id);
         Assert.checkNotNullParam("contextId", contextId);
         Assert.checkNotNullParam("status", status);
-        Assert.checkNotNullParam("kind", kind);
-        if (! kind.equals(TASK)) {
+        if (kind == null) {
+            kind = KIND;
+        }
+        if (!kind.equals(KIND)) {
             throw new IllegalArgumentException("Invalid Task");
         }
-        this.id = id;
-        this.contextId = contextId;
-        this.status = status;
-        this.artifacts = artifacts != null ? List.copyOf(artifacts) : List.of();
-        this.history = history != null ? List.copyOf(history) : List.of();
-        this.metadata = metadata;
-        this.kind = kind;
+        artifacts = artifacts != null ? List.copyOf(artifacts) : List.of();
+        history = history != null ? List.copyOf(history) : List.of();
     }
 
-    public String getId() {
-        return id;
-    }
-
-    public String getContextId() {
-        return contextId;
-    }
-
-    public TaskStatus_v0_3 getStatus() {
-        return status;
-    }
-
-    public List<Artifact_v0_3> getArtifacts() {
-        return artifacts;
-    }
-
-    public List<Message_v0_3> getHistory() {
-        return history;
-    }
-
-    public Map<String, Object> getMetadata() {
-        return metadata;
-    }
-
-    @Override
-    public String getKind() {
-        return kind;
+    public Task_v0_3(String id, String contextId, TaskStatus_v0_3 status, List<Artifact_v0_3> artifacts,
+                     List<Message_v0_3> history, @Nullable Map<String, Object> metadata) {
+        this(id, contextId, status, artifacts, history, metadata, KIND);
     }
 
     public static class Builder {
@@ -81,7 +49,6 @@ public final class Task_v0_3 implements EventKind_v0_3, StreamingEventKind_v0_3 
         private Map<String, Object> metadata;
 
         public Builder() {
-
         }
 
         public Builder(Task_v0_3 task) {
@@ -91,7 +58,6 @@ public final class Task_v0_3 implements EventKind_v0_3, StreamingEventKind_v0_3 
             artifacts = task.artifacts;
             history = task.history;
             metadata = task.metadata;
-
         }
 
         public Builder id(String id) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/TextPart_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/TextPart_v0_3.java
@@ -3,39 +3,30 @@ package org.a2aproject.sdk.compat03.spec;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a text segment within a message or artifact.
  */
-public class TextPart_v0_3 extends Part_v0_3<String> {
+public record TextPart_v0_3(String text, @Nullable Map<String, Object> metadata, Kind kind) implements Part_v0_3<String> {
 
     public static final String TEXT = "text";
-    private final String text;
-    private final Map<String, Object> metadata;
-    private final Kind kind;
+
+    public TextPart_v0_3 {
+        Assert.checkNotNullParam("text", text);
+        if (kind == null) {
+            kind = Kind.TEXT;
+        }
+        if (kind != Kind.TEXT) {
+            throw new IllegalArgumentException("Invalid TextPart kind: " + kind);
+        }
+    }
 
     public TextPart_v0_3(String text) {
-        this(text, null);
+        this(text, null, Kind.TEXT);
     }
 
-    public TextPart_v0_3(String text, Map<String, Object> metadata) {
-        Assert.checkNotNullParam("text", text);
-        this.text = text;
-        this.metadata = metadata;
-        this.kind = Kind.TEXT;
-    }
-
-    @Override
-    public Kind getKind() {
-        return kind;
-    }
-
-    public String getText() {
-        return text;
-    }
-
-    @Override
-    public Map<String, Object> getMetadata() {
-        return metadata;
+    public TextPart_v0_3(String text, @Nullable Map<String, Object> metadata) {
+        this(text, metadata, Kind.TEXT);
     }
 }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/TextPart_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/TextPart_v0_3.java
@@ -8,18 +8,18 @@ import org.jspecify.annotations.Nullable;
 /**
  * Represents a text segment within a message or artifact.
  */
-public record TextPart_v0_3(String text, @Nullable Map<String, Object> metadata, Kind kind) implements Part_v0_3<String> {
+public record TextPart_v0_3(String text, Map<String, Object> metadata, Kind kind) implements Part_v0_3<String> {
 
     public static final String TEXT = "text";
 
-    public TextPart_v0_3 {
+    public TextPart_v0_3 (String text, @Nullable Map<String, Object> metadata, Kind kind){
         Assert.checkNotNullParam("text", text);
-        if (kind == null) {
-            kind = Kind.TEXT;
-        }
         if (kind != Kind.TEXT) {
             throw new IllegalArgumentException("Invalid TextPart kind: " + kind);
         }
+        this.text = text;
+        this.metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+        this.kind = kind;
     }
 
     public TextPart_v0_3(String text) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/util/Utils_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/util/Utils_v0_3.java
@@ -97,11 +97,11 @@ public class Utils_v0_3 {
      */
     public static Task_v0_3 appendArtifactToTask(Task_v0_3 task, TaskArtifactUpdateEvent_v0_3 event, String taskId) {
         // Append artifacts
-        List<Artifact_v0_3> artifacts = task.getArtifacts() == null ? new ArrayList<>() : new ArrayList<>(task.getArtifacts());
+        List<Artifact_v0_3> artifacts = new ArrayList<>(task.artifacts());
 
-        Artifact_v0_3 newArtifact = event.getArtifact();
+        Artifact_v0_3 newArtifact = event.artifact();
         String artifactId = newArtifact.artifactId();
-        boolean appendParts = event.isAppend() != null && event.isAppend();
+        boolean appendParts = event.append() != null && event.append();
 
         Artifact_v0_3 existingArtifact = null;
         int existingArtifactIndex = -1;

--- a/compat-0.3/spec/src/test/java/org/a2aproject/sdk/compat03/spec/SubTypeSerialization_v0_3_Test.java
+++ b/compat-0.3/spec/src/test/java/org/a2aproject/sdk/compat03/spec/SubTypeSerialization_v0_3_Test.java
@@ -32,24 +32,24 @@ public class SubTypeSerialization_v0_3_Test {
         return Stream.of(
                 Arguments.of(
                         new TaskStatusUpdateEvent_v0_3.Builder()
-                                .taskId(MINIMAL_TASK.getId())
-                                .contextId(MINIMAL_TASK.getContextId())
+                                .taskId(MINIMAL_TASK.id())
+                                .contextId(MINIMAL_TASK.contextId())
                                 .status(new TaskStatus_v0_3(TaskState_v0_3.COMPLETED))
                                 .isFinal(true)
-                                .build(), "kind", TaskStatusUpdateEvent_v0_3.STATUS_UPDATE
+                                .build(), "kind", TaskStatusUpdateEvent_v0_3.KIND
                 ),
                 Arguments.of(
                         new TaskArtifactUpdateEvent_v0_3.Builder()
-                                .taskId(MINIMAL_TASK.getId())
-                                .contextId(MINIMAL_TASK.getContextId())
+                                .taskId(MINIMAL_TASK.id())
+                                .contextId(MINIMAL_TASK.contextId())
                                 .artifact(new Artifact_v0_3.Builder()
                                         .artifactId("11")
                                         .parts(new TextPart_v0_3("text"))
                                         .build())
-                                .build(), "kind", TaskArtifactUpdateEvent_v0_3.ARTIFACT_UPDATE
+                                .build(), "kind", TaskArtifactUpdateEvent_v0_3.KIND
                 ),
                 Arguments.of(
-                        MINIMAL_TASK, "kind", Task_v0_3.TASK
+                        MINIMAL_TASK, "kind", Task_v0_3.KIND
                 ),
                 Arguments.of(
                         new Message_v0_3.Builder()
@@ -57,7 +57,7 @@ public class SubTypeSerialization_v0_3_Test {
                                 .parts(new TextPart_v0_3("tell me some jokes"))
                                 .contextId("context-1234")
                                 .messageId("message-1234")
-                                .build(), "kind", Message_v0_3.MESSAGE
+                                .build(), "kind", Message_v0_3.KIND
                 ),
                 Arguments.of(
                         new TextPart_v0_3("text"), "kind", TextPart_v0_3.TEXT
@@ -73,28 +73,28 @@ public class SubTypeSerialization_v0_3_Test {
                 Arguments.of(
                         new APIKeySecurityScheme_v0_3.Builder()
                                 .in("test").name("name").description("description").build(),
-                        "type", APIKeySecurityScheme_v0_3.API_KEY
+                        "type", APIKeySecurityScheme_v0_3.TYPE
                 ),
                 Arguments.of(
                         new HTTPAuthSecurityScheme_v0_3.Builder()
                         .scheme("basic").description("Basic Auth").build(),
-                        "type", HTTPAuthSecurityScheme_v0_3.HTTP
+                        "type", HTTPAuthSecurityScheme_v0_3.TYPE
                 ),
                 Arguments.of(
                         new OAuth2SecurityScheme_v0_3.Builder()
                                 .flows(new OAuthFlows_v0_3.Builder().build())
                                 .description("oAuth2SecurityScheme").build(),
-                        "type", OAuth2SecurityScheme_v0_3.OAUTH2
+                        "type", OAuth2SecurityScheme_v0_3.TYPE
                 ),
                 Arguments.of(
                         new OpenIdConnectSecurityScheme_v0_3.Builder()
                                 .openIdConnectUrl("https://accounts.google.com/.well-known/openid-configuration")
                                 .description("OpenId").build(),
-                        "type", OpenIdConnectSecurityScheme_v0_3.OPENID_CONNECT
+                        "type", OpenIdConnectSecurityScheme_v0_3.TYPE
                 ),
                 Arguments.of(
                         new MutualTLSSecurityScheme_v0_3("mutual tls test"),
-                        "type", MutualTLSSecurityScheme_v0_3.MUTUAL_TLS
+                        "type", MutualTLSSecurityScheme_v0_3.TYPE
                 )
         );
     }

--- a/compat-0.3/spec/src/test/java/org/a2aproject/sdk/compat03/spec/TaskSerialization_v0_3_Test.java
+++ b/compat-0.3/spec/src/test/java/org/a2aproject/sdk/compat03/spec/TaskSerialization_v0_3_Test.java
@@ -40,8 +40,8 @@ class TaskSerialization_v0_3_Test {
         Task_v0_3 deserialized = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
         // Verify deserialized task matches original
-        assertEquals(task.getId(), deserialized.getId());
-        assertEquals(task.getStatus().state(), deserialized.getStatus().state());
+        assertEquals(task.id(), deserialized.id());
+        assertEquals(task.status().state(), deserialized.status().state());
     }
 
     @Test
@@ -61,8 +61,8 @@ class TaskSerialization_v0_3_Test {
         Task_v0_3 deserialized = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
         // Verify OffsetDateTime timestamp is preserved
-        assertNotNull(deserialized.getStatus().timestamp());
-        assertEquals(task.getStatus().timestamp(), deserialized.getStatus().timestamp());
+        assertNotNull(deserialized.status().timestamp());
+        assertEquals(task.status().timestamp(), deserialized.status().timestamp());
     }
 
     @Test
@@ -96,10 +96,10 @@ class TaskSerialization_v0_3_Test {
         Task_v0_3 deserialized = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
         // Verify artifacts are preserved
-        assertNotNull(deserialized.getArtifacts());
-        assertEquals(1, deserialized.getArtifacts().size());
-        assertEquals("artifact-1", deserialized.getArtifacts().get(0).artifactId());
-        assertEquals(2, deserialized.getArtifacts().get(0).parts().size());
+        assertNotNull(deserialized.artifacts());
+        assertEquals(1, deserialized.artifacts().size());
+        assertEquals("artifact-1", deserialized.artifacts().get(0).artifactId());
+        assertEquals(2, deserialized.artifacts().get(0).parts().size());
     }
 
     @Test
@@ -127,10 +127,10 @@ class TaskSerialization_v0_3_Test {
         Task_v0_3 deserialized = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
         // Verify history is preserved
-        assertNotNull(deserialized.getHistory());
-        assertEquals(1, deserialized.getHistory().size());
-        assertEquals(Message_v0_3.Role.USER, deserialized.getHistory().get(0).getRole());
-        assertEquals(1, deserialized.getHistory().get(0).getParts().size());
+        assertNotNull(deserialized.history());
+        assertEquals(1, deserialized.history().size());
+        assertEquals(Message_v0_3.Role.USER, deserialized.history().get(0).role());
+        assertEquals(1, deserialized.history().get(0).parts().size());
     }
 
     @Test
@@ -167,14 +167,14 @@ class TaskSerialization_v0_3_Test {
         Task_v0_3 deserialized = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
         // Verify all fields are preserved
-        assertEquals(task.getId(), deserialized.getId());
-        assertEquals(task.getContextId(), deserialized.getContextId());
-        assertEquals(task.getStatus().state(), deserialized.getStatus().state());
-        assertEquals(task.getStatus().timestamp(), deserialized.getStatus().timestamp());
-        assertEquals(task.getHistory().size(), deserialized.getHistory().size());
-        assertEquals(task.getArtifacts().size(), deserialized.getArtifacts().size());
-        assertNotNull(deserialized.getMetadata());
-        assertEquals("value1", deserialized.getMetadata().get("key1"));
+        assertEquals(task.id(), deserialized.id());
+        assertEquals(task.contextId(), deserialized.contextId());
+        assertEquals(task.status().state(), deserialized.status().state());
+        assertEquals(task.status().timestamp(), deserialized.status().timestamp());
+        assertEquals(task.history().size(), deserialized.history().size());
+        assertEquals(task.artifacts().size(), deserialized.artifacts().size());
+        assertNotNull(deserialized.metadata());
+        assertEquals("value1", deserialized.metadata().get("key1"));
     }
 
     @Test
@@ -196,7 +196,7 @@ class TaskSerialization_v0_3_Test {
             Task_v0_3 deserialized = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
             // Verify state is preserved
-            assertEquals(state, deserialized.getStatus().state());
+            assertEquals(state, deserialized.status().state());
         }
     }
 
@@ -216,15 +216,15 @@ class TaskSerialization_v0_3_Test {
         Task_v0_3 deserialized = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
         // Verify required fields are present
-        assertEquals("task-123", deserialized.getId());
-        assertEquals("context-456", deserialized.getContextId());
-        assertEquals(TaskState_v0_3.SUBMITTED, deserialized.getStatus().state());
+        assertEquals("task-123", deserialized.id());
+        assertEquals("context-456", deserialized.contextId());
+        assertEquals(TaskState_v0_3.SUBMITTED, deserialized.status().state());
 
         // Verify optional lists default to empty
-        assertNotNull(deserialized.getArtifacts());
-        assertEquals(0, deserialized.getArtifacts().size());
-        assertNotNull(deserialized.getHistory());
-        assertEquals(0, deserialized.getHistory().size());
+        assertNotNull(deserialized.artifacts());
+        assertEquals(0, deserialized.artifacts().size());
+        assertNotNull(deserialized.history());
+        assertEquals(0, deserialized.history().size());
     }
 
     @Test
@@ -255,11 +255,11 @@ class TaskSerialization_v0_3_Test {
         Task_v0_3 deserialized = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
         // Verify file part is preserved
-        Part_v0_3<?> part = deserialized.getArtifacts().get(0).parts().get(0);
+        Part_v0_3<?> part = deserialized.artifacts().get(0).parts().get(0);
         assertTrue(part instanceof FilePart_v0_3);
         FilePart_v0_3 deserializedFilePart = (FilePart_v0_3) part;
-        assertTrue(deserializedFilePart.getFile() instanceof FileWithBytes_v0_3);
-        FileWithBytes_v0_3 fileWithBytes = (FileWithBytes_v0_3) deserializedFilePart.getFile();
+        assertTrue(deserializedFilePart.file() instanceof FileWithBytes_v0_3);
+        FileWithBytes_v0_3 fileWithBytes = (FileWithBytes_v0_3) deserializedFilePart.file();
         assertEquals("document.pdf", fileWithBytes.name());
         assertEquals("application/pdf", fileWithBytes.mimeType());
     }
@@ -290,11 +290,11 @@ class TaskSerialization_v0_3_Test {
         Task_v0_3 deserialized = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
         // Verify file part URI is preserved
-        Part_v0_3<?> part = deserialized.getArtifacts().get(0).parts().get(0);
+        Part_v0_3<?> part = deserialized.artifacts().get(0).parts().get(0);
         assertTrue(part instanceof FilePart_v0_3);
         FilePart_v0_3 deserializedFilePart = (FilePart_v0_3) part;
-        assertTrue(deserializedFilePart.getFile() instanceof FileWithUri_v0_3);
-        FileWithUri_v0_3 fileWithUri = (FileWithUri_v0_3) deserializedFilePart.getFile();
+        assertTrue(deserializedFilePart.file() instanceof FileWithUri_v0_3);
+        FileWithUri_v0_3 fileWithUri = (FileWithUri_v0_3) deserializedFilePart.file();
         assertEquals("https://example.com/photo.png", fileWithUri.uri());
     }
 
@@ -325,10 +325,10 @@ class TaskSerialization_v0_3_Test {
         Task_v0_3 deserialized = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
         // Verify data part is preserved
-        Part_v0_3<?> part = deserialized.getArtifacts().get(0).parts().get(0);
+        Part_v0_3<?> part = deserialized.artifacts().get(0).parts().get(0);
         assertTrue(part instanceof DataPart_v0_3);
         DataPart_v0_3 deserializedDataPart = (DataPart_v0_3) part;
-        assertNotNull(deserializedDataPart.getData());
+        assertNotNull(deserializedDataPart.data());
     }
 
     @Test
@@ -372,11 +372,11 @@ class TaskSerialization_v0_3_Test {
         Task_v0_3 deserialized2 = JsonUtil_v0_3.fromJson(json2, Task_v0_3.class);
 
         // Verify multiple round-trips produce identical results
-        assertEquals(deserialized.getId(), deserialized2.getId());
-        assertEquals(deserialized.getContextId(), deserialized2.getContextId());
-        assertEquals(deserialized.getStatus().state(), deserialized2.getStatus().state());
-        assertEquals(deserialized.getHistory().size(), deserialized2.getHistory().size());
-        assertEquals(deserialized.getArtifacts().size(), deserialized2.getArtifacts().size());
+        assertEquals(deserialized.id(), deserialized2.id());
+        assertEquals(deserialized.contextId(), deserialized2.contextId());
+        assertEquals(deserialized.status().state(), deserialized2.status().state());
+        assertEquals(deserialized.history().size(), deserialized2.history().size());
+        assertEquals(deserialized.artifacts().size(), deserialized2.artifacts().size());
     }
 
     @Test
@@ -403,10 +403,10 @@ class TaskSerialization_v0_3_Test {
         Task_v0_3 deserialized = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
         // Verify status message is preserved
-        assertEquals(TaskState_v0_3.COMPLETED, deserialized.getStatus().state());
-        assertNotNull(deserialized.getStatus().message());
-        assertEquals(Message_v0_3.Role.AGENT, deserialized.getStatus().message().getRole());
-        assertTrue(deserialized.getStatus().message().getParts().get(0) instanceof TextPart_v0_3);
+        assertEquals(TaskState_v0_3.COMPLETED, deserialized.status().state());
+        assertNotNull(deserialized.status().message());
+        assertEquals(Message_v0_3.Role.AGENT, deserialized.status().message().role());
+        assertTrue(deserialized.status().message().parts().get(0) instanceof TextPart_v0_3);
     }
 
     @Test
@@ -424,12 +424,12 @@ class TaskSerialization_v0_3_Test {
 
         Task_v0_3 task = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
-        assertEquals("task-123", task.getId());
-        assertEquals("context-456", task.getContextId());
-        assertEquals(TaskState_v0_3.SUBMITTED, task.getStatus().state());
-        assertNull(task.getStatus().message());
+        assertEquals("task-123", task.id());
+        assertEquals("context-456", task.contextId());
+        assertEquals(TaskState_v0_3.SUBMITTED, task.status().state());
+        assertNull(task.status().message());
         // TaskStatus automatically sets timestamp to current time if not provided
-        assertNotNull(task.getStatus().timestamp());
+        assertNotNull(task.status().timestamp());
     }
 
     @Test
@@ -459,14 +459,14 @@ class TaskSerialization_v0_3_Test {
 
         Task_v0_3 task = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
-        assertEquals("task-123", task.getId());
-        assertEquals(TaskState_v0_3.COMPLETED, task.getStatus().state());
-        assertEquals(1, task.getArtifacts().size());
-        assertEquals("artifact-1", task.getArtifacts().get(0).artifactId());
-        assertEquals("Result", task.getArtifacts().get(0).name());
-        assertEquals(1, task.getArtifacts().get(0).parts().size());
-        assertTrue(task.getArtifacts().get(0).parts().get(0) instanceof TextPart_v0_3);
-        assertEquals("Hello World", ((TextPart_v0_3) task.getArtifacts().get(0).parts().get(0)).getText());
+        assertEquals("task-123", task.id());
+        assertEquals(TaskState_v0_3.COMPLETED, task.status().state());
+        assertEquals(1, task.artifacts().size());
+        assertEquals("artifact-1", task.artifacts().get(0).artifactId());
+        assertEquals("Result", task.artifacts().get(0).name());
+        assertEquals(1, task.artifacts().get(0).parts().size());
+        assertTrue(task.artifacts().get(0).parts().get(0) instanceof TextPart_v0_3);
+        assertEquals("Hello World", ((TextPart_v0_3) task.artifacts().get(0).parts().get(0)).text());
     }
 
     @Test
@@ -499,13 +499,13 @@ class TaskSerialization_v0_3_Test {
 
         Task_v0_3 task = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
-        assertEquals("task-123", task.getId());
-        assertEquals(1, task.getArtifacts().size());
-        Part_v0_3<?> part = task.getArtifacts().get(0).parts().get(0);
+        assertEquals("task-123", task.id());
+        assertEquals(1, task.artifacts().size());
+        Part_v0_3<?> part = task.artifacts().get(0).parts().get(0);
         assertTrue(part instanceof FilePart_v0_3);
         FilePart_v0_3 filePart = (FilePart_v0_3) part;
-        assertTrue(filePart.getFile() instanceof FileWithBytes_v0_3);
-        FileWithBytes_v0_3 fileWithBytes = (FileWithBytes_v0_3) filePart.getFile();
+        assertTrue(filePart.file() instanceof FileWithBytes_v0_3);
+        FileWithBytes_v0_3 fileWithBytes = (FileWithBytes_v0_3) filePart.file();
         assertEquals("application/pdf", fileWithBytes.mimeType());
         assertEquals("document.pdf", fileWithBytes.name());
         assertEquals("base64encodeddata", fileWithBytes.bytes());
@@ -541,12 +541,12 @@ class TaskSerialization_v0_3_Test {
 
         Task_v0_3 task = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
-        assertEquals("task-123", task.getId());
-        Part_v0_3<?> part = task.getArtifacts().get(0).parts().get(0);
+        assertEquals("task-123", task.id());
+        Part_v0_3<?> part = task.artifacts().get(0).parts().get(0);
         assertTrue(part instanceof FilePart_v0_3);
         FilePart_v0_3 filePart = (FilePart_v0_3) part;
-        assertTrue(filePart.getFile() instanceof FileWithUri_v0_3);
-        FileWithUri_v0_3 fileWithUri = (FileWithUri_v0_3) filePart.getFile();
+        assertTrue(filePart.file() instanceof FileWithUri_v0_3);
+        FileWithUri_v0_3 fileWithUri = (FileWithUri_v0_3) filePart.file();
         assertEquals("image/png", fileWithUri.mimeType());
         assertEquals("photo.png", fileWithUri.name());
         assertEquals("https://example.com/photo.png", fileWithUri.uri());
@@ -581,11 +581,11 @@ class TaskSerialization_v0_3_Test {
 
         Task_v0_3 task = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
-        assertEquals("task-123", task.getId());
-        Part_v0_3<?> part = task.getArtifacts().get(0).parts().get(0);
+        assertEquals("task-123", task.id());
+        Part_v0_3<?> part = task.artifacts().get(0).parts().get(0);
         assertTrue(part instanceof DataPart_v0_3);
         DataPart_v0_3 dataPart = (DataPart_v0_3) part;
-        assertNotNull(dataPart.getData());
+        assertNotNull(dataPart.data());
     }
 
     @Test
@@ -623,12 +623,12 @@ class TaskSerialization_v0_3_Test {
 
         Task_v0_3 task = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
-        assertEquals("task-123", task.getId());
-        assertEquals(2, task.getHistory().size());
-        assertEquals(Message_v0_3.Role.USER, task.getHistory().get(0).getRole());
-        assertEquals(Message_v0_3.Role.AGENT, task.getHistory().get(1).getRole());
-        assertTrue(task.getHistory().get(0).getParts().get(0) instanceof TextPart_v0_3);
-        assertEquals("User message", ((TextPart_v0_3) task.getHistory().get(0).getParts().get(0)).getText());
+        assertEquals("task-123", task.id());
+        assertEquals(2, task.history().size());
+        assertEquals(Message_v0_3.Role.USER, task.history().get(0).role());
+        assertEquals(Message_v0_3.Role.AGENT, task.history().get(1).role());
+        assertTrue(task.history().get(0).parts().get(0) instanceof TextPart_v0_3);
+        assertEquals("User message", ((TextPart_v0_3) task.history().get(0).parts().get(0)).text());
     }
 
     @Test
@@ -647,10 +647,10 @@ class TaskSerialization_v0_3_Test {
 
         Task_v0_3 task = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
-        assertEquals("task-123", task.getId());
-        assertEquals(TaskState_v0_3.WORKING, task.getStatus().state());
-        assertNotNull(task.getStatus().timestamp());
-        assertEquals("2023-10-01T12:00:00.234-05:00", task.getStatus().timestamp().toString());
+        assertEquals("task-123", task.id());
+        assertEquals(TaskState_v0_3.WORKING, task.status().state());
+        assertNotNull(task.status().timestamp());
+        assertEquals("2023-10-01T12:00:00.234-05:00", task.status().timestamp().toString());
     }
 
     @Test
@@ -672,9 +672,9 @@ class TaskSerialization_v0_3_Test {
 
         Task_v0_3 task = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
-        assertEquals("task-123", task.getId());
-        assertNotNull(task.getMetadata());
-        assertEquals("value1", task.getMetadata().get("key1"));
+        assertEquals("task-123", task.id());
+        assertNotNull(task.metadata());
+        assertEquals("value1", task.metadata().get("key1"));
     }
 
     @Test
@@ -703,7 +703,7 @@ class TaskSerialization_v0_3_Test {
         Task_v0_3 deserialized = JsonUtil_v0_3.fromJson(json, Task_v0_3.class);
 
         // Verify all part types are preserved
-        List<Part_v0_3<?>> parts = deserialized.getArtifacts().get(0).parts();
+        List<Part_v0_3<?>> parts = deserialized.artifacts().get(0).parts();
         assertEquals(4, parts.size());
         assertTrue(parts.get(0) instanceof TextPart_v0_3);
         assertTrue(parts.get(1) instanceof FilePart_v0_3);

--- a/compat-0.3/transport/grpc/src/test/java/org/a2aproject/sdk/compat03/transport/grpc/handler/GrpcHandler_v0_3_Test.java
+++ b/compat-0.3/transport/grpc/src/test/java/org/a2aproject/sdk/compat03/transport/grpc/handler/GrpcHandler_v0_3_Test.java
@@ -58,11 +58,11 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
 
     // gRPC Message fixture (protobuf format)
     private static final Message GRPC_MESSAGE = Message.newBuilder()
-            .setTaskId(MINIMAL_TASK.getId())
-            .setContextId(MINIMAL_TASK.getContextId())
-            .setMessageId(MESSAGE.getMessageId())
+            .setTaskId(MINIMAL_TASK.id())
+            .setContextId(MINIMAL_TASK.contextId())
+            .setMessageId(MESSAGE.messageId())
             .setRole(Role.ROLE_AGENT)
-            .addContent(Part.newBuilder().setText(((TextPart_v0_3) MESSAGE.getParts().get(0)).getText()).build())
+            .addContent(Part.newBuilder().setText(((TextPart_v0_3) MESSAGE.parts().get(0)).text()).build())
             .build();
 
     private final ServerCallContext callContext = new ServerCallContext(
@@ -80,7 +80,7 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
         taskStore.save(TaskMapper_v0_3.INSTANCE.toV10(MINIMAL_TASK), false);
 
         GetTaskRequest request = GetTaskRequest.newBuilder()
-                .setName("tasks/" + MINIMAL_TASK.getId())
+                .setName("tasks/" + MINIMAL_TASK.id())
                 .build();
 
         StreamRecorder<Task> streamRecorder = StreamRecorder.create();
@@ -91,8 +91,8 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
         List<Task> result = streamRecorder.getValues();
         Assertions.assertEquals(1, result.size());
         Task task = result.get(0);
-        assertEquals(MINIMAL_TASK.getId(), task.getId());
-        assertEquals(MINIMAL_TASK.getContextId(), task.getContextId());
+        assertEquals(MINIMAL_TASK.id(), task.getId());
+        assertEquals(MINIMAL_TASK.contextId(), task.getContextId());
     }
 
     @Test
@@ -100,7 +100,7 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
         TestGrpcHandler handler = new TestGrpcHandler(CARD, convert03To10Handler, internalExecutor);
 
         GetTaskRequest request = GetTaskRequest.newBuilder()
-                .setName("tasks/" + MINIMAL_TASK.getId())
+                .setName("tasks/" + MINIMAL_TASK.id())
                 .build();
 
         StreamRecorder<Task> streamRecorder = StreamRecorder.create();
@@ -127,7 +127,7 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
         };
 
         CancelTaskRequest request = CancelTaskRequest.newBuilder()
-                .setName("tasks/" + MINIMAL_TASK.getId())
+                .setName("tasks/" + MINIMAL_TASK.id())
                 .build();
 
         StreamRecorder<Task> streamRecorder = StreamRecorder.create();
@@ -138,8 +138,8 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
         List<Task> result = streamRecorder.getValues();
         Assertions.assertEquals(1, result.size());
         Task task = result.get(0);
-        assertEquals(MINIMAL_TASK.getId(), task.getId());
-        assertEquals(MINIMAL_TASK.getContextId(), task.getContextId());
+        assertEquals(MINIMAL_TASK.id(), task.getId());
+        assertEquals(MINIMAL_TASK.contextId(), task.getContextId());
         assertEquals(TaskState.TASK_STATE_CANCELLED, task.getStatus().getState());
     }
 
@@ -156,7 +156,7 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
         };
 
         CancelTaskRequest request = CancelTaskRequest.newBuilder()
-                .setName("tasks/" + MINIMAL_TASK.getId())
+                .setName("tasks/" + MINIMAL_TASK.id())
                 .build();
 
         StreamRecorder<Task> streamRecorder = StreamRecorder.create();
@@ -171,7 +171,7 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
         TestGrpcHandler handler = new TestGrpcHandler(CARD, convert03To10Handler, internalExecutor);
 
         CancelTaskRequest request = CancelTaskRequest.newBuilder()
-                .setName("tasks/" + MINIMAL_TASK.getId())
+                .setName("tasks/" + MINIMAL_TASK.id())
                 .build();
 
         StreamRecorder<Task> streamRecorder = StreamRecorder.create();
@@ -304,7 +304,7 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
         TestGrpcHandler handler = new TestGrpcHandler(nonStreamingCard, convert03To10Handler, internalExecutor);
 
         TaskSubscriptionRequest request = TaskSubscriptionRequest.newBuilder()
-                .setName("tasks/" + MINIMAL_TASK.getId())
+                .setName("tasks/" + MINIMAL_TASK.id())
                 .build();
 
         StreamRecorder<StreamResponse> streamRecorder = StreamRecorder.create();
@@ -341,7 +341,7 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
     public void testSetPushNotificationConfigSuccess() throws Exception {
         TestGrpcHandler handler = new TestGrpcHandler(CARD, convert03To10Handler, internalExecutor);
 
-        String NAME = "tasks/" + MINIMAL_TASK.getId() + "/pushNotificationConfigs/config456";
+        String NAME = "tasks/" + MINIMAL_TASK.id() + "/pushNotificationConfigs/config456";
         StreamRecorder<org.a2aproject.sdk.compat03.grpc.TaskPushNotificationConfig> streamRecorder =
                 createTaskPushNotificationConfigRequest(handler, NAME);
 
@@ -364,7 +364,7 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
             agentEmitter.emitEvent(context.getTask() != null ? context.getTask() : context.getMessage());
         };
 
-        String NAME = "tasks/" + MINIMAL_TASK.getId() + "/pushNotificationConfigs/config456";
+        String NAME = "tasks/" + MINIMAL_TASK.id() + "/pushNotificationConfigs/config456";
 
         // First set the task push notification config
         StreamRecorder<org.a2aproject.sdk.compat03.grpc.TaskPushNotificationConfig> streamRecorder =
@@ -389,7 +389,7 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
         AgentCard_v0_3 card = createAgentCard(true, false, false);
         TestGrpcHandler handler = new TestGrpcHandler(card, convert03To10Handler, internalExecutor);
 
-        String NAME = "tasks/" + MINIMAL_TASK.getId() + "/pushNotificationConfigs/" + MINIMAL_TASK.getId();
+        String NAME = "tasks/" + MINIMAL_TASK.id() + "/pushNotificationConfigs/" + MINIMAL_TASK.id();
         StreamRecorder<org.a2aproject.sdk.compat03.grpc.TaskPushNotificationConfig> streamRecorder =
                 createTaskPushNotificationConfigRequest(handler, NAME);
 
@@ -406,7 +406,7 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
         // Save task to v1.0 backend
         taskStore.save(TaskMapper_v0_3.INSTANCE.toV10(MINIMAL_TASK), false);
 
-        String NAME = "tasks/" + MINIMAL_TASK.getId() + "/pushNotificationConfigs/" + MINIMAL_TASK.getId();
+        String NAME = "tasks/" + MINIMAL_TASK.id() + "/pushNotificationConfigs/" + MINIMAL_TASK.id();
         org.a2aproject.sdk.compat03.grpc.DeleteTaskPushNotificationConfigRequest request =
                 org.a2aproject.sdk.compat03.grpc.DeleteTaskPushNotificationConfigRequest.newBuilder()
                         .setName(NAME)
@@ -428,7 +428,7 @@ public class GrpcHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
         // Save task to v1.0 backend
         taskStore.save(TaskMapper_v0_3.INSTANCE.toV10(MINIMAL_TASK), false);
 
-        String PARENT = "tasks/" + MINIMAL_TASK.getId();
+        String PARENT = "tasks/" + MINIMAL_TASK.id();
         org.a2aproject.sdk.compat03.grpc.ListTaskPushNotificationConfigRequest request =
                 org.a2aproject.sdk.compat03.grpc.ListTaskPushNotificationConfigRequest.newBuilder()
                         .setParent(PARENT)

--- a/compat-0.3/transport/jsonrpc/src/test/java/org/a2aproject/sdk/compat03/transport/jsonrpc/handler/JSONRPCHandler_v0_3_Test.java
+++ b/compat-0.3/transport/jsonrpc/src/test/java/org/a2aproject/sdk/compat03/transport/jsonrpc/handler/JSONRPCHandler_v0_3_Test.java
@@ -99,7 +99,7 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         // Save v0.3 task by converting to v1.0 for taskStore
         taskStore.save(TaskMapper_v0_3.INSTANCE.toV10(MINIMAL_TASK), false);
 
-        GetTaskRequest_v0_3 request = new GetTaskRequest_v0_3("1", new TaskQueryParams_v0_3(MINIMAL_TASK.getId()));
+        GetTaskRequest_v0_3 request = new GetTaskRequest_v0_3("1", new TaskQueryParams_v0_3(MINIMAL_TASK.id()));
         GetTaskResponse_v0_3 response = handler.onGetTask(request, callContext);
 
         assertEquals(request.getId(), response.getId());
@@ -107,15 +107,15 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
 
         // Response should contain v0.3 task (converted back from v1.0)
         Task_v0_3 result = response.getResult();
-        assertEquals(MINIMAL_TASK.getId(), result.getId());
-        assertEquals(MINIMAL_TASK.getContextId(), result.getContextId());
+        assertEquals(MINIMAL_TASK.id(), result.id());
+        assertEquals(MINIMAL_TASK.contextId(), result.contextId());
     }
 
     @Test
     public void testOnGetTaskNotFound() throws Exception {
         JSONRPCHandler_v0_3 handler = new JSONRPCHandler_v0_3(CARD, internalExecutor, convert03To10Handler);
 
-        GetTaskRequest_v0_3 request = new GetTaskRequest_v0_3("1", new TaskQueryParams_v0_3(MINIMAL_TASK.getId()));
+        GetTaskRequest_v0_3 request = new GetTaskRequest_v0_3("1", new TaskQueryParams_v0_3(MINIMAL_TASK.id()));
         GetTaskResponse_v0_3 response = handler.onGetTask(request, callContext);
 
         assertEquals(request.getId(), response.getId());
@@ -140,7 +140,7 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
             emitter.cancel();
         };
 
-        CancelTaskRequest_v0_3 request = new CancelTaskRequest_v0_3("111", new TaskIdParams_v0_3(MINIMAL_TASK.getId()));
+        CancelTaskRequest_v0_3 request = new CancelTaskRequest_v0_3("111", new TaskIdParams_v0_3(MINIMAL_TASK.id()));
         CancelTaskResponse_v0_3 response = handler.onCancelTask(request, callContext);
 
         assertNull(response.getError());
@@ -148,9 +148,9 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
 
         // Verify task was canceled
         Task_v0_3 task = response.getResult();
-        assertEquals(MINIMAL_TASK.getId(), task.getId());
-        assertEquals(MINIMAL_TASK.getContextId(), task.getContextId());
-        assertEquals(TaskState_v0_3.CANCELED, task.getStatus().state());
+        assertEquals(MINIMAL_TASK.id(), task.id());
+        assertEquals(MINIMAL_TASK.contextId(), task.contextId());
+        assertEquals(TaskState_v0_3.CANCELED, task.status().state());
     }
 
     @Test
@@ -165,7 +165,7 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
             throw new org.a2aproject.sdk.spec.UnsupportedOperationError();
         };
 
-        CancelTaskRequest_v0_3 request = new CancelTaskRequest_v0_3("1", new TaskIdParams_v0_3(MINIMAL_TASK.getId()));
+        CancelTaskRequest_v0_3 request = new CancelTaskRequest_v0_3("1", new TaskIdParams_v0_3(MINIMAL_TASK.id()));
         CancelTaskResponse_v0_3 response = handler.onCancelTask(request, callContext);
 
         assertEquals(request.getId(), response.getId());
@@ -177,7 +177,7 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
     public void testOnCancelTaskNotFound() {
         JSONRPCHandler_v0_3 handler = new JSONRPCHandler_v0_3(CARD, internalExecutor, convert03To10Handler);
 
-        CancelTaskRequest_v0_3 request = new CancelTaskRequest_v0_3("1", new TaskIdParams_v0_3(MINIMAL_TASK.getId()));
+        CancelTaskRequest_v0_3 request = new CancelTaskRequest_v0_3("1", new TaskIdParams_v0_3(MINIMAL_TASK.id()));
         CancelTaskResponse_v0_3 response = handler.onCancelTask(request, callContext);
 
         assertEquals(request.getId(), response.getId());
@@ -204,8 +204,8 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         };
 
         Message_v0_3 message = new Message_v0_3.Builder(MESSAGE)
-                .taskId(MINIMAL_TASK.getId())
-                .contextId(MINIMAL_TASK.getContextId())
+                .taskId(MINIMAL_TASK.id())
+                .contextId(MINIMAL_TASK.contextId())
                 .build();
 
         SendMessageRequest_v0_3 request = new SendMessageRequest_v0_3("1", new MessageSendParams_v0_3(message, null, null));
@@ -215,7 +215,7 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         // Response should contain the message (converted back from v1.0)
         EventKind_v0_3 result = response.getResult();
         if (result instanceof Message_v0_3) {
-            assertEquals(message.getMessageId(), ((Message_v0_3) result).getMessageId());
+            assertEquals(message.messageId(), ((Message_v0_3) result).messageId());
         }
     }
 
@@ -233,8 +233,8 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         };
 
         Message_v0_3 message = new Message_v0_3.Builder(MESSAGE)
-                .taskId(MINIMAL_TASK.getId())
-                .contextId(MINIMAL_TASK.getContextId())
+                .taskId(MINIMAL_TASK.id())
+                .contextId(MINIMAL_TASK.contextId())
                 .build();
 
         SendMessageRequest_v0_3 request = new SendMessageRequest_v0_3("1", new MessageSendParams_v0_3(message, null, null));
@@ -243,7 +243,7 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         assertNull(response.getError());
         EventKind_v0_3 result = response.getResult();
         if (result instanceof Message_v0_3) {
-            assertEquals(message.getMessageId(), ((Message_v0_3) result).getMessageId());
+            assertEquals(message.messageId(), ((Message_v0_3) result).messageId());
         }
     }
 
@@ -260,8 +260,8 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         };
 
         Message_v0_3 message = new Message_v0_3.Builder(MESSAGE)
-                .taskId(MINIMAL_TASK.getId())
-                .contextId(MINIMAL_TASK.getContextId())
+                .taskId(MINIMAL_TASK.id())
+                .contextId(MINIMAL_TASK.contextId())
                 .build();
 
         SendMessageRequest_v0_3 request = new SendMessageRequest_v0_3("1", new MessageSendParams_v0_3(message, null, null));
@@ -289,8 +289,8 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         };
 
         Message_v0_3 message = new Message_v0_3.Builder(MESSAGE)
-                .taskId(MINIMAL_TASK.getId())
-                .contextId(MINIMAL_TASK.getContextId())
+                .taskId(MINIMAL_TASK.id())
+                .contextId(MINIMAL_TASK.contextId())
                 .build();
 
         SendStreamingMessageRequest_v0_3 request = new SendStreamingMessageRequest_v0_3(
@@ -344,7 +344,7 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
 
         // Verify the event is the message (converted back from v1.0)
         Message_v0_3 receivedMessage = assertInstanceOf(Message_v0_3.class, results.get(0), "Event should be a Message");
-        assertEquals(message.getMessageId(), receivedMessage.getMessageId());
+        assertEquals(message.messageId(), receivedMessage.messageId());
     }
 
     @Test
@@ -360,8 +360,8 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
                 .build();
 
         TaskArtifactUpdateEvent_v0_3 v03ArtifactEvent = new TaskArtifactUpdateEvent_v0_3.Builder()
-                .taskId(MINIMAL_TASK.getId())
-                .contextId(MINIMAL_TASK.getContextId())
+                .taskId(MINIMAL_TASK.id())
+                .contextId(MINIMAL_TASK.contextId())
                 .artifact(new Artifact_v0_3.Builder()
                         .artifactId("artifact-1")
                         .parts(new TextPart_v0_3("Generated artifact content"))
@@ -369,8 +369,8 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
                 .build();
 
         TaskStatusUpdateEvent_v0_3 v03StatusEvent = new TaskStatusUpdateEvent_v0_3.Builder()
-                .taskId(MINIMAL_TASK.getId())
-                .contextId(MINIMAL_TASK.getContextId())
+                .taskId(MINIMAL_TASK.id())
+                .contextId(MINIMAL_TASK.contextId())
                 .status(new TaskStatus_v0_3(TaskState_v0_3.COMPLETED))
                 .isFinal(true) // Must be true for COMPLETED state in v1.0
                 .build();
@@ -385,8 +385,8 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         };
 
         Message_v0_3 message = new Message_v0_3.Builder(MESSAGE)
-                .taskId(MINIMAL_TASK.getId())
-                .contextId(MINIMAL_TASK.getContextId())
+                .taskId(MINIMAL_TASK.id())
+                .contextId(MINIMAL_TASK.contextId())
                 .build();
 
         SendStreamingMessageRequest_v0_3 request = new SendStreamingMessageRequest_v0_3(
@@ -440,21 +440,21 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
 
         // Verify the first event is the task
         Task_v0_3 receivedTask = assertInstanceOf(Task_v0_3.class, results.get(0), "First event should be a Task");
-        assertEquals(MINIMAL_TASK.getId(), receivedTask.getId());
-        assertEquals(MINIMAL_TASK.getContextId(), receivedTask.getContextId());
-        assertEquals(TaskState_v0_3.WORKING, receivedTask.getStatus().state());
+        assertEquals(MINIMAL_TASK.id(), receivedTask.id());
+        assertEquals(MINIMAL_TASK.contextId(), receivedTask.contextId());
+        assertEquals(TaskState_v0_3.WORKING, receivedTask.status().state());
 
         // Verify the second event is the artifact update
         TaskArtifactUpdateEvent_v0_3 receivedArtifact = assertInstanceOf(TaskArtifactUpdateEvent_v0_3.class, results.get(1),
                 "Second event should be a TaskArtifactUpdateEvent");
-        assertEquals(MINIMAL_TASK.getId(), receivedArtifact.getTaskId());
-        assertEquals("artifact-1", receivedArtifact.getArtifact().artifactId());
+        assertEquals(MINIMAL_TASK.id(), receivedArtifact.taskId());
+        assertEquals("artifact-1", receivedArtifact.artifact().artifactId());
 
         // Verify the third event is the status update
         TaskStatusUpdateEvent_v0_3 receivedStatus = assertInstanceOf(TaskStatusUpdateEvent_v0_3.class, results.get(2),
                 "Third event should be a TaskStatusUpdateEvent");
-        assertEquals(MINIMAL_TASK.getId(), receivedStatus.getTaskId());
-        assertEquals(TaskState_v0_3.COMPLETED, receivedStatus.getStatus().state());
+        assertEquals(MINIMAL_TASK.id(), receivedStatus.taskId());
+        assertEquals(TaskState_v0_3.COMPLETED, receivedStatus.status().state());
     }
 
     @Test
@@ -474,8 +474,8 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         taskStore.save(TaskMapper_v0_3.INSTANCE.toV10(v03Task), false);
 
         Message_v0_3 message = new Message_v0_3.Builder(MESSAGE)
-                .taskId(v03Task.getId())
-                .contextId(v03Task.getContextId())
+                .taskId(v03Task.id())
+                .contextId(v03Task.contextId())
                 .build();
 
         SendStreamingMessageRequest_v0_3 request = new SendStreamingMessageRequest_v0_3(
@@ -531,8 +531,8 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         // Verify the task was received
         assertEquals(1, results.size(), "Should have received exactly 1 event");
         Task_v0_3 receivedTask = assertInstanceOf(Task_v0_3.class, results.get(0), "Event should be a Task");
-        assertEquals(v03Task.getId(), receivedTask.getId());
-        assertEquals(v03Task.getContextId(), receivedTask.getContextId());
+        assertEquals(v03Task.id(), receivedTask.id());
+        assertEquals(v03Task.contextId(), receivedTask.contextId());
         // Note: v1.0 backend manages task history differently than v0.3
         // The key assertion is that we received a Task event for the existing task
     }
@@ -715,7 +715,7 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
 
         JSONRPCHandler_v0_3 handler = new JSONRPCHandler_v0_3(nonStreamingCard, internalExecutor, convert03To10Handler);
 
-        TaskResubscriptionRequest_v0_3 request = new TaskResubscriptionRequest_v0_3("1", new TaskIdParams_v0_3(MINIMAL_TASK.getId()));
+        TaskResubscriptionRequest_v0_3 request = new TaskResubscriptionRequest_v0_3("1", new TaskIdParams_v0_3(MINIMAL_TASK.id()));
         Flow.Publisher<SendStreamingMessageResponse_v0_3> response = handler.onResubscribeToTask(request, callContext);
 
         List<SendStreamingMessageResponse_v0_3> results = new ArrayList<>();
@@ -771,7 +771,7 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
 
         TaskPushNotificationConfig_v0_3 taskPushConfig =
                 new TaskPushNotificationConfig_v0_3(
-                        MINIMAL_TASK.getId(),
+                        MINIMAL_TASK.id(),
                         new PushNotificationConfig_v0_3.Builder()
                                 .url("http://example.com")
                                 .build());
@@ -783,10 +783,10 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
 
         TaskPushNotificationConfig_v0_3 taskPushConfigResult =
                 new TaskPushNotificationConfig_v0_3(
-                        MINIMAL_TASK.getId(),
+                        MINIMAL_TASK.id(),
                         new PushNotificationConfig_v0_3.Builder()
                                 .url("http://example.com")
-                                .id(MINIMAL_TASK.getId())
+                                .id(MINIMAL_TASK.id())
                                 .build());
         assertEquals(taskPushConfigResult, response.getResult());
     }
@@ -805,7 +805,7 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
 
         TaskPushNotificationConfig_v0_3 taskPushConfig =
                 new TaskPushNotificationConfig_v0_3(
-                        MINIMAL_TASK.getId(),
+                        MINIMAL_TASK.id(),
                         new PushNotificationConfig_v0_3.Builder()
                                 .url("http://example.com")
                                 .build());
@@ -814,11 +814,11 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         handler.setPushNotificationConfig(request, callContext);
 
         GetTaskPushNotificationConfigRequest_v0_3 getRequest =
-                new GetTaskPushNotificationConfigRequest_v0_3("111", new GetTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId()));
+                new GetTaskPushNotificationConfigRequest_v0_3("111", new GetTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id()));
         GetTaskPushNotificationConfigResponse_v0_3 getResponse = handler.getPushNotificationConfig(getRequest, callContext);
 
-        TaskPushNotificationConfig_v0_3 expectedConfig = new TaskPushNotificationConfig_v0_3(MINIMAL_TASK.getId(),
-                new PushNotificationConfig_v0_3.Builder().id(MINIMAL_TASK.getId()).url("http://example.com").build());
+        TaskPushNotificationConfig_v0_3 expectedConfig = new TaskPushNotificationConfig_v0_3(MINIMAL_TASK.id(),
+                new PushNotificationConfig_v0_3.Builder().id(MINIMAL_TASK.id()).url("http://example.com").build());
         assertEquals(expectedConfig, getResponse.getResult());
     }
 
@@ -836,16 +836,16 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
 
         TaskPushNotificationConfig_v0_3 taskPushConfig =
                 new TaskPushNotificationConfig_v0_3(
-                        MINIMAL_TASK.getId(),
+                        MINIMAL_TASK.id(),
                         new PushNotificationConfig_v0_3.Builder()
                                 .url("http://example.com")
-                                .id(MINIMAL_TASK.getId())
+                                .id(MINIMAL_TASK.id())
                                 .build());
         SetTaskPushNotificationConfigRequest_v0_3 request = new SetTaskPushNotificationConfigRequest_v0_3("1", taskPushConfig);
         handler.setPushNotificationConfig(request, callContext);
 
         DeleteTaskPushNotificationConfigRequest_v0_3 deleteRequest =
-                new DeleteTaskPushNotificationConfigRequest_v0_3("111", new DeleteTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId(), MINIMAL_TASK.getId()));
+                new DeleteTaskPushNotificationConfigRequest_v0_3("111", new DeleteTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id(), MINIMAL_TASK.id()));
         DeleteTaskPushNotificationConfigResponse_v0_3 deleteResponse =
                 handler.deletePushNotificationConfig(deleteRequest, callContext);
 
@@ -873,7 +873,7 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         taskStore.save(v10Task, false);
 
         GetTaskPushNotificationConfigRequest_v0_3 request =
-                new GetTaskPushNotificationConfigRequest_v0_3("id", new GetTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId()));
+                new GetTaskPushNotificationConfigRequest_v0_3("id", new GetTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id()));
         GetTaskPushNotificationConfigResponse_v0_3 response = handler.getPushNotificationConfig(request, callContext);
 
         assertNotNull(response.getError());
@@ -901,7 +901,7 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
 
         TaskPushNotificationConfig_v0_3 config =
                 new TaskPushNotificationConfig_v0_3(
-                        MINIMAL_TASK.getId(),
+                        MINIMAL_TASK.id(),
                         new PushNotificationConfig_v0_3.Builder()
                                 .url("http://example.com")
                                 .build());
@@ -930,16 +930,16 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
 
         TaskPushNotificationConfig_v0_3 taskPushConfig =
                 new TaskPushNotificationConfig_v0_3(
-                        MINIMAL_TASK.getId(),
+                        MINIMAL_TASK.id(),
                         new PushNotificationConfig_v0_3.Builder()
                                 .url("http://example.com")
-                                .id(MINIMAL_TASK.getId())
+                                .id(MINIMAL_TASK.id())
                                 .build());
         SetTaskPushNotificationConfigRequest_v0_3 request = new SetTaskPushNotificationConfigRequest_v0_3("1", taskPushConfig);
         handler.setPushNotificationConfig(request, callContext);
 
         DeleteTaskPushNotificationConfigRequest_v0_3 deleteRequest =
-                new DeleteTaskPushNotificationConfigRequest_v0_3("111", new DeleteTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId(), MINIMAL_TASK.getId()));
+                new DeleteTaskPushNotificationConfigRequest_v0_3("111", new DeleteTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id(), MINIMAL_TASK.id()));
         DeleteTaskPushNotificationConfigResponse_v0_3 deleteResponse =
                 handler.deletePushNotificationConfig(deleteRequest, callContext);
 
@@ -971,16 +971,16 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
 
         TaskPushNotificationConfig_v0_3 taskPushConfig =
                 new TaskPushNotificationConfig_v0_3(
-                        MINIMAL_TASK.getId(),
+                        MINIMAL_TASK.id(),
                         new PushNotificationConfig_v0_3.Builder()
                                 .url("http://example.com")
-                                .id(MINIMAL_TASK.getId())
+                                .id(MINIMAL_TASK.id())
                                 .build());
         SetTaskPushNotificationConfigRequest_v0_3 request = new SetTaskPushNotificationConfigRequest_v0_3("1", taskPushConfig);
         handler.setPushNotificationConfig(request, callContext);
 
         DeleteTaskPushNotificationConfigRequest_v0_3 deleteRequest =
-                new DeleteTaskPushNotificationConfigRequest_v0_3("111", new DeleteTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.getId(), MINIMAL_TASK.getId()));
+                new DeleteTaskPushNotificationConfigRequest_v0_3("111", new DeleteTaskPushNotificationConfigParams_v0_3(MINIMAL_TASK.id(), MINIMAL_TASK.id()));
         DeleteTaskPushNotificationConfigResponse_v0_3 deleteResponse =
                 handler.deletePushNotificationConfig(deleteRequest, callContext);
 
@@ -1009,16 +1009,16 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         List<Event_v0_3> events = List.of(
                 MINIMAL_TASK,
                 new TaskArtifactUpdateEvent_v0_3.Builder()
-                        .taskId(MINIMAL_TASK.getId())
-                        .contextId(MINIMAL_TASK.getContextId())
+                        .taskId(MINIMAL_TASK.id())
+                        .contextId(MINIMAL_TASK.contextId())
                         .artifact(new Artifact_v0_3.Builder()
                                 .artifactId("11")
                                 .parts(new TextPart_v0_3("text"))
                                 .build())
                         .build(),
                 new TaskStatusUpdateEvent_v0_3.Builder()
-                        .taskId(MINIMAL_TASK.getId())
-                        .contextId(MINIMAL_TASK.getContextId())
+                        .taskId(MINIMAL_TASK.id())
+                        .contextId(MINIMAL_TASK.contextId())
                         .status(new TaskStatus_v0_3(TaskState_v0_3.COMPLETED))
                         .isFinal(true)
                         .build());
@@ -1038,7 +1038,7 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
 
         // Set push notification config
         TaskPushNotificationConfig_v0_3 config = new TaskPushNotificationConfig_v0_3(
-                MINIMAL_TASK.getId(),
+                MINIMAL_TASK.id(),
                 new PushNotificationConfig_v0_3.Builder().url("http://example.com").build());
         SetTaskPushNotificationConfigRequest_v0_3 stpnRequest = new SetTaskPushNotificationConfigRequest_v0_3("1", config);
         SetTaskPushNotificationConfigResponse_v0_3 stpnResponse = handler.setPushNotificationConfig(stpnRequest, callContext);
@@ -1046,7 +1046,7 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
 
         // Send streaming message
         Message_v0_3 msg = new Message_v0_3.Builder(MESSAGE)
-                .taskId(MINIMAL_TASK.getId())
+                .taskId(MINIMAL_TASK.id())
                 .build();
         SendStreamingMessageRequest_v0_3 request = new SendStreamingMessageRequest_v0_3("1", new MessageSendParams_v0_3(msg, null, null));
         Flow.Publisher<SendStreamingMessageResponse_v0_3> response = handler.onMessageSendStream(request, callContext);
@@ -1115,8 +1115,8 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         org.a2aproject.sdk.spec.StreamingEventKind pushEvent0 = httpClient.events.get(0);
         assertTrue(pushEvent0 instanceof org.a2aproject.sdk.spec.Task);
         org.a2aproject.sdk.spec.Task v10PushedTask0 = (org.a2aproject.sdk.spec.Task) pushEvent0;
-        assertEquals(MINIMAL_TASK.getId(), v10PushedTask0.id());
-        assertEquals(MINIMAL_TASK.getContextId(), v10PushedTask0.contextId());
+        assertEquals(MINIMAL_TASK.id(), v10PushedTask0.id());
+        assertEquals(MINIMAL_TASK.contextId(), v10PushedTask0.contextId());
         // v0.3 SUBMITTED maps to v1.0 TASK_STATE_SUBMITTED
         assertEquals(org.a2aproject.sdk.spec.TaskState.TASK_STATE_SUBMITTED, v10PushedTask0.status().state());
         assertTrue(v10PushedTask0.artifacts() == null || v10PushedTask0.artifacts().isEmpty());
@@ -1125,8 +1125,8 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         org.a2aproject.sdk.spec.StreamingEventKind pushEvent1 = httpClient.events.get(1);
         assertTrue(pushEvent1 instanceof org.a2aproject.sdk.spec.TaskArtifactUpdateEvent);
         org.a2aproject.sdk.spec.TaskArtifactUpdateEvent v10ArtifactUpdate = (org.a2aproject.sdk.spec.TaskArtifactUpdateEvent) pushEvent1;
-        assertEquals(MINIMAL_TASK.getId(), v10ArtifactUpdate.taskId());
-        assertEquals(MINIMAL_TASK.getContextId(), v10ArtifactUpdate.contextId());
+        assertEquals(MINIMAL_TASK.id(), v10ArtifactUpdate.taskId());
+        assertEquals(MINIMAL_TASK.contextId(), v10ArtifactUpdate.contextId());
         assertNotNull(v10ArtifactUpdate.artifact());
         assertEquals(1, v10ArtifactUpdate.artifact().parts().size());
         assertEquals("text", ((org.a2aproject.sdk.spec.TextPart) v10ArtifactUpdate.artifact().parts().get(0)).text());
@@ -1135,8 +1135,8 @@ public class JSONRPCHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3
         org.a2aproject.sdk.spec.StreamingEventKind pushEvent2 = httpClient.events.get(2);
         assertTrue(pushEvent2 instanceof org.a2aproject.sdk.spec.TaskStatusUpdateEvent);
         org.a2aproject.sdk.spec.TaskStatusUpdateEvent v10StatusUpdate = (org.a2aproject.sdk.spec.TaskStatusUpdateEvent) pushEvent2;
-        assertEquals(MINIMAL_TASK.getId(), v10StatusUpdate.taskId());
-        assertEquals(MINIMAL_TASK.getContextId(), v10StatusUpdate.contextId());
+        assertEquals(MINIMAL_TASK.id(), v10StatusUpdate.taskId());
+        assertEquals(MINIMAL_TASK.contextId(), v10StatusUpdate.contextId());
         assertEquals(org.a2aproject.sdk.spec.TaskState.TASK_STATE_COMPLETED, v10StatusUpdate.status().state());
         } finally {
             // Reset push notification executor to async

--- a/compat-0.3/transport/rest/src/test/java/org/a2aproject/sdk/compat03/transport/rest/handler/RestHandler_v0_3_Test.java
+++ b/compat-0.3/transport/rest/src/test/java/org/a2aproject/sdk/compat03/transport/rest/handler/RestHandler_v0_3_Test.java
@@ -46,18 +46,18 @@ public class RestHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
         // Save v0.3 task by converting to v1.0
         taskStore.save(TaskMapper_v0_3.INSTANCE.toV10(MINIMAL_TASK), false);
 
-        RestHandler_v0_3.HTTPRestResponse response = handler.getTask(MINIMAL_TASK.getId(), 0, callContext);
+        RestHandler_v0_3.HTTPRestResponse response = handler.getTask(MINIMAL_TASK.id(), 0, callContext);
 
         Assertions.assertEquals(200, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
-        Assertions.assertTrue(response.getBody().contains(MINIMAL_TASK.getId()));
+        Assertions.assertTrue(response.getBody().contains(MINIMAL_TASK.id()));
 
         // Test with different version parameter
-        response = handler.getTask(MINIMAL_TASK.getId(), 2, callContext);
+        response = handler.getTask(MINIMAL_TASK.id(), 2, callContext);
 
         Assertions.assertEquals(200, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
-        Assertions.assertTrue(response.getBody().contains(MINIMAL_TASK.getId()));
+        Assertions.assertTrue(response.getBody().contains(MINIMAL_TASK.id()));
     }
 
     @Test
@@ -176,11 +176,11 @@ public class RestHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
             emitter.cancel();
         };
 
-        RestHandler_v0_3.HTTPRestResponse response = handler.cancelTask(MINIMAL_TASK.getId(), callContext);
+        RestHandler_v0_3.HTTPRestResponse response = handler.cancelTask(MINIMAL_TASK.id(), callContext);
 
         Assertions.assertEquals(200, response.getStatusCode());
         Assertions.assertEquals("application/json", response.getContentType());
-        Assertions.assertTrue(response.getBody().contains(MINIMAL_TASK.getId()));
+        Assertions.assertTrue(response.getBody().contains(MINIMAL_TASK.id()));
     }
 
     @Test
@@ -291,9 +291,9 @@ public class RestHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
                   }
                 }
               }
-            }""".formatted(MINIMAL_TASK.getId(), MINIMAL_TASK.getId());
+            }""".formatted(MINIMAL_TASK.id(), MINIMAL_TASK.id());
 
-        RestHandler_v0_3.HTTPRestResponse response = handler.setTaskPushNotificationConfiguration(MINIMAL_TASK.getId(), requestBody, callContext);
+        RestHandler_v0_3.HTTPRestResponse response = handler.setTaskPushNotificationConfiguration(MINIMAL_TASK.id(), requestBody, callContext);
 
         assertEquals(201, response.getStatusCode(), response.toString());
         assertEquals("application/json", response.getContentType());
@@ -312,9 +312,9 @@ public class RestHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
                     "url": "http://example.com"
                 }
             }
-            """.formatted(MINIMAL_TASK.getId());
+            """.formatted(MINIMAL_TASK.id());
 
-        RestHandler_v0_3.HTTPRestResponse response = handler.setTaskPushNotificationConfiguration(MINIMAL_TASK.getId(), requestBody, callContext);
+        RestHandler_v0_3.HTTPRestResponse response = handler.setTaskPushNotificationConfiguration(MINIMAL_TASK.id(), requestBody, callContext);
 
         assertEquals(501, response.getStatusCode());
         assertTrue(response.getBody().contains("PushNotificationNotSupportedError"));
@@ -340,13 +340,13 @@ public class RestHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
                   }
                 }
               }
-            }""".formatted(MINIMAL_TASK.getId(), MINIMAL_TASK.getId());
-        RestHandler_v0_3.HTTPRestResponse response = handler.setTaskPushNotificationConfiguration(MINIMAL_TASK.getId(), createRequestBody, callContext);
+            }""".formatted(MINIMAL_TASK.id(), MINIMAL_TASK.id());
+        RestHandler_v0_3.HTTPRestResponse response = handler.setTaskPushNotificationConfiguration(MINIMAL_TASK.id(), createRequestBody, callContext);
         assertEquals(201, response.getStatusCode(), response.toString());
         assertEquals("application/json", response.getContentType());
 
         // Now get it (using taskId as configId since that's the default)
-        response = handler.getTaskPushNotificationConfiguration(MINIMAL_TASK.getId(), MINIMAL_TASK.getId(), callContext);
+        response = handler.getTaskPushNotificationConfiguration(MINIMAL_TASK.id(), MINIMAL_TASK.id(), callContext);
         assertEquals(200, response.getStatusCode(), response.toString());
         assertEquals("application/json", response.getContentType());
     }
@@ -358,7 +358,7 @@ public class RestHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
         // Save task to v1.0 backend
         taskStore.save(TaskMapper_v0_3.INSTANCE.toV10(MINIMAL_TASK), false);
 
-        RestHandler_v0_3.HTTPRestResponse response = handler.deleteTaskPushNotificationConfiguration(MINIMAL_TASK.getId(), MINIMAL_TASK.getId(), callContext);
+        RestHandler_v0_3.HTTPRestResponse response = handler.deleteTaskPushNotificationConfiguration(MINIMAL_TASK.id(), MINIMAL_TASK.id(), callContext);
         assertEquals(204, response.getStatusCode());
     }
 
@@ -369,7 +369,7 @@ public class RestHandler_v0_3_Test extends AbstractA2ARequestHandlerTest_v0_3 {
         // Save task to v1.0 backend
         taskStore.save(TaskMapper_v0_3.INSTANCE.toV10(MINIMAL_TASK), false);
 
-        RestHandler_v0_3.HTTPRestResponse response = handler.listTaskPushNotificationConfigurations(MINIMAL_TASK.getId(), callContext);
+        RestHandler_v0_3.HTTPRestResponse response = handler.listTaskPushNotificationConfigurations(MINIMAL_TASK.id(), callContext);
 
         assertEquals(200, response.getStatusCode());
         assertEquals("application/json", response.getContentType());

--- a/tests/multiversion/rest/src/test/java/org/a2aproject/sdk/tests/multiversion/rest/MultiVersion_v0_3_RestWithAuthTest.java
+++ b/tests/multiversion/rest/src/test/java/org/a2aproject/sdk/tests/multiversion/rest/MultiVersion_v0_3_RestWithAuthTest.java
@@ -50,10 +50,10 @@ public class MultiVersion_v0_3_RestWithAuthTest extends AbstractA2AServerWithAut
         saveTaskInTaskStore(MINIMAL_TASK);
 
         givenAuthenticated()
-                .get("/v1/tasks/" + MINIMAL_TASK.getId())
+                .get("/v1/tasks/" + MINIMAL_TASK.id())
                 .then()
                 .statusCode(200);
 
-        deleteTaskInTaskStore(MINIMAL_TASK.getId());
+        deleteTaskInTaskStore(MINIMAL_TASK.id());
     }
 }


### PR DESCRIPTION
This became apparent since in non-Quarkus environments you have to set a bunch of JVM flags, and also introduce default constructors, which in turn means making fields non-final.

Additionally, added default constructors for some CDI beans to work in stricter CDI environments than Quarkus
