### PR TITLE
feat: add ITK integration for cross-SDK interoperability testing

### DIFF
--- a/.github/workflows/itk-nightly.yaml
+++ b/.github/workflows/itk-nightly.yaml
@@ -1,0 +1,42 @@
+name: Nightly ITK
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  nightly:
+    name: Nightly ITK Run
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run Nightly ITK Tests
+        run: bash run_itk.sh
+        working-directory: itk
+        env:
+          A2A_ITK_REVISION: main
+          ITK_NIGHTLY_RUN: "True"
+
+      - name: Upload Results to Rolling Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: "nightly-metrics"
+          prerelease: true
+          files: |
+            itk/itk_java.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/itk.yaml
+++ b/.github/workflows/itk.yaml
@@ -1,0 +1,44 @@
+name: ITK
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'client/**'
+      - 'common/**'
+      - 'http-client/**'
+      - 'itk/**'
+      - 'jsonrpc-common/**'
+      - 'reference/**'
+      - 'server-common/**'
+      - 'spec/**'
+      - 'spec-grpc/**'
+      - 'transport/**'
+      - 'pom.xml'
+      - '.github/workflows/itk.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  itk:
+    name: ITK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run ITK Tests
+        run: bash run_itk.sh
+        working-directory: itk
+        env:
+          A2A_ITK_REVISION: main

