### PR TITLE
fix: add awaitChildQueueCountStable to subscribe tests to prevent race condition

### DIFF
--- a/tests/server-common/src/test/java/org/a2aproject/sdk/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/org/a2aproject/sdk/server/apps/common/AbstractA2AServerTest.java
@@ -932,8 +932,8 @@ public abstract class AbstractA2AServerTest {
 
             // Wait for EventConsumer polling loop to start (transport-level subscription
             // does not guarantee the consumer is ready to receive events)
-            assertTrue(waitForChildQueueCountToBe(MINIMAL_TASK.id(), childCountBefore + 1, 15000),
-                    "subscribeToTask child queue should be created");
+            assertTrue(awaitChildQueueCountStable(MINIMAL_TASK.id(), childCountBefore + 1, 15000),
+                    "subscribeToTask child queue should be created and stable");
 
             // Enqueue events on the server
             List<Event> events = List.of(

--- a/tests/server-common/src/test/java/org/a2aproject/sdk/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/org/a2aproject/sdk/server/apps/common/AbstractA2AServerTest.java
@@ -790,6 +790,9 @@ public abstract class AbstractA2AServerTest {
                 eventLatch.countDown();
             };
 
+            // Capture child queue count before subscribing (ensureQueueForTask creates one)
+            int childCountBefore = getChildQueueCount(MINIMAL_TASK.id());
+
             // Count down when the streaming subscription is established
             CountDownLatch subscriptionLatch = new CountDownLatch(1);
             awaitStreamingSubscription()
@@ -800,6 +803,11 @@ public abstract class AbstractA2AServerTest {
 
             // Wait for subscription to be established
             assertTrue(subscriptionLatch.await(15, TimeUnit.SECONDS));
+
+            // Wait for EventConsumer polling loop to start (transport-level subscription
+            // does not guarantee the consumer is ready to receive events)
+            assertTrue(waitForChildQueueCountToBe(MINIMAL_TASK.id(), childCountBefore + 1, 15000),
+                    "subscribeToTask child queue should be created");
 
             // Enqueue events on the server
             List<Event> events = List.of(
@@ -908,6 +916,9 @@ public abstract class AbstractA2AServerTest {
 
             Client clientWithConsumer = clientBuilder.build();
 
+            // Capture child queue count before subscribing (ensureQueueForTask creates one)
+            int childCountBefore = getChildQueueCount(MINIMAL_TASK.id());
+
             // Count down when the streaming subscription is established
             CountDownLatch subscriptionLatch = new CountDownLatch(1);
             awaitStreamingSubscription()
@@ -918,6 +929,11 @@ public abstract class AbstractA2AServerTest {
 
             // Wait for subscription to be established
             assertTrue(subscriptionLatch.await(15, TimeUnit.SECONDS));
+
+            // Wait for EventConsumer polling loop to start (transport-level subscription
+            // does not guarantee the consumer is ready to receive events)
+            assertTrue(waitForChildQueueCountToBe(MINIMAL_TASK.id(), childCountBefore + 1, 15000),
+                    "subscribeToTask child queue should be created");
 
             // Enqueue events on the server
             List<Event> events = List.of(

--- a/tests/server-common/src/test/java/org/a2aproject/sdk/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/org/a2aproject/sdk/server/apps/common/AbstractA2AServerTest.java
@@ -806,8 +806,8 @@ public abstract class AbstractA2AServerTest {
 
             // Wait for EventConsumer polling loop to start (transport-level subscription
             // does not guarantee the consumer is ready to receive events)
-            assertTrue(waitForChildQueueCountToBe(MINIMAL_TASK.id(), childCountBefore + 1, 15000),
-                    "subscribeToTask child queue should be created");
+            assertTrue(awaitChildQueueCountStable(MINIMAL_TASK.id(), childCountBefore + 1, 15000),
+                    "subscribeToTask child queue should be created and stable");
 
             // Enqueue events on the server
             List<Event> events = List.of(


### PR DESCRIPTION
## Summary
- Add `awaitChildQueueCountStable()` synchronization to `testSubscribeExistingTaskSuccess` and `testSubscribeExistingTaskSuccessWithClientConsumers` in `AbstractA2AServerTest`
- `awaitStreamingSubscription()` only guarantees transport-level subscription (`Flow.Subscriber.onSubscribe()` called), but the `EventConsumer` polling loop starts asynchronously on a separate thread. Without waiting for the child queue to stabilize, events enqueued on the server can be lost if they fire before the consumer is ready to receive them
- This race is more pronounced with the Vert.x HTTP client (async event-loop model), causing flaky 30s timeouts in CI — which then cascades via Maven `-fae` to ban downstream modules like `quarkus-app-1`/`quarkus-app-2`, failing `MultiInstanceReplicationTest` with a Docker build-context error
- The same synchronization pattern is already used in `testResubscriptionPreservesEventsFromBothStreams` (line ~1739)

## Test plan
- [ ] CI passes on all Java versions (17, 21, 25)
- [ ] `QuarkusA2AJSONRPCVertxTest.testSubscribeExistingTaskSuccess` no longer times out
- [ ] `MultiInstanceReplicationTest` no longer fails due to cascading ban

🤖 Generated with [Claude Code](https://claude.com/claude-code)