### PR TITLE
fix: defer CDI request context destruction for streaming requests

### DIFF
--- a/compat-0.3/reference/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/server/apps/quarkus/A2AServerRoutes_v0_3.java
+++ b/compat-0.3/reference/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/server/apps/quarkus/A2AServerRoutes_v0_3.java
@@ -96,7 +96,7 @@ public class A2AServerRoutes_v0_3 {
             .handler(BodyHandler.create())
             .blockingHandler(ctx -> {
                 try {
-                    vertxSecurityHelper.runInRequestContext(ctx, () -> {
+                    vertxSecurityHelper.runInRequestContextDeferred(ctx, () -> {
                         invokeJSONRPCHandler(ctx.body().asString(), ctx);
                     });
                 } catch (UnauthorizedException | ForbiddenException e) {

--- a/compat-0.3/reference/rest/src/main/java/org/a2aproject/sdk/compat03/server/rest/quarkus/A2AServerRoutes_v0_3.java
+++ b/compat-0.3/reference/rest/src/main/java/org/a2aproject/sdk/compat03/server/rest/quarkus/A2AServerRoutes_v0_3.java
@@ -87,7 +87,7 @@ public class A2AServerRoutes_v0_3 {
         // POST /v1/message:stream
         router.postWithRegex("^\\/v1\\/message:stream$")
             .handler(BodyHandler.create())
-            .blockingHandler(authenticated(ctx -> {
+            .blockingHandler(authenticatedStreaming(ctx -> {
                 sendMessageStreaming(extractBody(ctx), ctx);
             }));
 
@@ -104,7 +104,7 @@ public class A2AServerRoutes_v0_3 {
         // POST /v1/tasks/{id}:subscribe
         router.postWithRegex("^\\/v1\\/tasks\\/([^/]+):subscribe$")
             .order(1)
-            .blockingHandler(authenticated(this::resubscribeTask));
+            .blockingHandler(authenticatedStreaming(this::resubscribeTask));
 
         // POST /v1/tasks/:id/pushNotificationConfigs
         router.post("/v1/tasks/:id/pushNotificationConfigs")
@@ -150,6 +150,18 @@ public class A2AServerRoutes_v0_3 {
         return ctx -> {
             try {
                 vertxSecurityHelper.runInRequestContext(ctx, () -> action.accept(ctx));
+            } catch (UnauthorizedException | ForbiddenException e) {
+                vertxSecurityHelper.handleAuthError(ctx, e);
+            } catch (Exception e) {
+                VertxSecurityHelper.handleGenericError(ctx);
+            }
+        };
+    }
+
+    private Handler<RoutingContext> authenticatedStreaming(Consumer<RoutingContext> action) {
+        return ctx -> {
+            try {
+                vertxSecurityHelper.runInRequestContextDeferred(ctx, () -> action.accept(ctx));
             } catch (UnauthorizedException | ForbiddenException e) {
                 vertxSecurityHelper.handleAuthError(ctx, e);
             } catch (Exception e) {

--- a/reference/common/src/main/java/org/a2aproject/sdk/server/common/quarkus/VertxSecurityHelper.java
+++ b/reference/common/src/main/java/org/a2aproject/sdk/server/common/quarkus/VertxSecurityHelper.java
@@ -1,17 +1,20 @@
 package org.a2aproject.sdk.server.common.quarkus;
 
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableContext;
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.vertx.http.runtime.security.ChallengeData;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticator;
 import io.vertx.core.Context;
 import io.vertx.ext.web.RoutingContext;
-import java.util.Map;
 
 /**
  * CDI helper for integrating Quarkus security with Vert.x Web routes.
@@ -119,6 +122,81 @@ public final class VertxSecurityHelper {
             if (!wasActive) {
                 requestContext.terminate();
             }
+        }
+    }
+
+    /**
+     * Authenticates the request and executes a task, deferring CDI context destruction to the HTTP
+     * response lifecycle.
+     *
+     * <p>Unlike {@link #runInRequestContext}, this method does <b>not</b> terminate the CDI request
+     * context when the task completes. Instead, it:
+     * <ol>
+     *   <li>Activates the CDI request context and captures its {@link InjectableContext.ContextState}</li>
+     *   <li>Triggers HTTP authentication</li>
+     *   <li>Executes the task</li>
+     *   <li><b>Deactivates</b> the context (detaches from the worker thread without destroying beans)</li>
+     *   <li>Destroys the context state when the HTTP response ends or the connection closes</li>
+     * </ol>
+     *
+     * <p>This is required for streaming (SSE) requests where the task dispatches work to a background
+     * thread (via {@code CompletableFuture.runAsync} with a {@code ManagedExecutor}) and returns
+     * immediately. The {@code ManagedExecutor} captures the CDI context at submit time and propagates
+     * it to the agent thread — but only if the context hasn't been destroyed yet. By deferring
+     * destruction to the response lifecycle, the agent thread can access all {@code @RequestScoped}
+     * beans (including OIDC token credentials for token propagation).
+     *
+     * <p>This method is also safe for non-streaming requests: {@code response.end()} is called
+     * synchronously inside the task, and the {@code endHandler} fires the cleanup shortly after.
+     *
+     * @param ctx the Vert.x routing context containing the HTTP request
+     * @param task the code to execute within the authenticated request context
+     * @throws io.quarkus.security.UnauthorizedException if authentication fails
+     * @throws io.quarkus.security.ForbiddenException if authorization fails
+     * @throws RuntimeException if the task throws an exception
+     */
+    public void runInRequestContextDeferred(RoutingContext ctx, Runnable task) {
+        if (Context.isOnEventLoopThread()) {
+            throw new IllegalStateException(
+                    "Cannot perform blocking authentication on event loop thread. Use blockingHandler().");
+        }
+        ManagedContext requestContext = Arc.container().requestContext();
+        boolean wasActive = requestContext.isActive();
+        if (wasActive) {
+            if (!httpAuthenticator.isUnsatisfied()) {
+                var identity = httpAuthenticator.get().attemptAuthentication(ctx).await().indefinitely();
+                currentIdentityAssociation.get().setIdentity(identity);
+            }
+            task.run();
+            return;
+        }
+
+        InjectableContext.ContextState state = requestContext.activate();
+
+        AtomicBoolean destroyed = new AtomicBoolean(false);
+        Runnable cleanup = () -> {
+            if (destroyed.compareAndSet(false, true)) {
+                requestContext.destroy(state);
+            }
+        };
+
+        ctx.response().endHandler(v -> cleanup.run());
+        ctx.response().closeHandler(v -> cleanup.run());
+
+        try {
+            if (!httpAuthenticator.isUnsatisfied()) {
+                var identity = httpAuthenticator.get().attemptAuthentication(ctx).await().indefinitely();
+                currentIdentityAssociation.get().setIdentity(identity);
+            }
+            task.run();
+        } catch (Exception e) {
+            // Destroy bean instances immediately on error. The subsequent deactivate() in the
+            // finally block is still needed to detach the (now-empty) context from the worker
+            // thread. destroy(state) only destroys beans — it does not deactivate the context.
+            cleanup.run();
+            throw e;
+        } finally {
+            requestContext.deactivate();
         }
     }
 

--- a/reference/common/src/main/java/org/a2aproject/sdk/server/common/quarkus/VertxSecurityHelper.java
+++ b/reference/common/src/main/java/org/a2aproject/sdk/server/common/quarkus/VertxSecurityHelper.java
@@ -189,12 +189,12 @@ public final class VertxSecurityHelper {
                 currentIdentityAssociation.get().setIdentity(identity);
             }
             task.run();
-        } catch (Exception e) {
+        } catch (Throwable t) {
             // Destroy bean instances immediately on error. The subsequent deactivate() in the
             // finally block is still needed to detach the (now-empty) context from the worker
             // thread. destroy(state) only destroys beans — it does not deactivate the context.
             cleanup.run();
-            throw e;
+            throw t;
         } finally {
             requestContext.deactivate();
         }

--- a/reference/jsonrpc/src/main/java/org/a2aproject/sdk/server/apps/quarkus/A2AServerRoutes.java
+++ b/reference/jsonrpc/src/main/java/org/a2aproject/sdk/server/apps/quarkus/A2AServerRoutes.java
@@ -212,7 +212,7 @@ public class A2AServerRoutes {
             .handler(BodyHandler.create())
             .blockingHandler(ctx -> {
                 try {
-                    vertxSecurityHelper.runInRequestContext(ctx, () -> {
+                    vertxSecurityHelper.runInRequestContextDeferred(ctx, () -> {
                         invokeJSONRPCHandler(ctx.body().asString(), ctx);
                     });
                 } catch (UnauthorizedException | ForbiddenException e) {

--- a/reference/rest/src/main/java/org/a2aproject/sdk/server/rest/quarkus/A2AServerRoutes.java
+++ b/reference/rest/src/main/java/org/a2aproject/sdk/server/rest/quarkus/A2AServerRoutes.java
@@ -180,7 +180,7 @@ public class A2AServerRoutes {
         // POST /{tenant}/message:stream - Streaming message with SSE
         router.postWithRegex("^\\/(?<tenant>[^\\/]*\\/?)message:stream$")
             .handler(BodyHandler.create())
-            .blockingHandler(authenticated(ctx -> {
+            .blockingHandler(authenticatedStreaming(ctx -> {
                 String body = extractBody(ctx);
                 sendMessageStreaming(body, ctx);
             }), false);
@@ -209,7 +209,7 @@ public class A2AServerRoutes {
         // POST /{tenant}/tasks/{taskId}:subscribe - Subscribe to task updates (SSE)
         router.postWithRegex("^\\/(?<tenant>[^\\/]*\\/?)tasks\\/(?<taskId>[^/]+):subscribe$")
             .order(1)
-            .blockingHandler(authenticated(this::subscribeToTask), false);
+            .blockingHandler(authenticatedStreaming(this::subscribeToTask), false);
 
         // Push Notification Routes
 
@@ -256,6 +256,18 @@ public class A2AServerRoutes {
         return ctx -> {
             try {
                 vertxSecurityHelper.runInRequestContext(ctx, () -> action.accept(ctx));
+            } catch (UnauthorizedException | ForbiddenException e) {
+                vertxSecurityHelper.handleAuthError(ctx, e);
+            } catch (Exception e) {
+                VertxSecurityHelper.handleGenericError(ctx);
+            }
+        };
+    }
+
+    private Handler<RoutingContext> authenticatedStreaming(Consumer<RoutingContext> action) {
+        return ctx -> {
+            try {
+                vertxSecurityHelper.runInRequestContextDeferred(ctx, () -> action.accept(ctx));
             } catch (UnauthorizedException | ForbiddenException e) {
                 vertxSecurityHelper.handleAuthError(ctx, e);
             } catch (Exception e) {

--- a/tests/server-common/src/test/java/org/a2aproject/sdk/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/org/a2aproject/sdk/server/apps/common/AbstractA2AServerTest.java
@@ -572,7 +572,9 @@ public abstract class AbstractA2AServerTest {
                 }
             }
         }), error -> {
-            errorRef.set(error);
+            if (!isStreamClosedError(error)) {
+                errorRef.set(error);
+            }
             latch.countDown();
         });
 
@@ -2456,16 +2458,17 @@ public abstract class AbstractA2AServerTest {
     }
 
     protected boolean isStreamClosedError(Throwable throwable) {
-        // Unwrap the CompletionException
         Throwable cause = throwable;
 
         while (cause != null) {
             if (cause instanceof EOFException) {
                 return true;
             }
+            if (cause instanceof java.util.concurrent.CancellationException) {
+                return true;
+            }
             if (cause instanceof IOException && cause.getMessage() != null
                     && cause.getMessage().contains("cancelled")) {
-                // stream is closed upon cancellation
                 return true;
             }
             cause = cause.getCause();

--- a/tests/server-common/src/test/java/org/a2aproject/sdk/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/org/a2aproject/sdk/server/apps/common/AbstractA2AServerTest.java
@@ -548,6 +548,49 @@ public abstract class AbstractA2AServerTest {
     }
 
     @Test
+    public void testRequestScopedBeanAvailableOnAgentExecutorThreadStreaming() throws Exception {
+        Message message = Message.builder()
+                .messageId("request-scoped-streaming-test")
+                .role(Message.Role.ROLE_USER)
+                .parts(new TextPart("request-scoped:test"))
+                .build();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Task> receivedTask = new AtomicReference<>();
+        AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+        getClient().sendMessage(message, List.of((event, agentCard) -> {
+            if (event instanceof TaskEvent te) {
+                receivedTask.set(te.getTask());
+                if (te.getTask().status().state() == TaskState.TASK_STATE_COMPLETED) {
+                    latch.countDown();
+                }
+            } else if (event instanceof TaskUpdateEvent tue) {
+                receivedTask.set(tue.getTask());
+                if (tue.getTask().status().state() == TaskState.TASK_STATE_COMPLETED) {
+                    latch.countDown();
+                }
+            }
+        }), error -> {
+            errorRef.set(error);
+            latch.countDown();
+        });
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "Request should complete within timeout");
+        assertNull(errorRef.get(), "Should not have received an error");
+
+        Task task = receivedTask.get();
+        assertNotNull(task, "Should have received a task");
+        assertEquals(TaskState.TASK_STATE_COMPLETED, task.status().state());
+        assertNotNull(task.artifacts());
+        assertFalse(task.artifacts().isEmpty());
+
+        Part<?> part = task.artifacts().get(0).parts().get(0);
+        assertInstanceOf(TextPart.class, part);
+        assertEquals("request-scoped:request-scoped-value", ((TextPart) part).text());
+    }
+
+    @Test
     public void testSendMessageExistingTaskSuccess() throws Exception {
         saveTaskInTaskStore(MINIMAL_TASK);
         try {


### PR DESCRIPTION
Streaming (SSE) requests dispatch agent work to a background thread via ManagedExecutor and return immediately. The existing runInRequestContext() terminates the CDI request context in a finally block, destroying all @RequestScoped beans before the agent thread runs. This causes ContextNotActiveException when the agent accesses request-scoped beans (e.g. OIDC token propagation via @AccessToken).

Add runInRequestContextDeferred() which deactivates the context (detaching it from the worker thread) but defers bean destruction to the HTTP response lifecycle via endHandler/closeHandler. This keeps all @RequestScoped beans alive for the duration of the streaming response.

- JSONRPC routes: use runInRequestContextDeferred for the main handler (handles both streaming and non-streaming)
- REST routes: add authenticatedStreaming() wrapper for message:stream and tasks/:subscribe endpoints
- Apply same changes to compat-0.3 JSONRPC and REST routes
- Add streaming variant of CDI propagation test

Fixes #893  🦕