--- a/boms/extras/src/it/extras-usage-test/src/main/java/org/a2aproject/sdk/test/ExtrasBomVerifier.java
+++ b/boms/extras/src/it/extras-usage-test/src/main/java/org/a2aproject/sdk/test/ExtrasBomVerifier.java
@@ -14,6 +14,7 @@ public class ExtrasBomVerifier extends DynamicBomVerifier {
     private static final Set<String> EXTRAS_EXCLUSIONS = Set.of(
         "boms/",            // BOM test modules themselves
         "examples/",        // Example applications
+        "itk/",             // Integration Test Kit agent
         "tck/",             // TCK test suite
         "tests/",           // Integration tests
         "test-utils-docker/", // Test utilities for Docker-based tests

--- a/boms/reference/src/it/reference-usage-test/src/main/java/org/a2aproject/sdk/test/ReferenceBomVerifier.java
+++ b/boms/reference/src/it/reference-usage-test/src/main/java/org/a2aproject/sdk/test/ReferenceBomVerifier.java
@@ -14,6 +14,7 @@ public class ReferenceBomVerifier extends DynamicBomVerifier {
     private static final Set<String> REFERENCE_EXCLUSIONS = Set.of(
         "boms/",               // BOM test modules themselves
         "examples/",           // Example applications
+        "itk/",                // Integration Test Kit agent
         "tck/",                // TCK test suite
         "tests/",              // Integration tests
         "test-utils-docker/",  // Test utilities for Docker-based tests

--- a/boms/sdk/src/it/sdk-usage-test/src/main/java/org/a2aproject/sdk/test/SdkBomVerifier.java
+++ b/boms/sdk/src/it/sdk-usage-test/src/main/java/org/a2aproject/sdk/test/SdkBomVerifier.java
@@ -14,6 +14,7 @@ public class SdkBomVerifier extends DynamicBomVerifier {
     private static final Set<String> SDK_EXCLUSIONS = Set.of(
         "boms/",                 // BOM test modules themselves
         "examples/",             // Example applications
+        "itk/",                  // Integration Test Kit agent
         "tck/",                  // TCK test suite
         "compat-0.3/tck/",       // Compat 0.3 TCK (not yet enabled)
         "compat-0.3/reference/", // Compat 0.3 reference implementations (in reference BOM)

--- a/client/transport/rest/src/main/java/org/a2aproject/sdk/client/transport/rest/sse/SSEEventListener.java
+++ b/client/transport/rest/src/main/java/org/a2aproject/sdk/client/transport/rest/sse/SSEEventListener.java
@@ -30,7 +30,7 @@ public class SSEEventListener extends AbstractSSEEventListener {
     @Override
     public void onMessage(ServerSentEvent event, @Nullable Future<Void> completableFuture) {
         try {
-            log.fine("Streaming message received: " + event.data());
+            log.fine("REST SSE raw data: " + event.data());
             org.a2aproject.sdk.grpc.StreamResponse.Builder builder = org.a2aproject.sdk.grpc.StreamResponse.newBuilder();
             JsonFormat.parser().merge(event.data(), builder);
             parseAndHandleMessage(builder.build(), completableFuture);

--- a/compat-0.3/client/base/src/main/java/org/a2aproject/sdk/compat03/client/ClientTaskManager_v0_3.java
+++ b/compat-0.3/client/base/src/main/java/org/a2aproject/sdk/compat03/client/ClientTaskManager_v0_3.java
@@ -43,7 +43,7 @@ public class ClientTaskManager_v0_3 {
     }
 
     public Task_v0_3 saveTaskEvent(Task_v0_3 task) throws A2AClientInvalidArgsError_v0_3 {
-        if (currentTask != null) {
+        if (currentTask != null && !currentTask.id().equals(task.id())) {
             throw new A2AClientInvalidArgsError_v0_3("Task is already set, create new manager for new tasks.");
         }
         saveTask(task);

--- a/compat-0.3/reference/grpc/src/main/java/org/a2aproject/sdk/compat03/server/grpc/quarkus/BlockingOffloadInterceptor_v0_3.java
+++ b/compat-0.3/reference/grpc/src/main/java/org/a2aproject/sdk/compat03/server/grpc/quarkus/BlockingOffloadInterceptor_v0_3.java
@@ -1,0 +1,64 @@
+package org.a2aproject.sdk.compat03.server.grpc.quarkus;
+
+import java.util.concurrent.Executor;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.a2aproject.sdk.server.util.async.Internal;
+import io.grpc.Context;
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+
+/**
+ * v0.3 variant of {@code BlockingOffloadInterceptor} in the reference/grpc module.
+ */
+@ApplicationScoped
+public class BlockingOffloadInterceptor_v0_3 implements ServerInterceptor {
+
+    private final Executor executor;
+
+    @Inject
+    public BlockingOffloadInterceptor_v0_3(@Internal Executor executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call,
+            Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+
+        MethodDescriptor.MethodType type = call.getMethodDescriptor().getType();
+        if (type == MethodDescriptor.MethodType.CLIENT_STREAMING
+                || type == MethodDescriptor.MethodType.BIDI_STREAMING) {
+            return next.startCall(call, headers);
+        }
+
+        ServerCall.Listener<ReqT> delegate = next.startCall(call, headers);
+
+        return new SimpleForwardingServerCallListener<ReqT>(delegate) {
+            @Override
+            public void onHalfClose() {
+                Context grpcContext = Context.current().fork();
+                try {
+                    executor.execute(() -> {
+                        Context previous = grpcContext.attach();
+                        try {
+                            super.onHalfClose();
+                        } finally {
+                            grpcContext.detach(previous);
+                        }
+                    });
+                } catch (Exception e) {
+                    call.close(Status.INTERNAL.withDescription("Failed to offload to worker thread: " + e.getMessage()), new Metadata());
+                }
+            }
+        };
+    }
+}

--- a/compat-0.3/reference/grpc/src/main/java/org/a2aproject/sdk/compat03/server/grpc/quarkus/QuarkusGrpcHandler_v0_3.java
+++ b/compat-0.3/reference/grpc/src/main/java/org/a2aproject/sdk/compat03/server/grpc/quarkus/QuarkusGrpcHandler_v0_3.java
@@ -8,6 +8,7 @@ import jakarta.inject.Inject;
 import io.quarkus.grpc.GrpcService;
 import io.quarkus.grpc.RegisterInterceptor;
 import io.quarkus.security.Authenticated;
+import io.smallrye.common.annotation.Blocking;
 import org.a2aproject.sdk.compat03.conversion.Convert_v0_3_To10RequestHandler;
 import org.a2aproject.sdk.compat03.spec.AgentCard_v0_3;
 import org.a2aproject.sdk.compat03.transport.grpc.handler.CallContextFactory_v0_3;
@@ -17,7 +18,9 @@ import org.a2aproject.sdk.server.util.async.Internal;
 
 @GrpcService
 @RegisterInterceptor(A2AExtensionsInterceptor_v0_3.class)
+@RegisterInterceptor(BlockingOffloadInterceptor_v0_3.class)
 @Authenticated
+@Blocking
 public class QuarkusGrpcHandler_v0_3 extends GrpcHandler_v0_3 {
 
     private final AgentCard_v0_3 agentCard;

--- a/compat-0.3/reference/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/server/apps/quarkus/A2AServerRoutes_v0_3.java
+++ b/compat-0.3/reference/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/server/apps/quarkus/A2AServerRoutes_v0_3.java
@@ -97,7 +97,7 @@ public class A2AServerRoutes_v0_3 {
                 } catch (Exception e) {
                     VertxSecurityHelper.handleGenericError(ctx);
                 }
-            });
+            }, false);
 
         // Only register v0.3 agent card if no real v1.0 agent card producer exists.
         // DefaultProducers provides a @DefaultBean AgentCard fallback that is always

--- a/compat-0.3/reference/rest/src/main/java/org/a2aproject/sdk/compat03/server/rest/quarkus/A2AServerRoutes_v0_3.java
+++ b/compat-0.3/reference/rest/src/main/java/org/a2aproject/sdk/compat03/server/rest/quarkus/A2AServerRoutes_v0_3.java
@@ -75,29 +75,29 @@ public class A2AServerRoutes_v0_3 {
             .handler(BodyHandler.create())
             .blockingHandler(authenticated(ctx -> {
                 sendMessage(extractBody(ctx), ctx);
-            }));
+            }), false);
 
         // POST /v1/message:stream
         router.postWithRegex("^\\/v1\\/message:stream$")
             .handler(BodyHandler.create())
             .blockingHandler(authenticatedStreaming(ctx -> {
                 sendMessageStreaming(extractBody(ctx), ctx);
-            }));
+            }), false);
 
         // GET /v1/tasks/:id
         router.get("/v1/tasks/:id")
             .order(1)
-            .blockingHandler(authenticated(this::getTask));
+            .blockingHandler(authenticated(this::getTask), false);
 
         // POST /v1/tasks/{id}:cancel
         router.postWithRegex("^\\/v1\\/tasks\\/([^/]+):cancel$")
             .order(1)
-            .blockingHandler(authenticated(this::cancelTask));
+            .blockingHandler(authenticated(this::cancelTask), false);
 
         // POST /v1/tasks/{id}:subscribe
         router.postWithRegex("^\\/v1\\/tasks\\/([^/]+):subscribe$")
             .order(1)
-            .blockingHandler(authenticatedStreaming(this::resubscribeTask));
+            .blockingHandler(authenticatedStreaming(this::resubscribeTask), false);
 
         // POST /v1/tasks/:id/pushNotificationConfigs
         router.post("/v1/tasks/:id/pushNotificationConfigs")
@@ -105,22 +105,22 @@ public class A2AServerRoutes_v0_3 {
             .handler(BodyHandler.create())
             .blockingHandler(authenticated(ctx -> {
                 setTaskPushNotificationConfiguration(extractBody(ctx), ctx);
-            }));
+            }), false);
 
         // GET /v1/tasks/:id/pushNotificationConfigs/:configId
         router.get("/v1/tasks/:id/pushNotificationConfigs/:configId")
             .order(1)
-            .blockingHandler(authenticated(this::getTaskPushNotificationConfiguration));
+            .blockingHandler(authenticated(this::getTaskPushNotificationConfiguration), false);
 
         // GET /v1/tasks/:id/pushNotificationConfigs
         router.get("/v1/tasks/:id/pushNotificationConfigs")
             .order(2)
-            .blockingHandler(authenticated(this::listTaskPushNotificationConfigurations));
+            .blockingHandler(authenticated(this::listTaskPushNotificationConfigurations), false);
 
         // DELETE /v1/tasks/:id/pushNotificationConfigs/:configId
         router.delete("/v1/tasks/:id/pushNotificationConfigs/:configId")
             .order(1)
-            .blockingHandler(authenticated(this::deleteTaskPushNotificationConfiguration));
+            .blockingHandler(authenticated(this::deleteTaskPushNotificationConfiguration), false);
 
         // Only register v0.3 agent card if no real v1.0 agent card producer exists.
         // DefaultProducers provides a @DefaultBean AgentCard fallback that is always
@@ -136,7 +136,7 @@ public class A2AServerRoutes_v0_3 {
         router.get("/v1/card")
             .order(1)
             .produces(APPLICATION_JSON)
-            .blockingHandler(authenticated(this::getAuthenticatedExtendedCard));
+            .blockingHandler(authenticated(this::getAuthenticatedExtendedCard), false);
     }
 
     private Handler<RoutingContext> authenticated(Consumer<RoutingContext> action) {

--- a/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/FileContentMapper_v0_3.java
+++ b/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/FileContentMapper_v0_3.java
@@ -51,9 +51,11 @@ public interface FileContentMapper_v0_3 {
         }
 
         if (v03 instanceof FileWithBytes_v0_3 v03Bytes) {
-            return new FileWithBytes(v03Bytes.mimeType(), v03Bytes.name(), v03Bytes.bytes());
+            String name = v03Bytes.name() != null ? v03Bytes.name() : "";
+            return new FileWithBytes(v03Bytes.mimeType(), name, v03Bytes.bytes());
         } else if (v03 instanceof FileWithUri_v0_3 v03Uri) {
-            return new FileWithUri(v03Uri.mimeType(), v03Uri.name(), v03Uri.uri());
+            String name = v03Uri.name() != null ? v03Uri.name() : "";
+            return new FileWithUri(v03Uri.mimeType(), name, v03Uri.uri());
         }
 
         throw new InvalidRequestError(null, "Unrecognized FileContent type: " + v03.getClass().getName(), null);

--- a/compat-0.3/transport/grpc/src/main/java/org/a2aproject/sdk/compat03/transport/grpc/handler/GrpcHandler_v0_3.java
+++ b/compat-0.3/transport/grpc/src/main/java/org/a2aproject/sdk/compat03/transport/grpc/handler/GrpcHandler_v0_3.java
@@ -43,6 +43,7 @@ import org.a2aproject.sdk.common.A2AErrorMessages;
 import org.a2aproject.sdk.server.auth.UnauthenticatedUser;
 import org.a2aproject.sdk.server.auth.User;
 import org.a2aproject.sdk.spec.A2AError;
+import io.grpc.Context;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 
@@ -235,6 +236,16 @@ public abstract class GrpcHandler_v0_3 extends org.a2aproject.sdk.compat03.grpc.
 
         try {
             ServerCallContext context = createCallContext(responseObserver);
+            Context forked = Context.current().fork();
+            context.getState().put(ServerCallContext.EXECUTION_WRAPPER_KEY,
+                    (java.util.function.UnaryOperator<Runnable>) (runnable -> () -> {
+                        Context prev = forked.attach();
+                        try {
+                            runnable.run();
+                        } finally {
+                            forked.detach(prev);
+                        }
+                    }));
             MessageSendParams_v0_3 params = FromProto.messageSendParams(request);
             Flow.Publisher<StreamingEventKind_v0_3> publisher = requestHandler.onMessageSendStream(params, context);
             convertToStreamResponse(publisher, responseObserver);
@@ -259,6 +270,16 @@ public abstract class GrpcHandler_v0_3 extends org.a2aproject.sdk.compat03.grpc.
 
         try {
             ServerCallContext context = createCallContext(responseObserver);
+            Context forkedSub = Context.current().fork();
+            context.getState().put(ServerCallContext.EXECUTION_WRAPPER_KEY,
+                    (java.util.function.UnaryOperator<Runnable>) (runnable -> () -> {
+                        Context prev = forkedSub.attach();
+                        try {
+                            runnable.run();
+                        } finally {
+                            forkedSub.detach(prev);
+                        }
+                    }));
             TaskIdParams_v0_3 params = FromProto.taskIdParams(request);
             Flow.Publisher<StreamingEventKind_v0_3> publisher = requestHandler.onResubscribeToTask(params, context);
             convertToStreamResponse(publisher, responseObserver);

--- a/itk/.gitignore
+++ b/itk/.gitignore
@@ -1,0 +1,4 @@
+a2a-itk/
+logs/
+raw_results.json
+itk_java.json

--- a/itk/pom.xml
+++ b/itk/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.a2aproject.sdk</groupId>
+        <artifactId>a2a-java-sdk-parent</artifactId>
+        <version>1.0.0.CR2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>a2a-java-sdk-itk</artifactId>
+
+    <name>Java SDK A2A ITK Agent</name>
+    <description>Integration Test Kit agent for cross-SDK interoperability testing</description>
+
+    <properties>
+        <protobuf-java.version>4.33.2</protobuf-java.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-reference-multiversion-jsonrpc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-reference-grpc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-compat-0.3-reference-grpc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-reference-multiversion-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf-java.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-client-transport-grpc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-client-transport-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-compat-0.3-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-compat-0.3-client-transport-jsonrpc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-compat-0.3-client-transport-grpc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-compat-0.3-client-transport-rest</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jvmArgs>--add-opens=java.base/java.lang=ALL-UNNAMED</jvmArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/itk/run_itk.sh
+++ b/itk/run_itk.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+set -ex
+
+# Set default log level
+export ITK_LOG_LEVEL="${ITK_LOG_LEVEL:-INFO}"
+
+# Detect container runtime (docker or podman)
+if command -v docker &> /dev/null; then
+  CONTAINER_RT=docker
+elif command -v podman &> /dev/null; then
+  CONTAINER_RT=podman
+else
+  echo "Error: neither docker nor podman found"
+  exit 1
+fi
+
+# Initialize default exit code
+RESULT=1
+
+# Cleanup function to be called on exit
+cleanup() {
+  set +x
+  echo "Cleaning up artifacts..."
+  $CONTAINER_RT stop itk-service > /dev/null 2>&1 || true
+  $CONTAINER_RT rm itk-service > /dev/null 2>&1 || true
+  $CONTAINER_RT rmi itk_service > /dev/null 2>&1 || true
+  rm -rf a2a-itk > /dev/null 2>&1 || true
+  echo "Done. Final exit code: $RESULT"
+}
+
+# Register cleanup function to run on script exit
+trap cleanup EXIT
+
+# 1. Pull a2a-itk and checkout revision
+: "${A2A_ITK_REVISION:?A2A_ITK_REVISION environment variable must be set}"
+
+if [ ! -d "a2a-itk" ]; then
+  git clone https://github.com/a2aproject/a2a-itk.git a2a-itk
+fi
+cd a2a-itk
+git fetch origin
+git checkout "$A2A_ITK_REVISION"
+
+# Only pull if it's a branch (not a detached HEAD)
+if git symbolic-ref -q HEAD > /dev/null; then
+  git pull origin "$A2A_ITK_REVISION"
+fi
+cd ..
+
+# 2. Copy latest instruction.proto from a2a-itk
+cp a2a-itk/protos/instruction.proto src/main/proto/instruction.proto
+
+# 3. Build itk_service container image from root of a2a-itk
+CONTAINER_BUILD_ARGS=""
+if [ "$CONTAINER_RT" = "podman" ]; then
+  CONTAINER_BUILD_ARGS="--format docker"
+fi
+$CONTAINER_RT build $CONTAINER_BUILD_ARGS -t itk_service a2a-itk
+
+# 4. Start container service with a single mount: the a2a-java repo
+A2A_JAVA_ROOT=$(cd .. && pwd)
+
+# Stop existing container if any
+$CONTAINER_RT rm -f itk-service || true
+
+# Create logs directory if debug
+if [ "${ITK_LOG_LEVEL^^}" = "DEBUG" ]; then
+  mkdir -p logs
+fi
+
+DOCKER_MOUNT_LOGS=""
+if [ "${ITK_LOG_LEVEL^^}" = "DEBUG" ]; then
+  DOCKER_MOUNT_LOGS="-v $(pwd)/logs:/app/logs"
+fi
+
+$CONTAINER_RT run -d --name itk-service \
+  -v "$A2A_JAVA_ROOT:/app/agents/repo" \
+  $DOCKER_MOUNT_LOGS \
+  -e ITK_LOG_LEVEL="$ITK_LOG_LEVEL" \
+  -p 8000:8000 \
+  itk_service
+
+# 5. Verify service is up and send post request
+MAX_RETRIES=30
+echo "Waiting for ITK service to start on 127.0.0.1:8000..."
+set +e
+for i in $(seq 1 $MAX_RETRIES); do
+  if curl -s http://127.0.0.1:8000/ > /dev/null; then
+    echo "Service is up!"
+    break
+  fi
+  echo "Still waiting... ($i/$MAX_RETRIES)"
+  sleep 2
+done
+
+# If we reached the end of the loop without success
+if ! curl -s http://127.0.0.1:8000/ > /dev/null; then
+  echo "Error: ITK service failed to start on port 8000"
+  $CONTAINER_RT logs itk-service
+  exit 1
+fi
+
+
+SCENARIO_FILE="scenarios.json"
+if [ "${ITK_NIGHTLY_RUN^^}" = "TRUE" ]; then
+  SCENARIO_FILE="scenarios_full.json"
+fi
+
+echo "ITK Service is up! Sending compatibility test request using $SCENARIO_FILE..."
+RESPONSE=$(curl -s -X POST http://127.0.0.1:8000/run \
+  -H "Content-Type: application/json" \
+  -d "@$SCENARIO_FILE")
+
+if [ "${ITK_NIGHTLY_RUN^^}" = "TRUE" ]; then
+  echo "Nightly run detected. Saving raw results and running process_results.py..."
+  echo "$RESPONSE" > raw_results.json
+  python3 a2a-itk/scripts/process_results.py \
+    --history_output_file itk_java.json \
+    --history_url https://github.com/a2aproject/a2a-java/releases/download/nightly-metrics/itk_java.json
+  RESULT=$?
+else
+  echo "--------------------------------------------------------"
+  echo "ITK TEST RESULTS:"
+  echo "--------------------------------------------------------"
+  echo "$RESPONSE" | python3 -c "
+import sys, json
+raw = sys.stdin.read()
+try:
+    data = json.loads(raw)
+    all_passed = data.get('all_passed', False)
+    results = data.get('results', {})
+    for test, passed in results.items():
+        status = 'PASSED' if passed else 'FAILED'
+        print(f'{test}: {status}')
+    print('--------------------------------------------------------')
+    print(f'OVERALL STATUS: {\"PASSED\" if all_passed else \"FAILED\"}')
+    if not all_passed:
+        sys.exit(1)
+except Exception as e:
+    print(f'Error parsing results: {e}')
+    print(f'Raw response: {raw}')
+    sys.exit(1)
+"
+  RESULT=$?
+fi
+set -e
+
+if [ $RESULT -ne 0 ]; then
+  echo "Tests failed. Container logs:"
+  $CONTAINER_RT logs itk-service
+fi
+echo "--------------------------------------------------------"
+
+# Final exit result will be captured by trap cleanup
+exit $RESULT

--- a/itk/scenarios.json
+++ b/itk/scenarios.json
@@ -1,0 +1,64 @@
+{
+  "tests": [
+    {
+      "name": "Star Topology (Full) - JSONRPC & GRPC",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["jsonrpc", "grpc"],
+      "behavior": "send_message"
+    },
+    {
+      "name": "Star Topology (No Go v03) - HTTP_JSON",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
+      "protocols": ["http_json"],
+      "behavior": "send_message"
+    },
+    {
+      "name": "Star Topology (Full) - JSONRPC & GRPC (Streaming)",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["jsonrpc", "grpc"],
+      "streaming": true,
+      "behavior": "send_message"
+    },
+    {
+      "name": "Star Topology (No Go v03) - HTTP_JSON (Streaming)",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
+      "protocols": ["http_json"],
+      "streaming": true,
+      "behavior": "send_message"
+    },
+    {
+      "name": "Push Notification Test - JSONRPC & GRPC",
+      "sdks": ["current", "java_v10", "python_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
+      "protocols": ["jsonrpc", "grpc"],
+      "behavior": "push_notification"
+    },
+    {
+      "name": "Push Notification Test - HTTP_JSON",
+      "sdks": ["current", "java_v10", "python_v10"],
+      "edges": ["0->1", "0->2", "1->0", "2->0"],
+      "protocols": ["http_json"],
+      "behavior": "push_notification"
+    },
+    {
+      "name": "Resubscribe Test - JSONRPC",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["jsonrpc"],
+      "streaming": true,
+      "behavior": "resubscribe"
+    },
+    {
+      "name": "Resubscribe Test - Non-JSONRPC Protocols",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
+      "protocols": ["grpc", "http_json"],
+      "streaming": true,
+      "behavior": "resubscribe"
+    }
+  ]
+}

--- a/itk/scenarios_full.json
+++ b/itk/scenarios_full.json
@@ -1,0 +1,106 @@
+{
+  "tests": [
+    {
+      "name": "Nightly - JSONRPC - Send Message",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["jsonrpc"],
+      "behavior": "send_message",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - JSONRPC - Send Message (Streaming)",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["jsonrpc"],
+      "streaming": true,
+      "behavior": "send_message",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - JSONRPC - Push Notification",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["jsonrpc"],
+      "behavior": "push_notification",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - JSONRPC - Resubscribe",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["jsonrpc"],
+      "streaming": true,
+      "behavior": "resubscribe",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - GRPC - Send Message",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["grpc"],
+      "behavior": "send_message",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - GRPC - Send Message (Streaming)",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["grpc"],
+      "streaming": true,
+      "behavior": "send_message",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - GRPC - Push Notification",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["grpc"],
+      "behavior": "push_notification",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - GRPC - Resubscribe",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["grpc"],
+      "streaming": true,
+      "behavior": "resubscribe",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - HTTP_JSON - Send Message",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["http_json"],
+      "behavior": "send_message",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - HTTP_JSON - Send Message (Streaming)",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["http_json"],
+      "streaming": true,
+      "behavior": "send_message",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - HTTP_JSON - Push Notification",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["http_json"],
+      "behavior": "push_notification",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - HTTP_JSON - Resubscribe",
+      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["http_json"],
+      "streaming": true,
+      "behavior": "resubscribe",
+      "build_subtests": true
+    }
+  ]
+}

--- a/itk/src/main/java/org/a2aproject/sdk/itk/AdditionalRoutes.java
+++ b/itk/src/main/java/org/a2aproject/sdk/itk/AdditionalRoutes.java
@@ -1,0 +1,39 @@
+package org.a2aproject.sdk.itk;
+
+import io.vertx.ext.web.Router;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class AdditionalRoutes {
+
+    private static final Logger log = LoggerFactory.getLogger(AdditionalRoutes.class);
+
+    void addPrefixedRoutes(@Observes Router router) {
+        router.get("/jsonrpc/.well-known/agent-card.json")
+                .handler(ctx -> {
+                    log.info("Rerouting GET /jsonrpc/.well-known/agent-card.json -> /.well-known/agent-card.json");
+                    ctx.reroute("/.well-known/agent-card.json");
+                });
+
+        router.route("/jsonrpc/*").handler(ctx -> {
+            log.info("Rerouting /jsonrpc -> /");
+            ctx.reroute("/");
+        });
+        router.route("/rest/*").handler(ctx -> {
+            log.info("Rerouting POST /rest -> /");
+            ctx.reroute("/");
+        });
+
+        router.route().order(Integer.MIN_VALUE)
+                .handler(ctx -> {
+                    String method = ctx.request().method().name();
+                    String path = ctx.request().path();
+                    String contentType = ctx.request().getHeader("Content-Type");
+                    log.info("Incoming {} {} Content-Type={}", method, path, contentType);
+                    ctx.next();
+                });
+    }
+}

--- a/itk/src/main/java/org/a2aproject/sdk/itk/AgentCardProducer.java
+++ b/itk/src/main/java/org/a2aproject/sdk/itk/AgentCardProducer.java
@@ -1,0 +1,79 @@
+package org.a2aproject.sdk.itk;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import org.a2aproject.sdk.compat03.spec.AgentCapabilities_v0_3;
+import org.a2aproject.sdk.compat03.spec.AgentCard_v0_3;
+import org.a2aproject.sdk.server.PublicAgentCard;
+import org.a2aproject.sdk.spec.AgentCapabilities;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.AgentInterface;
+import org.a2aproject.sdk.spec.AgentSkill;
+import org.a2aproject.sdk.spec.Compat03Fields;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.arc.DefaultBean;
+
+@ApplicationScoped
+public class AgentCardProducer {
+
+    @ConfigProperty(name = "quarkus.http.port", defaultValue = "10102")
+    int httpPort;
+
+    @ConfigProperty(name = "quarkus.grpc.server.port", defaultValue = "11002")
+    int grpcPort;
+
+    @Produces
+    @PublicAgentCard
+    public AgentCard agentCard() {
+        String url = "http://127.0.0.1:" + httpPort;
+        List<AgentInterface> interfaces = List.of(
+                new AgentInterface("JSONRPC", url),
+                new AgentInterface("HTTP+JSON", url),
+                new AgentInterface("GRPC", "127.0.0.1:" + grpcPort));
+
+        AgentCard.Builder builder = AgentCard.builder()
+                .name("ITK Current Agent")
+                .description("Java agent using A2A SDK (current source).")
+                .version("1.0.0")
+                .supportedInterfaces(interfaces)
+                .capabilities(AgentCapabilities.builder()
+                        .streaming(true)
+                        .pushNotifications(true)
+                        .build())
+                .defaultInputModes(List.of("text"))
+                .defaultOutputModes(List.of("text"))
+                .skills(List.of(AgentSkill.builder()
+                        .id("itk_current")
+                        .name("ITK Current")
+                        .description("Processes ITK instruction traversals")
+                        .tags(List.of("itk"))
+                        .examples(List.of())
+                        .build()));
+
+        Compat03Fields.addCompat03FieldsIfAvailable(builder, interfaces, url, "JSONRPC");
+
+        return builder.build();
+    }
+
+    @Produces
+    @PublicAgentCard
+    @DefaultBean
+    public AgentCard_v0_3 agentCard_v0_3() {
+        String url = "http://127.0.0.1:" + httpPort;
+        return new AgentCard_v0_3.Builder()
+                .name("ITK Current Agent")
+                .description("Java agent using A2A SDK (current source).")
+                .url(url)
+                .version("1.0.0")
+                .preferredTransport("JSONRPC")
+                .capabilities(new AgentCapabilities_v0_3(true, true, false, List.of()))
+                .defaultInputModes(List.of("text"))
+                .defaultOutputModes(List.of("text"))
+                .skills(List.of())
+                .build();
+    }
+}

--- a/itk/src/main/java/org/a2aproject/sdk/itk/AgentExecutorProducer.java
+++ b/itk/src/main/java/org/a2aproject/sdk/itk/AgentExecutorProducer.java
@@ -1,0 +1,497 @@
+package org.a2aproject.sdk.itk;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import org.a2aproject.sdk.A2A;
+import org.a2aproject.sdk.client.Client;
+import org.a2aproject.sdk.client.ClientEvent;
+import org.a2aproject.sdk.client.MessageEvent;
+import org.a2aproject.sdk.client.TaskEvent;
+import org.a2aproject.sdk.client.TaskUpdateEvent;
+import org.a2aproject.sdk.client.config.ClientConfig;
+import org.a2aproject.sdk.client.transport.grpc.GrpcTransport;
+import org.a2aproject.sdk.client.transport.grpc.GrpcTransportConfigBuilder;
+import org.a2aproject.sdk.client.transport.jsonrpc.JSONRPCTransport;
+import org.a2aproject.sdk.client.transport.jsonrpc.JSONRPCTransportConfigBuilder;
+import org.a2aproject.sdk.client.transport.rest.RestTransport;
+import org.a2aproject.sdk.client.transport.rest.RestTransportConfigBuilder;
+import org.a2aproject.sdk.compat03.A2A_v0_3;
+import org.a2aproject.sdk.compat03.client.Client_v0_3;
+import org.a2aproject.sdk.compat03.client.ClientEvent_v0_3;
+import org.a2aproject.sdk.compat03.client.MessageEvent_v0_3;
+import org.a2aproject.sdk.compat03.client.TaskEvent_v0_3;
+import org.a2aproject.sdk.compat03.client.TaskUpdateEvent_v0_3;
+import org.a2aproject.sdk.compat03.client.config.ClientConfig_v0_3;
+import org.a2aproject.sdk.compat03.client.transport.grpc.GrpcTransportConfigBuilder_v0_3;
+import org.a2aproject.sdk.compat03.client.transport.grpc.GrpcTransport_v0_3;
+import org.a2aproject.sdk.compat03.client.transport.jsonrpc.JSONRPCTransportConfigBuilder_v0_3;
+import org.a2aproject.sdk.compat03.client.transport.jsonrpc.JSONRPCTransport_v0_3;
+import org.a2aproject.sdk.compat03.client.transport.rest.RestTransportConfigBuilder_v0_3;
+import org.a2aproject.sdk.compat03.client.transport.rest.RestTransport_v0_3;
+import org.a2aproject.sdk.compat03.spec.AgentCard_v0_3;
+import org.a2aproject.sdk.compat03.spec.FilePart_v0_3;
+import org.a2aproject.sdk.compat03.spec.FileWithBytes_v0_3;
+import org.a2aproject.sdk.compat03.spec.Message_v0_3;
+import org.a2aproject.sdk.compat03.spec.Part_v0_3;
+import org.a2aproject.sdk.compat03.spec.PushNotificationConfig_v0_3;
+import org.a2aproject.sdk.compat03.spec.TextPart_v0_3;
+import org.a2aproject.sdk.server.agentexecution.AgentExecutor;
+import org.a2aproject.sdk.server.agentexecution.RequestContext;
+import org.a2aproject.sdk.server.tasks.AgentEmitter;
+import org.a2aproject.sdk.spec.A2AError;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.FilePart;
+import org.a2aproject.sdk.spec.FileWithBytes;
+import org.a2aproject.sdk.spec.Message;
+import org.a2aproject.sdk.spec.Part;
+import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
+import org.a2aproject.sdk.spec.TaskState;
+import org.a2aproject.sdk.spec.TextPart;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.grpc.ManagedChannelBuilder;
+
+import itk.InstructionOuterClass.CallAgent;
+import itk.InstructionOuterClass.Instruction;
+
+@ApplicationScoped
+public class AgentExecutorProducer {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentExecutorProducer.class);
+
+    @Produces
+    public AgentExecutor agentExecutor() {
+        return new ItkAgentExecutor();
+    }
+
+    static class ItkAgentExecutor implements AgentExecutor {
+
+        private static final int HOLD_ITERATIONS = 5;
+        private static final long HOLD_INTERVAL_MS = 2000;
+        private static final long TASK_TIMEOUT_SECONDS = 60;
+
+        @Override
+        public void execute(RequestContext context, AgentEmitter emitter) throws A2AError {
+            log.info("Executing task {}", emitter.getTaskId());
+
+            emitter.startWork();
+
+            Instruction instruction = extractInstruction(context.getMessage());
+            if (instruction == null) {
+                log.error("No valid instruction found in request");
+                emitter.sendMessage("No valid instruction found in request");
+                emitter.fail();
+                return;
+            }
+
+            try {
+                List<String> results = handleInstruction(instruction);
+                String response = String.join("\n", results);
+                log.info("Response: {}", response);
+
+                if (shouldHold(instruction)) {
+                    log.info("Holding task {} as requested", emitter.getTaskId());
+
+                    Message holdMsg = emitter.newAgentMessage(
+                            List.of(new TextPart(response + "\ntask-finished")), null);
+                    emitter.updateStatus(TaskState.TASK_STATE_WORKING, holdMsg);
+
+                    for (int i = 0; i < HOLD_ITERATIONS; i++) {
+                        log.info("Emitting periodic status update for held task {}", emitter.getTaskId());
+                        try {
+                            Thread.sleep(HOLD_INTERVAL_MS);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            log.info("Task {} interrupted during hold", emitter.getTaskId());
+                            return;
+                        }
+                    }
+                    log.info("Held task {} timed out, auto-completing", emitter.getTaskId());
+                    Message completeMsg = emitter.newAgentMessage(
+                            List.of(new TextPart(response + "\ntask-finished")), null);
+                    emitter.complete(completeMsg);
+                } else {
+                    Message completeMsg = emitter.newAgentMessage(
+                            List.of(new TextPart(response)), null);
+                    emitter.complete(completeMsg);
+                }
+            } catch (TimeoutException e) {
+                log.error("Timed out waiting for remote agent response", e);
+                emitter.fail();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Task {} interrupted while calling remote agent", emitter.getTaskId(), e);
+                emitter.fail();
+            } catch (ExecutionException e) {
+                log.error("Remote agent call failed for task {}: {}",
+                        emitter.getTaskId(), e.getCause().getMessage(), e.getCause());
+                emitter.fail();
+            } catch (Exception e) {
+                log.error("Unexpected error handling instruction for task {}",
+                        emitter.getTaskId(), e);
+                emitter.fail();
+            }
+        }
+
+        @Override
+        public void cancel(RequestContext context, AgentEmitter emitter) throws A2AError {
+            log.info("Cancel requested for task {}", emitter.getTaskId());
+            emitter.cancel();
+        }
+
+        private Instruction extractInstruction(Message message) {
+            if (message == null || message.parts() == null) {
+                return null;
+            }
+
+            for (Part<?> part : message.parts()) {
+                if (part instanceof FilePart filePart) {
+                    var file = filePart.file();
+                    if ("application/x-protobuf".equals(file.mimeType())
+                            || "instruction.bin".equals(file.name())) {
+                        try {
+                            if (file instanceof FileWithBytes fwb) {
+                                byte[] raw = Base64.getDecoder().decode(fwb.bytes());
+                                return Instruction.parseFrom(raw);
+                            }
+                        } catch (Exception e) {
+                            log.debug("Failed to parse instruction from file part", e);
+                        }
+                    }
+                }
+
+                if (part instanceof TextPart textPart) {
+                    try {
+                        byte[] raw = Base64.getDecoder().decode(textPart.text());
+                        return Instruction.parseFrom(raw);
+                    } catch (Exception e) {
+                        log.debug("Failed to parse instruction from text part", e);
+                    }
+                }
+            }
+            return null;
+        }
+
+        private List<String> handleInstruction(Instruction inst) throws Exception {
+            if (inst.hasCallAgent()) {
+                return handleCallAgent(inst.getCallAgent());
+            }
+            if (inst.hasReturnResponse()) {
+                return List.of(inst.getReturnResponse().getResponse());
+            }
+            if (inst.hasSteps()) {
+                List<String> allResults = new ArrayList<>();
+                for (Instruction step : inst.getSteps().getInstructionsList()) {
+                    allResults.addAll(handleInstruction(step));
+                }
+                return allResults;
+            }
+            throw new IllegalStateException("Unknown instruction type");
+        }
+
+        private List<String> handleCallAgent(CallAgent call) throws Exception {
+            log.info("Calling agent {} via {}", call.getAgentCardUri(), call.getTransport());
+            AgentCard remoteCard = A2A.getAgentCard(call.getAgentCardUri());
+
+            if (remoteCard.supportedInterfaces().isEmpty()) {
+                log.info("Agent {} has no supportedInterfaces, falling back to v0.3 client", call.getAgentCardUri());
+                return handleCallAgentV03(call);
+            }
+
+            ClientConfig.Builder configBuilder = new ClientConfig.Builder()
+                    .setStreaming(call.getStreaming() || isGrpc(call.getTransport()))
+                    .setUseClientPreference(true);
+
+            if (call.hasPushNotification()) {
+                String url = call.getPushNotification().getUrl();
+                if (url.isEmpty()) {
+                    throw new IllegalArgumentException("URL not specified in push_notification behavior");
+                }
+                if (!url.startsWith("http://") && !url.startsWith("https://")) {
+                    url = "http://" + url;
+                }
+                configBuilder.setTaskPushNotificationConfig(
+                        TaskPushNotificationConfig.builder()
+                                .id(UUID.randomUUID().toString())
+                                .url(url + "/notifications")
+                                .token("itk-token")
+                                .build());
+            }
+
+            var clientBuilder = Client.builder(remoteCard)
+                    .clientConfig(configBuilder.build());
+
+            addTransport(clientBuilder, call.getTransport());
+
+            byte[] instBytes = call.getInstruction().toByteArray();
+            Message wrappedMsg = Message.builder()
+                    .role(Message.Role.ROLE_USER)
+                    .parts(List.of(new FilePart(
+                            new FileWithBytes("application/x-protobuf", "instruction.bin", instBytes))))
+                    .build();
+
+            CompletableFuture<List<String>> resultFuture = new CompletableFuture<>();
+            List<String> responses = Collections.synchronizedList(new ArrayList<>());
+
+            clientBuilder.addConsumer((event, card) -> {
+                List<String> texts = extractTextFromEvent(event);
+                if (call.hasResubscribe()) {
+                    String finished = findTaskFinishedText(texts);
+                    if (finished != null) {
+                        responses.add(finished);
+                        if (!resultFuture.isDone()) {
+                            resultFuture.complete(responses);
+                        }
+                        return;
+                    }
+                }
+                responses.addAll(texts);
+                if (!resultFuture.isDone() && isTerminalEvent(event)) {
+                    resultFuture.complete(responses);
+                }
+            });
+            clientBuilder.streamingErrorHandler(error -> {
+                log.error("Streaming error calling {} via {}",
+                        call.getAgentCardUri(), call.getTransport(), error);
+                if (!resultFuture.isDone()) {
+                    resultFuture.completeExceptionally(error);
+                }
+            });
+
+            try (Client client = clientBuilder.build()) {
+                client.sendMessage(wrappedMsg, (TaskPushNotificationConfig) null, null, null);
+                log.info("Received responses from {}", call.getAgentCardUri());
+                return resultFuture.get(TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            }
+        }
+
+        private List<String> handleCallAgentV03(CallAgent call) throws Exception {
+            AgentCard_v0_3 v03Card = A2A_v0_3.getAgentCard(call.getAgentCardUri());
+
+            ClientConfig_v0_3.Builder configBuilder = new ClientConfig_v0_3.Builder()
+                    .setStreaming(call.getStreaming() || isGrpc(call.getTransport()))
+                    .setUseClientPreference(true);
+
+            PushNotificationConfig_v0_3 pushConfig = null;
+            if (call.hasPushNotification()) {
+                String url = call.getPushNotification().getUrl();
+                if (url.isEmpty()) {
+                    throw new IllegalArgumentException("URL not specified in push_notification behavior");
+                }
+                if (!url.startsWith("http://") && !url.startsWith("https://")) {
+                    url = "http://" + url;
+                }
+                pushConfig = new PushNotificationConfig_v0_3.Builder()
+                        .id(UUID.randomUUID().toString())
+                        .url(url + "/notifications")
+                        .token("itk-token")
+                        .build();
+                configBuilder.setPushNotificationConfig(pushConfig);
+            }
+
+            var clientBuilder = Client_v0_3.builder(v03Card)
+                    .clientConfig(configBuilder.build());
+
+            addTransportV03(clientBuilder, call.getTransport());
+
+            byte[] instBytes = call.getInstruction().toByteArray();
+            String instBase64 = Base64.getEncoder().encodeToString(instBytes);
+            Message_v0_3 wrappedMsg = new Message_v0_3.Builder()
+                    .role(Message_v0_3.Role.USER)
+                    .parts(List.of(new FilePart_v0_3(
+                            new FileWithBytes_v0_3("application/x-protobuf", "instruction.bin", instBase64))))
+                    .build();
+
+            CompletableFuture<List<String>> resultFuture = new CompletableFuture<>();
+            List<String> responses = Collections.synchronizedList(new ArrayList<>());
+
+            clientBuilder.addConsumer((event, card) -> {
+                List<String> texts = extractTextFromEventV03(event);
+                if (call.hasResubscribe()) {
+                    String finished = findTaskFinishedText(texts);
+                    if (finished != null) {
+                        responses.add(finished);
+                        if (!resultFuture.isDone()) {
+                            resultFuture.complete(responses);
+                        }
+                        return;
+                    }
+                }
+                responses.addAll(texts);
+                if (!resultFuture.isDone() && isTerminalEventV03(event)) {
+                    resultFuture.complete(responses);
+                }
+            });
+            clientBuilder.streamingErrorHandler(error -> {
+                log.error("Streaming error calling v0.3 agent {}", call.getAgentCardUri(), error);
+                if (!resultFuture.isDone()) {
+                    resultFuture.completeExceptionally(error);
+                }
+            });
+
+            Client_v0_3 client = clientBuilder.build();
+            try {
+                client.sendMessage(wrappedMsg, pushConfig, null, null);
+                log.info("Received v0.3 responses from {}", call.getAgentCardUri());
+                return resultFuture.get(TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } finally {
+                client.close();
+            }
+        }
+
+        private List<String> extractTextFromMessage(Message message) {
+            List<String> texts = new ArrayList<>();
+            if (message != null && message.parts() != null) {
+                for (Part<?> part : message.parts()) {
+                    if (part instanceof TextPart tp && tp.text() != null && !tp.text().isEmpty()) {
+                        texts.add(tp.text());
+                    }
+                }
+            }
+            return texts;
+        }
+
+        private List<String> extractTextFromEvent(ClientEvent event) {
+            Message message = null;
+
+            if (event instanceof MessageEvent me) {
+                message = me.getMessage();
+            } else if (event instanceof TaskEvent te) {
+                if (te.getTask() != null && te.getTask().status() != null && te.getTask().status().message() != null) {
+                    message = te.getTask().status().message();
+                }
+            } else if (event instanceof TaskUpdateEvent tue) {
+                if (tue.getTask() != null && tue.getTask().status() != null && tue.getTask().status().message() != null) {
+                    message = tue.getTask().status().message();
+                }
+            }
+
+            return extractTextFromMessage(message);
+        }
+
+        private String findTaskFinishedText(List<String> texts) {
+            for (String text : texts) {
+                if (text.contains("task-finished")) {
+                    return text.replace("task-finished", "");
+                }
+            }
+            return null;
+        }
+
+        private boolean shouldHold(Instruction inst) {
+            if (inst.hasReturnResponse() && inst.getReturnResponse().getHoldTask()) {
+                return true;
+            }
+            if (inst.hasSteps()) {
+                for (Instruction step : inst.getSteps().getInstructionsList()) {
+                    if (shouldHold(step)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        private boolean isTerminalEvent(ClientEvent event) {
+            if (event instanceof MessageEvent) {
+                return true;
+            }
+            if (event instanceof TaskEvent te) {
+                return te.getTask() != null && te.getTask().status() != null && te.getTask().status().state().isFinal();
+            }
+            if (event instanceof TaskUpdateEvent tue) {
+                return tue.getTask() != null && tue.getTask().status() != null && tue.getTask().status().state().isFinal();
+            }
+            return false;
+        }
+
+        private boolean isGrpc(String transport) {
+            return "GRPC".equalsIgnoreCase(transport);
+        }
+
+        private List<String> extractTextFromMessageV03(Message_v0_3 message) {
+            List<String> texts = new ArrayList<>();
+            if (message != null && message.parts() != null) {
+                for (Part_v0_3<?> part : message.parts()) {
+                    if (part instanceof TextPart_v0_3 tp && tp.text() != null && !tp.text().isEmpty()) {
+                        texts.add(tp.text());
+                    }
+                }
+            }
+            return texts;
+        }
+
+        private List<String> extractTextFromEventV03(ClientEvent_v0_3 event) {
+            Message_v0_3 message = null;
+
+            if (event instanceof MessageEvent_v0_3 me) {
+                message = me.getMessage();
+            } else if (event instanceof TaskEvent_v0_3 te) {
+                if (te.getTask() != null && te.getTask().status() != null && te.getTask().status().message() != null) {
+                    message = te.getTask().status().message();
+                }
+            } else if (event instanceof TaskUpdateEvent_v0_3 tue) {
+                if (tue.getTask() != null && tue.getTask().status() != null && tue.getTask().status().message() != null) {
+                    message = tue.getTask().status().message();
+                }
+            }
+
+            return extractTextFromMessageV03(message);
+        }
+
+        private boolean isTerminalEventV03(ClientEvent_v0_3 event) {
+            if (event instanceof MessageEvent_v0_3) {
+                return true;
+            }
+            if (event instanceof TaskEvent_v0_3 te) {
+                return te.getTask() != null && te.getTask().status() != null && te.getTask().status().state().isFinal();
+            }
+            if (event instanceof TaskUpdateEvent_v0_3 tue) {
+                return tue.getTask() != null && tue.getTask().status() != null && tue.getTask().status().state().isFinal();
+            }
+            return false;
+        }
+
+        @SuppressWarnings("unchecked")
+        private void addTransport(org.a2aproject.sdk.client.ClientBuilder builder, String transport) {
+            switch (transport.toUpperCase()) {
+                case "GRPC" -> builder.withTransport(GrpcTransport.class,
+                        new GrpcTransportConfigBuilder()
+                                .channelFactory(url -> ManagedChannelBuilder.forTarget(url)
+                                        .usePlaintext()
+                                        .build()));
+                case "REST", "HTTP_JSON", "HTTP+JSON" -> builder.withTransport(
+                        RestTransport.class, new RestTransportConfigBuilder());
+                default -> builder.withTransport(JSONRPCTransport.class,
+                        new JSONRPCTransportConfigBuilder());
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private void addTransportV03(org.a2aproject.sdk.compat03.client.ClientBuilder_v0_3 builder, String transport) {
+            switch (transport.toUpperCase()) {
+                case "GRPC" -> builder.withTransport(GrpcTransport_v0_3.class,
+                        new GrpcTransportConfigBuilder_v0_3()
+                                .channelFactory(url -> ManagedChannelBuilder.forTarget(url)
+                                        .usePlaintext()
+                                        .build()));
+                case "REST", "HTTP_JSON", "HTTP+JSON" -> builder.withTransport(
+                        RestTransport_v0_3.class, new RestTransportConfigBuilder_v0_3());
+                default -> builder.withTransport(JSONRPCTransport_v0_3.class,
+                        new JSONRPCTransportConfigBuilder_v0_3());
+            }
+        }
+    }
+}

--- a/itk/src/main/java/org/a2aproject/sdk/itk/Main.java
+++ b/itk/src/main/java/org/a2aproject/sdk/itk/Main.java
@@ -1,0 +1,45 @@
+package org.a2aproject.sdk.itk;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        String httpPort = "10102";
+        String grpcPort = "11002";
+
+        for (int i = 0; i < args.length; i++) {
+            if ("--httpPort".equals(args[i]) && i + 1 < args.length) {
+                httpPort = args[++i];
+            } else if ("--grpcPort".equals(args[i]) && i + 1 < args.length) {
+                grpcPort = args[++i];
+            }
+        }
+
+        Path jarPath = Path.of("target", "quarkus-app", "quarkus-run.jar");
+        if (!jarPath.toFile().exists()) {
+            System.err.println("quarkus-run.jar not found at " + jarPath.toAbsolutePath());
+            System.exit(1);
+        }
+
+        List<String> command = new ArrayList<>();
+        command.add(ProcessHandle.current().info().command().orElse("java"));
+        command.add("-Dquarkus.http.port=" + httpPort);
+        command.add("-Dquarkus.grpc.server.port=" + grpcPort);
+        command.add("-jar");
+        command.add(jarPath.toString());
+
+        Process process = new ProcessBuilder(command)
+                .inheritIO()
+                .directory(new File("."))
+                .start();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> process.destroyForcibly()));
+
+        System.exit(process.waitFor());
+    }
+}

--- a/itk/src/main/proto/instruction.proto
+++ b/itk/src/main/proto/instruction.proto
@@ -1,0 +1,60 @@
+syntax = "proto3";
+
+package itk;
+
+
+message Instruction {
+  // what should the "agent" do
+  oneof step {
+    CallAgent call_agent = 1;
+    ReturnResponse return_response = 2;
+    SeriesOfSteps steps = 3;
+  }
+}
+
+// Behavior messages
+message SendMessageBehavior {}
+message PushNotificationBehavior {
+  string url = 1;
+}
+message ResubscribeBehavior {}
+
+// gets the agent card from a remote agent, calls it and returns the response
+message CallAgent {
+  // which transport use to get agent card and later call
+  string transport = 1;
+  // where to get the agent card from
+  string agent_card_uri = 2;
+  // instruction for the called agent
+  Instruction instruction = 3;
+  // whether to use streaming
+  bool streaming = 4;
+
+  // behavior mode
+  oneof behavior {
+    SendMessageBehavior send_message = 5;
+    PushNotificationBehavior push_notification = 6;
+    ResubscribeBehavior resubscribe = 7;
+  }
+}
+
+// this option just returns a response
+message ReturnResponse {
+  // what to return to the calling agent
+  string response = 1;
+  // whether to hold the task in WORKING state instead of completing it
+  bool hold_task = 2;
+}
+
+// executes step series and returns response based on response_generator
+message SeriesOfSteps {
+  repeated Instruction instructions = 1;
+
+  enum ResponseGenerator {
+    // default
+    RESPONSE_GENERATOR_UNSPECIFIED = 0;
+    RESPONSE_GENERATOR_CONCAT = 1;
+  }
+
+  ResponseGenerator response_generator = 2;
+}

--- a/itk/src/main/resources/application.properties
+++ b/itk/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+quarkus.http.port=10102
+quarkus.grpc.server.port=11002
+
+# File logging
+quarkus.log.file.enable=true
+quarkus.log.file.path=/tmp/java-current.log
+quarkus.log.file.level=DEBUG
+quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/json/JsonUtil.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/json/JsonUtil.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.ToNumberPolicy;
@@ -474,7 +475,11 @@ public class JsonUtil {
             return Collections.emptyMap();
         }
         try {
-            return readMetadata(JsonParser.parseString(json).getAsJsonObject());
+            JsonElement element = JsonParser.parseString(json);
+            if (!element.isJsonObject()) {
+                return Collections.emptyMap();
+            }
+            return readMetadata(element.getAsJsonObject());
         } catch (JsonSyntaxException e) {
             throw new JsonProcessingException("Failed to parse metadata JSON", e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -599,6 +599,9 @@
         <module>transport/grpc</module>
         <module>transport/rest</module>
 
+        <!-- ITK (Integration Test Kit) agent -->
+        <module>itk</module>
+
         <!-- A2A Protocol v0.3 backward compatibility layer -->
         <module>compat-0.3</module>
 

--- a/reference/grpc/src/main/java/org/a2aproject/sdk/server/grpc/quarkus/BlockingOffloadInterceptor.java
+++ b/reference/grpc/src/main/java/org/a2aproject/sdk/server/grpc/quarkus/BlockingOffloadInterceptor.java
@@ -1,0 +1,79 @@
+package org.a2aproject.sdk.server.grpc.quarkus;
+
+import java.util.concurrent.Executor;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.a2aproject.sdk.server.util.async.Internal;
+import io.grpc.Context;
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+
+/**
+ * gRPC server interceptor that offloads handler execution from the Vert.x event loop
+ * to a worker thread, using a forked gRPC {@link Context}.
+ *
+ * <p>In Quarkus separate-server mode ({@code quarkus.grpc.server.use-separate-server=true}),
+ * the {@code @Blocking} annotation is ignored and gRPC handlers run on the Vert.x event loop.
+ * Synchronous operations like {@code sendMessage()} deadlock the event loop. This interceptor
+ * wraps the {@code onHalfClose()} callback to run the handler on a worker thread instead.
+ *
+ * <p>The context is forked ({@link Context#fork()}) so that the handler's outbound gRPC calls
+ * do not inherit the inbound call's cancellation signal. Without this, Quarkus'
+ * {@code ContextStorageOverride} propagates the server context through the
+ * {@code ManagedExecutor}, causing outbound client calls to be cancelled when the
+ * inbound caller disconnects.
+ *
+ * <p>This applies to both unary and server-streaming methods (which both have a single
+ * inbound request). Client-streaming and bidi-streaming methods are excluded.
+ */
+@ApplicationScoped
+public class BlockingOffloadInterceptor implements ServerInterceptor {
+
+    private final Executor executor;
+
+    @Inject
+    public BlockingOffloadInterceptor(@Internal Executor executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call,
+            Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+
+        MethodDescriptor.MethodType type = call.getMethodDescriptor().getType();
+        if (type == MethodDescriptor.MethodType.CLIENT_STREAMING
+                || type == MethodDescriptor.MethodType.BIDI_STREAMING) {
+            return next.startCall(call, headers);
+        }
+
+        ServerCall.Listener<ReqT> delegate = next.startCall(call, headers);
+
+        return new SimpleForwardingServerCallListener<ReqT>(delegate) {
+            @Override
+            public void onHalfClose() {
+                Context grpcContext = Context.current().fork();
+                try {
+                    executor.execute(() -> {
+                        Context previous = grpcContext.attach();
+                        try {
+                            super.onHalfClose();
+                        } finally {
+                            grpcContext.detach(previous);
+                        }
+                    });
+                } catch (Exception e) {
+                    call.close(Status.INTERNAL.withDescription("Failed to offload to worker thread: " + e.getMessage()), new Metadata());
+                }
+            }
+        };
+    }
+}

--- a/reference/grpc/src/main/java/org/a2aproject/sdk/server/grpc/quarkus/QuarkusGrpcHandler.java
+++ b/reference/grpc/src/main/java/org/a2aproject/sdk/server/grpc/quarkus/QuarkusGrpcHandler.java
@@ -15,6 +15,7 @@ import org.a2aproject.sdk.transport.grpc.handler.GrpcHandler;
 import io.quarkus.grpc.GrpcService;
 import io.quarkus.grpc.RegisterInterceptor;
 import io.quarkus.security.Authenticated;
+import io.smallrye.common.annotation.Blocking;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -68,7 +69,9 @@ import org.jspecify.annotations.Nullable;
  */
 @GrpcService
 @RegisterInterceptor(A2AExtensionsInterceptor.class)
+@RegisterInterceptor(BlockingOffloadInterceptor.class)
 @Authenticated
+@Blocking
 public class QuarkusGrpcHandler extends GrpcHandler {
 
     private final AgentCard agentCard;

--- a/reference/multiversion-jsonrpc/src/main/java/org/a2aproject/sdk/server/multiversion/jsonrpc/MultiVersionJSONRPCRoutes.java
+++ b/reference/multiversion-jsonrpc/src/main/java/org/a2aproject/sdk/server/multiversion/jsonrpc/MultiVersionJSONRPCRoutes.java
@@ -62,6 +62,6 @@ public class MultiVersionJSONRPCRoutes {
                 } catch (Exception e) {
                     VertxSecurityHelper.handleGenericError(ctx);
                 }
-            });
+            }, false);
     }
 }

--- a/reference/multiversion-rest/src/main/java/org/a2aproject/sdk/server/multiversion/rest/MultiVersionRestRoutes.java
+++ b/reference/multiversion-rest/src/main/java/org/a2aproject/sdk/server/multiversion/rest/MultiVersionRestRoutes.java
@@ -45,7 +45,7 @@ public class MultiVersionRestRoutes {
             .blockingHandler(versionDispatch(
                 MultiVersionRestRoutes::bridgeTenant,
                 (body, ctx) -> v10Routes.sendMessage(body, ctx),
-                (body, ctx) -> v03Routes.sendMessage(body, ctx)));
+                (body, ctx) -> v03Routes.sendMessage(body, ctx)), false);
 
         // POST /v1/message:stream
         router.postWithRegex("^\\/v1\\/message:stream$")
@@ -54,7 +54,7 @@ public class MultiVersionRestRoutes {
             .blockingHandler(versionDispatch(
                 MultiVersionRestRoutes::bridgeTenant,
                 (body, ctx) -> v10Routes.sendMessageStreaming(body, ctx),
-                (body, ctx) -> v03Routes.sendMessageStreaming(body, ctx)));
+                (body, ctx) -> v03Routes.sendMessageStreaming(body, ctx)), false);
 
         // GET /v1/tasks/{taskId}
         router.getWithRegex("^\\/v1\\/tasks\\/(?<taskId>[^:^/]+)$")
@@ -62,7 +62,7 @@ public class MultiVersionRestRoutes {
             .blockingHandler(versionDispatchNoBody(
                 ctx -> { bridgeTenant(ctx); bridgeTaskId(ctx); },
                 ctx -> v10Routes.getTask(ctx),
-                ctx -> v03Routes.getTask(ctx)));
+                ctx -> v03Routes.getTask(ctx)), false);
 
         // POST /v1/tasks/{taskId}:cancel
         router.postWithRegex("^\\/v1\\/tasks\\/(?<taskId>[^/]+):cancel$")
@@ -71,7 +71,7 @@ public class MultiVersionRestRoutes {
             .blockingHandler(versionDispatch(
                 ctx -> { bridgeTenant(ctx); bridgeTaskId(ctx); },
                 (body, ctx) -> v10Routes.cancelTask(body, ctx),
-                (body, ctx) -> v03Routes.cancelTask(ctx)));
+                (body, ctx) -> v03Routes.cancelTask(ctx)), false);
 
         // POST /v1/tasks/{taskId}:subscribe
         router.postWithRegex("^\\/v1\\/tasks\\/(?<taskId>[^/]+):subscribe$")
@@ -79,7 +79,7 @@ public class MultiVersionRestRoutes {
             .blockingHandler(versionDispatchNoBody(
                 ctx -> { bridgeTenant(ctx); bridgeTaskId(ctx); },
                 ctx -> v10Routes.subscribeToTask(ctx),
-                ctx -> v03Routes.resubscribeTask(ctx)));
+                ctx -> v03Routes.resubscribeTask(ctx)), false);
 
         // POST /v1/tasks/{taskId}/pushNotificationConfigs
         router.postWithRegex("^\\/v1\\/tasks\\/(?<taskId>[^/]+)\\/pushNotificationConfigs$")
@@ -88,7 +88,7 @@ public class MultiVersionRestRoutes {
             .blockingHandler(versionDispatch(
                 ctx -> { bridgeTenant(ctx); bridgeTaskId(ctx); },
                 (body, ctx) -> v10Routes.createTaskPushNotificationConfiguration(body, ctx),
-                (body, ctx) -> v03Routes.setTaskPushNotificationConfiguration(body, ctx)));
+                (body, ctx) -> v03Routes.setTaskPushNotificationConfiguration(body, ctx)), false);
 
         // GET /v1/tasks/{taskId}/pushNotificationConfigs/{configId}
         router.getWithRegex("^\\/v1\\/tasks\\/(?<taskId>[^/]+)\\/pushNotificationConfigs\\/(?<configId>[^\\/]+)")
@@ -96,7 +96,7 @@ public class MultiVersionRestRoutes {
             .blockingHandler(versionDispatchNoBody(
                 ctx -> { bridgeTenant(ctx); bridgeTaskId(ctx); },
                 ctx -> v10Routes.getTaskPushNotificationConfiguration(ctx),
-                ctx -> v03Routes.getTaskPushNotificationConfiguration(ctx)));
+                ctx -> v03Routes.getTaskPushNotificationConfiguration(ctx)), false);
 
         // GET /v1/tasks/{taskId}/pushNotificationConfigs
         router.getWithRegex("^\\/v1\\/tasks\\/(?<taskId>[^/]+)\\/pushNotificationConfigs\\/?$")
@@ -104,7 +104,7 @@ public class MultiVersionRestRoutes {
             .blockingHandler(versionDispatchNoBody(
                 ctx -> { bridgeTenant(ctx); bridgeTaskId(ctx); },
                 ctx -> v10Routes.listTaskPushNotificationConfigurations(ctx),
-                ctx -> v03Routes.listTaskPushNotificationConfigurations(ctx)));
+                ctx -> v03Routes.listTaskPushNotificationConfigurations(ctx)), false);
 
         // DELETE /v1/tasks/{taskId}/pushNotificationConfigs/{configId}
         router.deleteWithRegex("^\\/v1\\/tasks\\/(?<taskId>[^/]+)\\/pushNotificationConfigs\\/(?<configId>[^/]+)")
@@ -112,7 +112,7 @@ public class MultiVersionRestRoutes {
             .blockingHandler(versionDispatchNoBody(
                 ctx -> { bridgeTenant(ctx); bridgeTaskId(ctx); },
                 ctx -> v10Routes.deleteTaskPushNotificationConfiguration(ctx),
-                ctx -> v03Routes.deleteTaskPushNotificationConfiguration(ctx)));
+                ctx -> v03Routes.deleteTaskPushNotificationConfiguration(ctx)), false);
 
         // GET /v1/card — v0.3 only (v1.0 uses /{tenant}/extendedAgentCard)
         router.get("/v1/card")
@@ -127,7 +127,7 @@ public class MultiVersionRestRoutes {
                 } catch (Exception e) {
                     VertxSecurityHelper.handleGenericError(ctx);
                 }
-            });
+            }, false);
     }
 
     private static void bridgeTenant(RoutingContext ctx) {

--- a/server-common/src/main/java/org/a2aproject/sdk/server/ServerCallContext.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/ServerCallContext.java
@@ -23,6 +23,14 @@ public class ServerCallContext {
      */
     public static final String STRICT_CONTEXT_VALIDATION_KEY = "strictContextValidation";
 
+    /**
+     * Key for an execution wrapper in the state map.
+     * Value should be a {@link java.util.function.UnaryOperator UnaryOperator&lt;Runnable&gt;} that wraps
+     * the agent execution runnable. Used by gRPC transport to fork the inbound call's context
+     * so that agent outbound calls are isolated from inbound cancellation.
+     */
+    public static final String EXECUTION_WRAPPER_KEY = "executionWrapper";
+
     // TODO Not totally sure yet about these field types
     private final Map<Object, Object> modelConfig = new ConcurrentHashMap<>();
     private final Map<String, Object> state;

--- a/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
@@ -962,7 +962,14 @@ public class DefaultRequestHandler implements RequestHandler {
         // Mark as started to prevent further callback additions (enforced by runtime check)
         runnable.markStarted();
 
-        CompletableFuture<Void> cf = CompletableFuture.runAsync(runnable, executor)
+        // Apply transport-provided execution wrapper (e.g. gRPC context fork for cancellation isolation)
+        @SuppressWarnings("unchecked")
+        java.util.function.UnaryOperator<Runnable> wrapper = requestContext.getCallContext() != null
+                ? (java.util.function.UnaryOperator<Runnable>) requestContext.getCallContext().getState().get(ServerCallContext.EXECUTION_WRAPPER_KEY)
+                : null;
+        Runnable wrappedRunnable = wrapper != null ? wrapper.apply(runnable) : runnable;
+
+        CompletableFuture<Void> cf = CompletableFuture.runAsync(wrappedRunnable, executor)
                 .whenComplete((v, err) -> {
                     if (err != null) {
                         LOGGER.error("Agent execution failed for task {}", taskId, err);

--- a/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
+++ b/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
@@ -394,6 +394,19 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
 
         try {
             ServerCallContext context = createCallContext(responseObserver);
+            // Fork the gRPC context so that agent outbound calls are isolated from
+            // the inbound streaming call's cancellation signal. The forked context is
+            // stored as a wrapper so DefaultRequestHandler can apply it without a gRPC dependency.
+            Context forked = Context.current().fork();
+            context.getState().put(ServerCallContext.EXECUTION_WRAPPER_KEY,
+                    (java.util.function.UnaryOperator<Runnable>) (runnable -> () -> {
+                        Context prev = forked.attach();
+                        try {
+                            runnable.run();
+                        } finally {
+                            forked.detach(prev);
+                        }
+                    }));
             A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
             A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             MessageSendParams params = FromProto.messageSendParams(request);
@@ -418,6 +431,18 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
 
         try {
             ServerCallContext context = createCallContext(responseObserver);
+            // Fork context for subscribeToTask too — the EventConsumer polling loop
+            // should not be cancelled when the original inbound call is cancelled
+            Context forkedSub = Context.current().fork();
+            context.getState().put(ServerCallContext.EXECUTION_WRAPPER_KEY,
+                    (java.util.function.UnaryOperator<Runnable>) (runnable -> () -> {
+                        Context prev = forkedSub.attach();
+                        try {
+                            runnable.run();
+                        } finally {
+                            forkedSub.detach(prev);
+                        }
+                    }));
             TaskIdParams params = FromProto.taskIdParams(request);
             Flow.Publisher<StreamingEventKind> publisher = getRequestHandler().onSubscribeToTask(params, context);
             convertToStreamResponse(publisher, responseObserver, context);


### PR DESCRIPTION
Add a Quarkus-based ITK agent that implements the A2A protocol for
cross-SDK interoperability testing against Go, Python, and Java agents.
Includes CI workflows for PR validation and nightly runs.
    
Key components:
- ITK agent module with v1.0 and v0.3 protocol support
- BlockingOffloadInterceptor for gRPC: forks context and offloads 
  handler execution from Vert.x event loop to worker thread, preventing
  deadlocks in separate-server mode
- gRPC context isolation for streaming methods: forks the inbound call's
   context so agent outbound calls are not cancelled when the streaming
   client disconnects
- JsonUtil.readMetadata handles JSON null body gracefully (Go SDK
   sends literal "null" for CancelTask)
- Bug fixes in v0.3 compat layer (FileContentMapper, REST/JSONRPC
   route registration)
