### PR TITLE
feat: expose HTTP response headers in A2AHttpResponse and A2AClientHT…

### DIFF
--- a/client/transport/jsonrpc/src/main/java/org/a2aproject/sdk/client/transport/jsonrpc/JSONRPCTransport.java
+++ b/client/transport/jsonrpc/src/main/java/org/a2aproject/sdk/client/transport/jsonrpc/JSONRPCTransport.java
@@ -328,7 +328,7 @@ public class JSONRPCTransport implements ClientTransport {
         if (!response.success()) {
             int status = response.status();
             String message = "Request failed with HTTP " + status;
-            throw new A2AClientException(message, new A2AClientHTTPError(status, message, response.body()));
+            throw new A2AClientException(message, new A2AClientHTTPError(status, message, response.body(), response.headers().toMap()));
         }
         return response.body();
     }

--- a/client/transport/jsonrpc/src/test/java/org/a2aproject/sdk/client/transport/jsonrpc/JSONRPCTransportTest.java
+++ b/client/transport/jsonrpc/src/test/java/org/a2aproject/sdk/client/transport/jsonrpc/JSONRPCTransportTest.java
@@ -728,13 +728,11 @@ public class JSONRPCTransportTest {
             assertNotNull(headers);
             assertFalse(headers.isEmpty());
 
-            List<String> retryAfter = headers.getOrDefault("Retry-After",
-                    headers.getOrDefault("retry-after", List.of()));
+            List<String> retryAfter = headers.getOrDefault("Retry-After", List.of());
             assertFalse(retryAfter.isEmpty(), "Expected Retry-After header");
             assertEquals("120", retryAfter.get(0));
 
-            List<String> rateLimitRemaining = headers.getOrDefault("X-RateLimit-Remaining",
-                    headers.getOrDefault("x-ratelimit-remaining", List.of()));
+            List<String> rateLimitRemaining = headers.getOrDefault("X-RateLimit-Remaining", List.of());
             assertFalse(rateLimitRemaining.isEmpty(), "Expected X-RateLimit-Remaining header");
             assertEquals("0", rateLimitRemaining.get(0));
         }

--- a/client/transport/jsonrpc/src/test/java/org/a2aproject/sdk/client/transport/jsonrpc/JSONRPCTransportTest.java
+++ b/client/transport/jsonrpc/src/test/java/org/a2aproject/sdk/client/transport/jsonrpc/JSONRPCTransportTest.java
@@ -688,6 +688,59 @@ public class JSONRPCTransportTest {
     }
 
     /**
+     * Test that HTTP error responses expose response headers via A2AClientHTTPError,
+     * enabling callers to read headers like Retry-After on 429 responses.
+     */
+    @Test
+    public void testHttpErrorExposeResponseHeaders() throws Exception {
+        this.server.when(
+                        request()
+                                .withMethod("POST")
+                                .withPath("/")
+                )
+                .respond(
+                        response()
+                                .withStatusCode(429)
+                                .withHeader("Retry-After", "120")
+                                .withHeader("X-RateLimit-Remaining", "0")
+                                .withBody("{\"error\": \"Too Many Requests\"}")
+                );
+
+        JSONRPCTransport client = new JSONRPCTransport("http://localhost:4001");
+        MessageSendParams params = MessageSendParams.builder()
+                .message(Message.builder()
+                        .role(Message.Role.ROLE_USER)
+                        .parts(Collections.singletonList(new TextPart("hello")))
+                        .contextId("ctx")
+                        .messageId("msg")
+                        .build())
+                .build();
+
+        try {
+            client.sendMessage(params, null);
+            fail("Expected A2AClientException to be thrown");
+        } catch (A2AClientException e) {
+            assertInstanceOf(A2AClientHTTPError.class, e.getCause());
+            A2AClientHTTPError httpError = (A2AClientHTTPError) e.getCause();
+            assertEquals(429, httpError.getCode());
+
+            Map<String, List<String>> headers = httpError.getResponseHeaders();
+            assertNotNull(headers);
+            assertFalse(headers.isEmpty());
+
+            List<String> retryAfter = headers.getOrDefault("Retry-After",
+                    headers.getOrDefault("retry-after", List.of()));
+            assertFalse(retryAfter.isEmpty(), "Expected Retry-After header");
+            assertEquals("120", retryAfter.get(0));
+
+            List<String> rateLimitRemaining = headers.getOrDefault("X-RateLimit-Remaining",
+                    headers.getOrDefault("x-ratelimit-remaining", List.of()));
+            assertFalse(rateLimitRemaining.isEmpty(), "Expected X-RateLimit-Remaining header");
+            assertEquals("0", rateLimitRemaining.get(0));
+        }
+    }
+
+    /**
      * Test that VersionNotSupportedError is properly unmarshalled from JSON-RPC error response.
      */
     @Test

--- a/client/transport/rest/src/main/java/org/a2aproject/sdk/client/transport/rest/RestErrorMapper.java
+++ b/client/transport/rest/src/main/java/org/a2aproject/sdk/client/transport/rest/RestErrorMapper.java
@@ -104,10 +104,6 @@ public class RestErrorMapper {
         }
     }
 
-    public static A2AClientException mapRestError(String className, String errorMessage, int code) {
-        return mapRestErrorByClassName(className, errorMessage, code);
-    }
-
     /**
      * Extracts the "reason" and "metadata" fields from the first entry in the "details" array.
      */

--- a/client/transport/rest/src/main/java/org/a2aproject/sdk/client/transport/rest/RestErrorMapper.java
+++ b/client/transport/rest/src/main/java/org/a2aproject/sdk/client/transport/rest/RestErrorMapper.java
@@ -70,7 +70,13 @@ public class RestErrorMapper {
                     String errorMessage = errorObj.has("message") ? errorObj.get("message").getAsString() : "";
                     ReasonAndMetadata reasonAndMetadata = extractReasonAndMetadata(errorObj);
                     if (reasonAndMetadata != null) {
-                        return mapRestErrorByReason(reasonAndMetadata.reason(), errorMessage, reasonAndMetadata.metadata());
+                        A2AClientException known = mapRestErrorByReason(reasonAndMetadata.reason(), errorMessage, reasonAndMetadata.metadata());
+                        if (known.getCause() != null) {
+                            return known;
+                        }
+                        // Unrecognized reason — include HTTP status and headers
+                        String msg = errorMessage.isEmpty() ? "Request failed with HTTP " + code : errorMessage;
+                        return new A2AClientException(msg, new A2AClientHTTPError(code, msg, body, headers));
                     }
                     return new A2AClientException(errorMessage,
                             new A2AClientHTTPError(code, errorMessage, body, headers));
@@ -78,14 +84,23 @@ public class RestErrorMapper {
                 // Legacy format (error class name, message)
                 String className = node.has("error") ? node.get("error").getAsString() : "";
                 String errorMessage = node.has("message") ? node.get("message").getAsString() : "";
-                return mapRestErrorByClassName(className, errorMessage, code);
+                if (!className.isEmpty()) {
+                    A2AClientException known = mapRestErrorByClassName(className, errorMessage, code);
+                    if (known.getCause() != null) {
+                        return known;
+                    }
+                }
+                // Unknown or empty class name — include HTTP status and headers
+                String msg = errorMessage.isEmpty() ? "Request failed with HTTP " + code : errorMessage;
+                return new A2AClientException(msg, new A2AClientHTTPError(code, msg, body, headers));
             }
             String message = "Request failed with HTTP " + code;
             return new A2AClientException(message,
                     new A2AClientHTTPError(code, message, body, headers));
         } catch (JsonProcessingException ex) {
             Logger.getLogger(RestErrorMapper.class.getName()).log(Level.SEVERE, null, ex);
-            return new A2AClientException("Failed to parse error response: " + ex.getMessage());
+            String message = "Failed to parse error response: " + ex.getMessage();
+            return new A2AClientException(message, new A2AClientHTTPError(code, message, body, headers));
         }
     }
 

--- a/client/transport/rest/src/main/java/org/a2aproject/sdk/client/transport/rest/RestErrorMapper.java
+++ b/client/transport/rest/src/main/java/org/a2aproject/sdk/client/transport/rest/RestErrorMapper.java
@@ -1,6 +1,7 @@
 package org.a2aproject.sdk.client.transport.rest;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -10,6 +11,7 @@ import org.a2aproject.sdk.client.http.A2AHttpResponse;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonProcessingException;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonUtil;
 import org.a2aproject.sdk.spec.A2AClientException;
+import org.a2aproject.sdk.spec.A2AClientHTTPError;
 import org.a2aproject.sdk.spec.A2AErrorCodes;
 import org.a2aproject.sdk.spec.ContentTypeNotSupportedError;
 import org.a2aproject.sdk.spec.ExtendedAgentCardNotConfiguredError;
@@ -51,10 +53,14 @@ public class RestErrorMapper {
     );
 
     public static A2AClientException mapRestError(A2AHttpResponse response) {
-        return RestErrorMapper.mapRestError(response.body(), response.status());
+        return RestErrorMapper.mapRestError(response.body(), response.status(), response.headers().toMap());
     }
 
     public static A2AClientException mapRestError(String body, int code) {
+        return mapRestError(body, code, Map.of());
+    }
+
+    public static A2AClientException mapRestError(String body, int code, Map<String, List<String>> headers) {
         try {
             if (body != null && !body.isBlank()) {
                 JsonObject node = JsonUtil.fromJson(body, JsonObject.class);
@@ -66,14 +72,17 @@ public class RestErrorMapper {
                     if (reasonAndMetadata != null) {
                         return mapRestErrorByReason(reasonAndMetadata.reason(), errorMessage, reasonAndMetadata.metadata());
                     }
-                    return new A2AClientException(errorMessage);
+                    return new A2AClientException(errorMessage,
+                            new A2AClientHTTPError(code, errorMessage, body, headers));
                 }
                 // Legacy format (error class name, message)
                 String className = node.has("error") ? node.get("error").getAsString() : "";
                 String errorMessage = node.has("message") ? node.get("message").getAsString() : "";
                 return mapRestErrorByClassName(className, errorMessage, code);
             }
-            return mapRestErrorByClassName("", "", code);
+            String message = "Request failed with HTTP " + code;
+            return new A2AClientException(message,
+                    new A2AClientHTTPError(code, message, body, headers));
         } catch (JsonProcessingException ex) {
             Logger.getLogger(RestErrorMapper.class.getName()).log(Level.SEVERE, null, ex);
             return new A2AClientException("Failed to parse error response: " + ex.getMessage());

--- a/client/transport/rest/src/test/java/org/a2aproject/sdk/client/transport/rest/RestErrorMapperTest.java
+++ b/client/transport/rest/src/test/java/org/a2aproject/sdk/client/transport/rest/RestErrorMapperTest.java
@@ -1,0 +1,130 @@
+package org.a2aproject.sdk.client.transport.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.a2aproject.sdk.client.http.A2AHttpHeaders;
+import org.a2aproject.sdk.client.http.A2AHttpResponse;
+import org.a2aproject.sdk.spec.A2AClientException;
+import org.a2aproject.sdk.spec.A2AClientHTTPError;
+import org.a2aproject.sdk.spec.TaskNotFoundError;
+import org.junit.jupiter.api.Test;
+
+public class RestErrorMapperTest {
+
+    @Test
+    public void testEmptyBodyFallbackIncludesHeaders() {
+        Map<String, List<String>> headers = Map.of("Retry-After", List.of("60"));
+        A2AClientException ex = RestErrorMapper.mapRestError("", 429, headers);
+
+        assertInstanceOf(A2AClientHTTPError.class, ex.getCause());
+        A2AClientHTTPError httpError = (A2AClientHTTPError) ex.getCause();
+        assertEquals(429, httpError.getCode());
+        assertEquals(List.of("60"), httpError.getResponseHeaders().get("Retry-After"));
+    }
+
+    @Test
+    public void testNullBodyFallbackIncludesHeaders() {
+        Map<String, List<String>> headers = Map.of("WWW-Authenticate", List.of("Bearer"));
+        A2AClientException ex = RestErrorMapper.mapRestError(null, 401, headers);
+
+        assertInstanceOf(A2AClientHTTPError.class, ex.getCause());
+        A2AClientHTTPError httpError = (A2AClientHTTPError) ex.getCause();
+        assertEquals(401, httpError.getCode());
+        assertEquals(List.of("Bearer"), httpError.getResponseHeaders().get("WWW-Authenticate"));
+    }
+
+    @Test
+    public void testUnrecognizedGoogleErrorFormatIncludesHeaders() {
+        String body = "{\"error\": {\"code\": 503, \"message\": \"Service Unavailable\"}}";
+        Map<String, List<String>> headers = Map.of("Retry-After", List.of("30"));
+        A2AClientException ex = RestErrorMapper.mapRestError(body, 503, headers);
+
+        assertInstanceOf(A2AClientHTTPError.class, ex.getCause());
+        A2AClientHTTPError httpError = (A2AClientHTTPError) ex.getCause();
+        assertEquals(503, httpError.getCode());
+        assertEquals(List.of("30"), httpError.getResponseHeaders().get("Retry-After"));
+    }
+
+    @Test
+    public void testRecognizedA2AErrorDoesNotWrapInHttpError() {
+        String body = "{\"error\": {\"code\": 404, \"status\": \"NOT_FOUND\", \"message\": \"Task not found\", " +
+                "\"details\": [{\"reason\": \"TASK_NOT_FOUND\"}]}}";
+        A2AClientException ex = RestErrorMapper.mapRestError(body, 404, Map.of());
+
+        assertInstanceOf(TaskNotFoundError.class, ex.getCause());
+    }
+
+    @Test
+    public void testMapRestErrorFromA2AHttpResponse() {
+        Map<String, List<String>> headerMap = Map.of("X-Custom", List.of("value"));
+        A2AHttpResponse response = new A2AHttpResponse() {
+            @Override
+            public int status() {
+                return 500;
+            }
+
+            @Override
+            public boolean success() {
+                return false;
+            }
+
+            @Override
+            public String body() {
+                return "";
+            }
+
+            @Override
+            public A2AHttpHeaders headers() {
+                return new A2AHttpHeaders() {
+                    @Override
+                    public String firstValue(String name) {
+                        List<String> values = headerMap.get(name);
+                        return values != null && !values.isEmpty() ? values.get(0) : null;
+                    }
+
+                    @Override
+                    public List<String> allValues(String name) {
+                        return headerMap.getOrDefault(name, List.of());
+                    }
+
+                    @Override
+                    public Map<String, List<String>> toMap() {
+                        return headerMap;
+                    }
+                };
+            }
+        };
+
+        A2AClientException ex = RestErrorMapper.mapRestError(response);
+        assertInstanceOf(A2AClientHTTPError.class, ex.getCause());
+        A2AClientHTTPError httpError = (A2AClientHTTPError) ex.getCause();
+        assertEquals(500, httpError.getCode());
+        assertEquals(List.of("value"), httpError.getResponseHeaders().get("X-Custom"));
+    }
+
+    @Test
+    public void testHeaderLookupIsCaseInsensitive() {
+        Map<String, List<String>> headers = Map.of("Retry-After", List.of("60"));
+        A2AClientException ex = RestErrorMapper.mapRestError("", 429, headers);
+
+        A2AClientHTTPError httpError = (A2AClientHTTPError) ex.getCause();
+        assertEquals(List.of("60"), httpError.getResponseHeaders().get("retry-after"));
+        assertEquals(List.of("60"), httpError.getResponseHeaders().get("RETRY-AFTER"));
+    }
+
+    @Test
+    public void testTwoArgOverloadDefaultsToEmptyHeaders() {
+        A2AClientException ex = RestErrorMapper.mapRestError("", 500);
+
+        assertInstanceOf(A2AClientHTTPError.class, ex.getCause());
+        A2AClientHTTPError httpError = (A2AClientHTTPError) ex.getCause();
+        assertNotNull(httpError.getResponseHeaders());
+        assertTrue(httpError.getResponseHeaders().isEmpty());
+    }
+}

--- a/common/src/main/java/org/a2aproject/sdk/util/HttpHeaderUtils.java
+++ b/common/src/main/java/org/a2aproject/sdk/util/HttpHeaderUtils.java
@@ -3,6 +3,7 @@ package org.a2aproject.sdk.util;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 /**
@@ -18,7 +19,8 @@ public final class HttpHeaderUtils {
      *
      * <p>Null keys and null value lists are silently skipped (e.g. the {@code null}
      * status-line key from {@link java.net.HttpURLConnection}).
-     * Individual value lists are defensively copied via {@link List#copyOf(java.util.Collection)}.
+     * Null elements within value lists are filtered out, and the remaining values
+     * are defensively copied.
      *
      * @param headers the source header map
      * @return an unmodifiable, case-insensitive map
@@ -27,7 +29,10 @@ public final class HttpHeaderUtils {
         TreeMap<String, List<String>> copy = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
             if (entry.getKey() != null && entry.getValue() != null) {
-                copy.put(entry.getKey(), List.copyOf(entry.getValue()));
+                List<String> cleanValues = entry.getValue().stream()
+                        .filter(Objects::nonNull)
+                        .toList();
+                copy.put(entry.getKey(), cleanValues);
             }
         }
         return Collections.unmodifiableMap(copy);

--- a/common/src/main/java/org/a2aproject/sdk/util/HttpHeaderUtils.java
+++ b/common/src/main/java/org/a2aproject/sdk/util/HttpHeaderUtils.java
@@ -1,0 +1,35 @@
+package org.a2aproject.sdk.util;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Utilities for creating case-insensitive, immutable snapshots of HTTP header maps.
+ */
+public final class HttpHeaderUtils {
+
+    private HttpHeaderUtils() {
+    }
+
+    /**
+     * Creates an unmodifiable, case-insensitive copy of the given header map.
+     *
+     * <p>Null keys and null value lists are silently skipped (e.g. the {@code null}
+     * status-line key from {@link java.net.HttpURLConnection}).
+     * Individual value lists are defensively copied via {@link List#copyOf(java.util.Collection)}.
+     *
+     * @param headers the source header map
+     * @return an unmodifiable, case-insensitive map
+     */
+    public static Map<String, List<String>> copyOfCaseInsensitive(Map<String, List<String>> headers) {
+        TreeMap<String, List<String>> copy = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            if (entry.getKey() != null && entry.getValue() != null) {
+                copy.put(entry.getKey(), List.copyOf(entry.getValue()));
+            }
+        }
+        return Collections.unmodifiableMap(copy);
+    }
+}

--- a/extras/http-client-android/src/main/java/org/a2aproject/sdk/client/http/AndroidA2AHttpClient.java
+++ b/extras/http-client-android/src/main/java/org/a2aproject/sdk/client/http/AndroidA2AHttpClient.java
@@ -6,6 +6,7 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
 import org.a2aproject.sdk.common.A2AErrorMessages;
+import org.a2aproject.sdk.spec.A2AClientHTTPError;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,11 +18,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -127,10 +126,15 @@ public class AndroidA2AHttpClient implements A2AHttpClient {
 
     protected A2AHttpResponse execute(HttpURLConnection connection) throws IOException {
       int status = connection.getResponseCode();
+      A2AHttpHeaders responseHeaders = fromConnectionHeaders(connection.getHeaderFields());
       if (status == HTTP_UNAUTHORIZED) {
-        throw new IOException(A2AErrorMessages.AUTHENTICATION_FAILED);
+        throw new IOException(A2AErrorMessages.AUTHENTICATION_FAILED,
+            new A2AClientHTTPError(HTTP_UNAUTHORIZED, A2AErrorMessages.AUTHENTICATION_FAILED,
+                null, responseHeaders.toMap()));
       } else if (status == HTTP_FORBIDDEN) {
-        throw new IOException(A2AErrorMessages.AUTHORIZATION_FAILED);
+        throw new IOException(A2AErrorMessages.AUTHORIZATION_FAILED,
+            new A2AClientHTTPError(HTTP_FORBIDDEN, A2AErrorMessages.AUTHORIZATION_FAILED,
+                null, responseHeaders.toMap()));
       }
 
       String body = "";
@@ -141,8 +145,7 @@ public class AndroidA2AHttpClient implements A2AHttpClient {
         body = readStreamWithLimit(is);
       }
 
-      A2AHttpHeaders headers = fromConnectionHeaders(connection.getHeaderFields());
-      return new AndroidHttpResponse(status, body, headers);
+      return new AndroidHttpResponse(status, body, responseHeaders);
     }
 
     protected void processSSEResponse(
@@ -153,11 +156,13 @@ public class AndroidA2AHttpClient implements A2AHttpClient {
       try {
         int status = connection.getResponseCode();
         if (!(status >= HTTP_OK && status < HTTP_MULT_CHOICE)) {
-          if (status == HTTP_UNAUTHORIZED) {
-            errorConsumer.accept(new IOException(A2AErrorMessages.AUTHENTICATION_FAILED));
-            return;
-          } else if (status == HTTP_FORBIDDEN) {
-            errorConsumer.accept(new IOException(A2AErrorMessages.AUTHORIZATION_FAILED));
+          if (status == HTTP_UNAUTHORIZED || status == HTTP_FORBIDDEN) {
+            A2AHttpHeaders responseHeaders = fromConnectionHeaders(connection.getHeaderFields());
+            String msg = status == HTTP_UNAUTHORIZED
+                ? A2AErrorMessages.AUTHENTICATION_FAILED
+                : A2AErrorMessages.AUTHORIZATION_FAILED;
+            errorConsumer.accept(new IOException(msg,
+                new A2AClientHTTPError(status, msg, null, responseHeaders.toMap())));
             return;
           }
 
@@ -312,40 +317,9 @@ public class AndroidA2AHttpClient implements A2AHttpClient {
   }
 
   private static A2AHttpHeaders fromConnectionHeaders(@Nullable Map<String, List<String>> headerFields) {
-    Map<String, List<String>> filtered = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    if (headerFields != null) {
-      for (Map.Entry<String, List<String>> entry : headerFields.entrySet()) {
-        if (entry.getKey() != null && entry.getValue() != null) {
-          filtered.put(entry.getKey(), Collections.unmodifiableList(entry.getValue()));
-        }
-      }
-    }
-    Map<String, List<String>> immutable = Collections.unmodifiableMap(filtered);
-
-    return new A2AHttpHeaders() {
-      @Override
-      public @Nullable String firstValue(String name) {
-        if (name == null) {
-          return null;
-        }
-        List<String> values = immutable.get(name);
-        return (values != null && !values.isEmpty()) ? values.get(0) : null;
-      }
-
-      @Override
-      public List<String> allValues(String name) {
-        if (name == null) {
-          return List.of();
-        }
-        List<String> values = immutable.get(name);
-        return values != null ? values : List.of();
-      }
-
-      @Override
-      public Map<String, List<String>> toMap() {
-        return immutable;
-      }
-    };
+    // HttpURLConnection.getHeaderFields() may include a null key for the HTTP status line;
+    // A2AHttpHeaders.of() filters those out automatically.
+    return A2AHttpHeaders.of(headerFields != null ? headerFields : Map.of());
   }
 
   private record AndroidHttpResponse(int status, String body, A2AHttpHeaders headers) implements A2AHttpResponse {

--- a/extras/http-client-android/src/main/java/org/a2aproject/sdk/client/http/AndroidA2AHttpClient.java
+++ b/extras/http-client-android/src/main/java/org/a2aproject/sdk/client/http/AndroidA2AHttpClient.java
@@ -325,12 +325,18 @@ public class AndroidA2AHttpClient implements A2AHttpClient {
     return new A2AHttpHeaders() {
       @Override
       public @Nullable String firstValue(String name) {
+        if (name == null) {
+          return null;
+        }
         List<String> values = immutable.get(name);
         return (values != null && !values.isEmpty()) ? values.get(0) : null;
       }
 
       @Override
       public List<String> allValues(String name) {
+        if (name == null) {
+          return List.of();
+        }
         List<String> values = immutable.get(name);
         return values != null ? values : List.of();
       }

--- a/extras/http-client-android/src/main/java/org/a2aproject/sdk/client/http/AndroidA2AHttpClient.java
+++ b/extras/http-client-android/src/main/java/org/a2aproject/sdk/client/http/AndroidA2AHttpClient.java
@@ -17,12 +17,17 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
+
+import org.jspecify.annotations.Nullable;
 
 /** Android-specific implementation of {@link A2AHttpClient} using {@link HttpURLConnection}. */
 public class AndroidA2AHttpClient implements A2AHttpClient {
@@ -136,7 +141,8 @@ public class AndroidA2AHttpClient implements A2AHttpClient {
         body = readStreamWithLimit(is);
       }
 
-      return new AndroidHttpResponse(status, body);
+      A2AHttpHeaders headers = fromConnectionHeaders(connection.getHeaderFields());
+      return new AndroidHttpResponse(status, body, headers);
     }
 
     protected void processSSEResponse(
@@ -305,10 +311,46 @@ public class AndroidA2AHttpClient implements A2AHttpClient {
     }
   }
 
-  private record AndroidHttpResponse(int status, String body) implements A2AHttpResponse {
+  private static A2AHttpHeaders fromConnectionHeaders(@Nullable Map<String, List<String>> headerFields) {
+    Map<String, List<String>> filtered = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    if (headerFields != null) {
+      for (Map.Entry<String, List<String>> entry : headerFields.entrySet()) {
+        if (entry.getKey() != null && entry.getValue() != null) {
+          filtered.put(entry.getKey(), Collections.unmodifiableList(entry.getValue()));
+        }
+      }
+    }
+    Map<String, List<String>> immutable = Collections.unmodifiableMap(filtered);
+
+    return new A2AHttpHeaders() {
+      @Override
+      public @Nullable String firstValue(String name) {
+        List<String> values = immutable.get(name);
+        return (values != null && !values.isEmpty()) ? values.get(0) : null;
+      }
+
+      @Override
+      public List<String> allValues(String name) {
+        List<String> values = immutable.get(name);
+        return values != null ? values : List.of();
+      }
+
+      @Override
+      public Map<String, List<String>> toMap() {
+        return immutable;
+      }
+    };
+  }
+
+  private record AndroidHttpResponse(int status, String body, A2AHttpHeaders headers) implements A2AHttpResponse {
     @Override
     public boolean success() {
       return status >= HTTP_OK && status < HTTP_MULT_CHOICE;
+    }
+
+    @Override
+    public A2AHttpHeaders headers() {
+      return headers;
     }
   }
 }

--- a/extras/http-client-vertx/src/main/java/org/a2aproject/sdk/client/http/VertxA2AHttpClient.java
+++ b/extras/http-client-vertx/src/main/java/org/a2aproject/sdk/client/http/VertxA2AHttpClient.java
@@ -652,11 +652,17 @@ public class VertxA2AHttpClient implements A2AHttpClient, AutoCloseable {
         return new A2AHttpHeaders() {
             @Override
             public @Nullable String firstValue(String name) {
+                if (name == null) {
+                    return null;
+                }
                 return headers.get(name);
             }
 
             @Override
             public List<String> allValues(String name) {
+                if (name == null) {
+                    return List.of();
+                }
                 List<String> values = headers.getAll(name);
                 return values != null ? Collections.unmodifiableList(values) : List.of();
             }

--- a/extras/http-client-vertx/src/main/java/org/a2aproject/sdk/client/http/VertxA2AHttpClient.java
+++ b/extras/http-client-vertx/src/main/java/org/a2aproject/sdk/client/http/VertxA2AHttpClient.java
@@ -7,11 +7,9 @@ import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -276,7 +274,8 @@ public class VertxA2AHttpClient implements A2AHttpClient, AutoCloseable {
      * @param headers custom headers to add to the request
      * @param bodyBuffer optional body buffer for POST requests (null for GET/DELETE)
      * @return the HTTP response
-     * @throws IOException if the request fails or returns 401/403
+     * @throws IOException if the request fails; the cause may be an
+     *         {@link org.a2aproject.sdk.spec.A2AClientHTTPError} for HTTP 401/403 responses
      * @throws InterruptedException if the thread is interrupted while waiting
      */
     private A2AHttpResponse executeSyncRequest(
@@ -332,10 +331,19 @@ public class VertxA2AHttpClient implements A2AHttpClient, AutoCloseable {
             HttpResponse<Buffer> response = ar.result();
             int status = response.statusCode();
 
-            // Check for authentication/authorization errors
             switch (status) {
-                case HTTP_UNAUTHORIZED -> errorRef.set(new IOException(A2AErrorMessages.AUTHENTICATION_FAILED));
-                case HTTP_FORBIDDEN -> errorRef.set(new IOException(A2AErrorMessages.AUTHORIZATION_FAILED));
+                case HTTP_UNAUTHORIZED -> {
+                    A2AHttpHeaders headers = fromVertxHeaders(response.headers());
+                    errorRef.set(new IOException(A2AErrorMessages.AUTHENTICATION_FAILED,
+                            new org.a2aproject.sdk.spec.A2AClientHTTPError(
+                                    HTTP_UNAUTHORIZED, A2AErrorMessages.AUTHENTICATION_FAILED, null, headers.toMap())));
+                }
+                case HTTP_FORBIDDEN -> {
+                    A2AHttpHeaders headers = fromVertxHeaders(response.headers());
+                    errorRef.set(new IOException(A2AErrorMessages.AUTHORIZATION_FAILED,
+                            new org.a2aproject.sdk.spec.A2AClientHTTPError(
+                                    HTTP_FORBIDDEN, A2AErrorMessages.AUTHORIZATION_FAILED, null, headers.toMap())));
+                }
                 default -> {
                     String body = response.bodyAsString();
                     A2AHttpHeaders headers = fromVertxHeaders(response.headers());
@@ -394,10 +402,13 @@ public class VertxA2AHttpClient implements A2AHttpClient, AutoCloseable {
                     int statusCode = response.statusCode();
                     if (statusCode == HTTP_UNAUTHORIZED || statusCode == HTTP_FORBIDDEN) {
                         if (futureCompleted.compareAndSet(false, true)) {
-                            IOException error = (statusCode == HTTP_UNAUTHORIZED)
-                                    ? new IOException(A2AErrorMessages.AUTHENTICATION_FAILED)
-                                    : new IOException(A2AErrorMessages.AUTHORIZATION_FAILED);
-                            errorConsumer.accept(error);
+                            A2AHttpHeaders respHeaders = fromVertxHeaders(response.headers());
+                            String msg = statusCode == HTTP_UNAUTHORIZED
+                                    ? A2AErrorMessages.AUTHENTICATION_FAILED
+                                    : A2AErrorMessages.AUTHORIZATION_FAILED;
+                            errorConsumer.accept(new IOException(msg,
+                                    new org.a2aproject.sdk.spec.A2AClientHTTPError(
+                                            statusCode, msg, null, respHeaders.toMap())));
                             future.complete(null);
                         }
                         return;
@@ -478,12 +489,8 @@ public class VertxA2AHttpClient implements A2AHttpClient, AutoCloseable {
          * the asynchronous HTTP request completes. The underlying Vert.x operation executes
          * asynchronously on the Vert.x event loop.
          *
-         * @throws IOException if the request fails, including:
-         * <ul>
-         * <li>Network errors (connection refused, timeout, etc.)</li>
-         * <li>HTTP 401 Unauthorized - with message from {@link A2AErrorMessages#AUTHENTICATION_FAILED}</li>
-         * <li>HTTP 403 Forbidden - with message from {@link A2AErrorMessages#AUTHORIZATION_FAILED}</li>
-         * </ul>
+         * @throws IOException if the request fails, including network errors, HTTP 401, and HTTP 403;
+         *         the cause may be an {@link org.a2aproject.sdk.spec.A2AClientHTTPError} carrying the response headers
          * @throws InterruptedException if the thread is interrupted while waiting
          */
         @Override
@@ -519,12 +526,8 @@ public class VertxA2AHttpClient implements A2AHttpClient, AutoCloseable {
          * the asynchronous HTTP request completes. The underlying Vert.x operation executes
          * asynchronously on the Vert.x event loop.
          *
-         * @throws IOException if the request fails, including:
-         * <ul>
-         * <li>Network errors (connection refused, timeout, etc.)</li>
-         * <li>HTTP 401 Unauthorized - with message from {@link A2AErrorMessages#AUTHENTICATION_FAILED}</li>
-         * <li>HTTP 403 Forbidden - with message from {@link A2AErrorMessages#AUTHORIZATION_FAILED}</li>
-         * </ul>
+         * @throws IOException if the request fails, including network errors, HTTP 401, and HTTP 403;
+         *         the cause may be an {@link org.a2aproject.sdk.spec.A2AClientHTTPError} carrying the response headers
          * @throws InterruptedException if the thread is interrupted while waiting
          */
         @Override
@@ -554,12 +557,8 @@ public class VertxA2AHttpClient implements A2AHttpClient, AutoCloseable {
          * the asynchronous HTTP request completes. The underlying Vert.x operation executes
          * asynchronously on the Vert.x event loop.
          *
-         * @throws IOException if the request fails, including:
-         * <ul>
-         * <li>Network errors (connection refused, timeout, etc.)</li>
-         * <li>HTTP 401 Unauthorized - with message from {@link A2AErrorMessages#AUTHENTICATION_FAILED}</li>
-         * <li>HTTP 403 Forbidden - with message from {@link A2AErrorMessages#AUTHORIZATION_FAILED}</li>
-         * </ul>
+         * @throws IOException if the request fails, including network errors, HTTP 401, and HTTP 403;
+         *         the cause may be an {@link org.a2aproject.sdk.spec.A2AClientHTTPError} carrying the response headers
          * @throws InterruptedException if the thread is interrupted while waiting
          */
         @Override
@@ -649,33 +648,11 @@ public class VertxA2AHttpClient implements A2AHttpClient, AutoCloseable {
     }
 
     private static A2AHttpHeaders fromVertxHeaders(io.vertx.core.MultiMap headers) {
-        return new A2AHttpHeaders() {
-            @Override
-            public @Nullable String firstValue(String name) {
-                if (name == null) {
-                    return null;
-                }
-                return headers.get(name);
-            }
-
-            @Override
-            public List<String> allValues(String name) {
-                if (name == null) {
-                    return List.of();
-                }
-                List<String> values = headers.getAll(name);
-                return values != null ? Collections.unmodifiableList(values) : List.of();
-            }
-
-            @Override
-            public Map<String, List<String>> toMap() {
-                Map<String, List<String>> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-                for (String name : headers.names()) {
-                    map.put(name, Collections.unmodifiableList(headers.getAll(name)));
-                }
-                return Collections.unmodifiableMap(map);
-            }
-        };
+        Map<String, List<String>> snapshot = new HashMap<>();
+        for (String name : headers.names()) {
+            snapshot.put(name, headers.getAll(name));
+        }
+        return A2AHttpHeaders.of(snapshot);
     }
 
     private record VertxHttpResponse(int status, String body, A2AHttpHeaders headers) implements A2AHttpResponse {

--- a/extras/http-client-vertx/src/main/java/org/a2aproject/sdk/client/http/VertxA2AHttpClient.java
+++ b/extras/http-client-vertx/src/main/java/org/a2aproject/sdk/client/http/VertxA2AHttpClient.java
@@ -7,8 +7,11 @@ import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -335,7 +338,8 @@ public class VertxA2AHttpClient implements A2AHttpClient, AutoCloseable {
                 case HTTP_FORBIDDEN -> errorRef.set(new IOException(A2AErrorMessages.AUTHORIZATION_FAILED));
                 default -> {
                     String body = response.bodyAsString();
-                    responseRef.set(new VertxHttpResponse(status, body != null ? body : ""));
+                    A2AHttpHeaders headers = fromVertxHeaders(response.headers());
+                    responseRef.set(new VertxHttpResponse(status, body != null ? body : "", headers));
                 }
             }
         } else {
@@ -644,7 +648,31 @@ public class VertxA2AHttpClient implements A2AHttpClient, AutoCloseable {
         }
     }
 
-    private record VertxHttpResponse(int status, String body) implements A2AHttpResponse {
+    private static A2AHttpHeaders fromVertxHeaders(io.vertx.core.MultiMap headers) {
+        return new A2AHttpHeaders() {
+            @Override
+            public @Nullable String firstValue(String name) {
+                return headers.get(name);
+            }
+
+            @Override
+            public List<String> allValues(String name) {
+                List<String> values = headers.getAll(name);
+                return values != null ? Collections.unmodifiableList(values) : List.of();
+            }
+
+            @Override
+            public Map<String, List<String>> toMap() {
+                Map<String, List<String>> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+                for (String name : headers.names()) {
+                    map.put(name, Collections.unmodifiableList(headers.getAll(name)));
+                }
+                return Collections.unmodifiableMap(map);
+            }
+        };
+    }
+
+    private record VertxHttpResponse(int status, String body, A2AHttpHeaders headers) implements A2AHttpResponse {
 
         @Override
         public int status() {
@@ -659,6 +687,11 @@ public class VertxA2AHttpClient implements A2AHttpClient, AutoCloseable {
         @Override
         public String body() {
             return body;
+        }
+
+        @Override
+        public A2AHttpHeaders headers() {
+            return headers;
         }
     }
 }

--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/A2ACardResolver.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/A2ACardResolver.java
@@ -11,6 +11,8 @@ import org.a2aproject.sdk.grpc.utils.JSONRPCUtils;
 import org.a2aproject.sdk.grpc.utils.ProtoUtils;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonProcessingException;
 import org.a2aproject.sdk.spec.A2AClientError;
+import org.a2aproject.sdk.spec.A2AClientException;
+import org.a2aproject.sdk.spec.A2AClientHTTPError;
 import org.a2aproject.sdk.spec.A2AClientJSONError;
 import org.a2aproject.sdk.spec.AgentCard;
 import org.a2aproject.sdk.util.Utils;
@@ -226,11 +228,12 @@ public class A2ACardResolver {
      * is performed; errors are propagated directly to the caller.
      *
      * @return the agent card
-     * @throws A2AClientError If an HTTP or network error occurs fetching the card
+     * @throws A2AClientException If an HTTP error occurs fetching the card (with {@link A2AClientHTTPError} as cause)
+     * @throws A2AClientError If a network error occurs fetching the card
      * @throws A2AClientJSONError If the response body cannot be decoded as JSON or validated
      * against the AgentCard schema
      */
-    public AgentCard getAgentCard() throws A2AClientError, A2AClientJSONError {
+    public AgentCard getAgentCard() throws A2AClientException, A2AClientJSONError {
         LOGGER.debug("Fetching agent card from URL: {}", cardUrl);
 
         A2AHttpClient.GetBuilder builder = httpClient.createGet()
@@ -245,8 +248,10 @@ public class A2ACardResolver {
         try {
             A2AHttpResponse response = builder.get();
             if (!response.success()) {
+                String msg = "Failed to obtain agent card: " + response.status();
                 LOGGER.debug("Failed to fetch agent card from {}, status: {}", cardUrl, response.status());
-                throw new A2AClientError("Failed to obtain agent card: " + response.status());
+                throw new A2AClientException(msg,
+                        new A2AClientHTTPError(response.status(), msg, response.body(), response.headers().toMap()));
             }
             body = response.body();
             LOGGER.debug("Successfully fetched agent card from {}", cardUrl);

--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/A2ACardResolver.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/A2ACardResolver.java
@@ -11,7 +11,6 @@ import org.a2aproject.sdk.grpc.utils.JSONRPCUtils;
 import org.a2aproject.sdk.grpc.utils.ProtoUtils;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonProcessingException;
 import org.a2aproject.sdk.spec.A2AClientError;
-import org.a2aproject.sdk.spec.A2AClientException;
 import org.a2aproject.sdk.spec.A2AClientHTTPError;
 import org.a2aproject.sdk.spec.A2AClientJSONError;
 import org.a2aproject.sdk.spec.AgentCard;
@@ -228,12 +227,12 @@ public class A2ACardResolver {
      * is performed; errors are propagated directly to the caller.
      *
      * @return the agent card
-     * @throws A2AClientException If an HTTP error occurs fetching the card (with {@link A2AClientHTTPError} as cause)
+     * @throws A2AClientHTTPError If the server returns a non-2xx response (carries status, body, and headers)
      * @throws A2AClientError If a network error occurs fetching the card
      * @throws A2AClientJSONError If the response body cannot be decoded as JSON or validated
      * against the AgentCard schema
      */
-    public AgentCard getAgentCard() throws A2AClientException, A2AClientJSONError {
+    public AgentCard getAgentCard() throws A2AClientError, A2AClientJSONError {
         LOGGER.debug("Fetching agent card from URL: {}", cardUrl);
 
         A2AHttpClient.GetBuilder builder = httpClient.createGet()
@@ -250,8 +249,7 @@ public class A2ACardResolver {
             if (!response.success()) {
                 String msg = "Failed to obtain agent card: " + response.status();
                 LOGGER.debug("Failed to fetch agent card from {}, status: {}", cardUrl, response.status());
-                throw new A2AClientException(msg,
-                        new A2AClientHTTPError(response.status(), msg, response.body(), response.headers().toMap()));
+                throw new A2AClientHTTPError(response.status(), msg, response.body(), response.headers().toMap());
             }
             body = response.body();
             LOGGER.debug("Successfully fetched agent card from {}", cardUrl);

--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/A2AHttpHeaders.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/A2AHttpHeaders.java
@@ -1,7 +1,9 @@
 package org.a2aproject.sdk.client.http;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.jspecify.annotations.Nullable;
 
@@ -77,4 +79,47 @@ public interface A2AHttpHeaders {
      * @return map of header names to lists of values
      */
     Map<String, List<String>> toMap();
+
+    /**
+     * Creates an {@link A2AHttpHeaders} instance from a map of header name to value lists.
+     *
+     * <p>Builds a case-insensitive snapshot: null keys and null value lists are silently
+     * skipped (e.g. the {@code null} status-line key from {@link java.net.HttpURLConnection}).
+     *
+     * @param headers the source header map; may be null-keyed
+     * @return an immutable, case-insensitive {@link A2AHttpHeaders} view
+     */
+    static A2AHttpHeaders of(Map<String, List<String>> headers) {
+        TreeMap<String, List<String>> copy = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            if (entry.getKey() != null && entry.getValue() != null) {
+                copy.put(entry.getKey(), List.copyOf(entry.getValue()));
+            }
+        }
+        Map<String, List<String>> immutable = Collections.unmodifiableMap(copy);
+        return new A2AHttpHeaders() {
+            @Override
+            public @Nullable String firstValue(String name) {
+                if (name == null) {
+                    return null;
+                }
+                List<String> values = immutable.get(name);
+                return (values != null && !values.isEmpty()) ? values.get(0) : null;
+            }
+
+            @Override
+            public List<String> allValues(String name) {
+                if (name == null) {
+                    return List.of();
+                }
+                List<String> values = immutable.get(name);
+                return values != null ? values : List.of();
+            }
+
+            @Override
+            public Map<String, List<String>> toMap() {
+                return immutable;
+            }
+        };
+    }
 }

--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/A2AHttpHeaders.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/A2AHttpHeaders.java
@@ -1,10 +1,9 @@
 package org.a2aproject.sdk.client.http;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
+import org.a2aproject.sdk.util.HttpHeaderUtils;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -90,13 +89,7 @@ public interface A2AHttpHeaders {
      * @return an immutable, case-insensitive {@link A2AHttpHeaders} view
      */
     static A2AHttpHeaders of(Map<String, List<String>> headers) {
-        TreeMap<String, List<String>> copy = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
-            if (entry.getKey() != null && entry.getValue() != null) {
-                copy.put(entry.getKey(), List.copyOf(entry.getValue()));
-            }
-        }
-        Map<String, List<String>> immutable = Collections.unmodifiableMap(copy);
+        Map<String, List<String>> immutable = HttpHeaderUtils.copyOfCaseInsensitive(headers);
         return new A2AHttpHeaders() {
             @Override
             public @Nullable String firstValue(String name) {

--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/A2AHttpHeaders.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/A2AHttpHeaders.java
@@ -1,0 +1,80 @@
+package org.a2aproject.sdk.client.http;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Read-only abstraction over HTTP response headers.
+ *
+ * <p>Header names are case-insensitive per RFC 7230. Implementations must
+ * perform case-insensitive lookup for all accessor methods.
+ *
+ * <p>HTTP headers may have multiple values for the same name (e.g. Set-Cookie).
+ * Use {@link #allValues(String)} to retrieve all values, or {@link #firstValue(String)}
+ * when only a single value is expected (e.g. Retry-After, Content-Type).
+ *
+ * <h2>Usage Example</h2>
+ * <pre>{@code
+ * A2AHttpResponse response = client.createPost()
+ *     .url("http://localhost:9999/message:send")
+ *     .body(jsonBody)
+ *     .post();
+ *
+ * if (!response.success()) {
+ *     String retryAfter = response.headers().firstValue("Retry-After");
+ *     // Handle rate limiting
+ * }
+ * }</pre>
+ *
+ * @see A2AHttpResponse#headers()
+ */
+public interface A2AHttpHeaders {
+
+    /**
+     * Empty headers instance returned by default when headers are not available.
+     */
+    A2AHttpHeaders EMPTY = new A2AHttpHeaders() {
+        @Override
+        public @Nullable String firstValue(String name) {
+            return null;
+        }
+
+        @Override
+        public List<String> allValues(String name) {
+            return List.of();
+        }
+
+        @Override
+        public Map<String, List<String>> toMap() {
+            return Map.of();
+        }
+    };
+
+    /**
+     * Returns the first value for the given header name, or {@code null} if not present.
+     *
+     * @param name the header name (case-insensitive)
+     * @return the first header value, or {@code null}
+     */
+    @Nullable
+    String firstValue(String name);
+
+    /**
+     * Returns all values for the given header name.
+     *
+     * @param name the header name (case-insensitive)
+     * @return an unmodifiable list of values, empty if the header is not present
+     */
+    List<String> allValues(String name);
+
+    /**
+     * Returns an unmodifiable map of all headers.
+     *
+     * <p>The keys in the returned map are in their original casing from the response.
+     *
+     * @return map of header names to lists of values
+     */
+    Map<String, List<String>> toMap();
+}

--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/A2AHttpResponse.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/A2AHttpResponse.java
@@ -44,4 +44,16 @@ public interface A2AHttpResponse {
      * @return the response body, may be empty but not null
      */
     String body();
+
+    /**
+     * Returns the HTTP response headers.
+     *
+     * <p>Provides access to response headers such as {@code Retry-After},
+     * {@code WWW-Authenticate}, or any other server-provided headers.
+     *
+     * @return the response headers, never null; may be empty
+     */
+    default A2AHttpHeaders headers() {
+        return A2AHttpHeaders.EMPTY;
+    }
 }

--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/JdkA2AHttpClient.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/JdkA2AHttpClient.java
@@ -16,9 +16,11 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpResponse.BodySubscribers;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -396,7 +398,9 @@ public class JdkA2AHttpClient implements A2AHttpClient {
 
                 @Override
                 public Map<String, List<String>> toMap() {
-                    return jdkHeaders.map();
+                    Map<String, List<String>> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+                    map.putAll(jdkHeaders.map());
+                    return Collections.unmodifiableMap(map);
                 }
             };
         }

--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/JdkA2AHttpClient.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/JdkA2AHttpClient.java
@@ -379,6 +379,27 @@ public class JdkA2AHttpClient implements A2AHttpClient {
         public String body() {
             return response.body();
         }
+
+        @Override
+        public A2AHttpHeaders headers() {
+            java.net.http.HttpHeaders jdkHeaders = response.headers();
+            return new A2AHttpHeaders() {
+                @Override
+                public @Nullable String firstValue(String name) {
+                    return jdkHeaders.firstValue(name).orElse(null);
+                }
+
+                @Override
+                public List<String> allValues(String name) {
+                    return jdkHeaders.allValues(name);
+                }
+
+                @Override
+                public Map<String, List<String>> toMap() {
+                    return jdkHeaders.map();
+                }
+            };
+        }
     }
 }
 

--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/JdkA2AHttpClient.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/JdkA2AHttpClient.java
@@ -388,11 +388,17 @@ public class JdkA2AHttpClient implements A2AHttpClient {
             return new A2AHttpHeaders() {
                 @Override
                 public @Nullable String firstValue(String name) {
+                    if (name == null) {
+                        return null;
+                    }
                     return jdkHeaders.firstValue(name).orElse(null);
                 }
 
                 @Override
                 public List<String> allValues(String name) {
+                    if (name == null) {
+                        return List.of();
+                    }
                     return jdkHeaders.allValues(name);
                 }
 

--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/JdkA2AHttpClient.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/JdkA2AHttpClient.java
@@ -16,11 +16,9 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpResponse.BodySubscribers;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -28,6 +26,7 @@ import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 
 import org.a2aproject.sdk.common.A2AErrorMessages;
+import org.a2aproject.sdk.spec.A2AClientHTTPError;
 
 /**
  * Default HTTP client implementation using JDK 11+ {@link HttpClient}.
@@ -207,17 +206,17 @@ public class JdkA2AHttpClient implements A2AHttpClient {
             BodyHandler<Void> bodyHandler = responseInfo -> {
                 // Check for authentication/authorization errors only
                 if (responseInfo.statusCode() == HTTP_UNAUTHORIZED || responseInfo.statusCode() == HTTP_FORBIDDEN) {
-                    final String errorMessage;
-                    if (responseInfo.statusCode() == HTTP_UNAUTHORIZED) {
-                        errorMessage = A2AErrorMessages.AUTHENTICATION_FAILED;
-                    } else {
-                        errorMessage = A2AErrorMessages.AUTHORIZATION_FAILED;
-                    }
+                    final int statusCode = responseInfo.statusCode();
+                    final String errorMessage = statusCode == HTTP_UNAUTHORIZED
+                            ? A2AErrorMessages.AUTHENTICATION_FAILED
+                            : A2AErrorMessages.AUTHORIZATION_FAILED;
+                    final A2AClientHTTPError httpError = new A2AClientHTTPError(
+                            statusCode, errorMessage, null, responseInfo.headers().map());
                     // Return a body subscriber that immediately signals error
                     return BodySubscribers.fromSubscriber(new Flow.Subscriber<List<ByteBuffer>>() {
                         @Override
                         public void onSubscribe(Flow.Subscription subscription) {
-                            subscriber.onError(new IOException(errorMessage));
+                            subscriber.onError(new IOException(errorMessage, httpError));
                         }
 
                         @Override
@@ -277,9 +276,13 @@ public class JdkA2AHttpClient implements A2AHttpClient {
                     httpClient.send(request, BodyHandlers.ofString(StandardCharsets.UTF_8));
 
             if (response.statusCode() == HTTP_UNAUTHORIZED) {
-                throw new IOException(A2AErrorMessages.AUTHENTICATION_FAILED);
+                throw new IOException(A2AErrorMessages.AUTHENTICATION_FAILED,
+                        new A2AClientHTTPError(HTTP_UNAUTHORIZED, A2AErrorMessages.AUTHENTICATION_FAILED,
+                                null, response.headers().map()));
             } else if (response.statusCode() == HTTP_FORBIDDEN) {
-                throw new IOException(A2AErrorMessages.AUTHORIZATION_FAILED);
+                throw new IOException(A2AErrorMessages.AUTHORIZATION_FAILED,
+                        new A2AClientHTTPError(HTTP_FORBIDDEN, A2AErrorMessages.AUTHORIZATION_FAILED,
+                                null, response.headers().map()));
             }
 
             return new JdkHttpResponse(response);
@@ -306,9 +309,13 @@ public class JdkA2AHttpClient implements A2AHttpClient {
                     httpClient.send(request, BodyHandlers.ofString(StandardCharsets.UTF_8));
 
             if (response.statusCode() == HTTP_UNAUTHORIZED) {
-                throw new IOException(A2AErrorMessages.AUTHENTICATION_FAILED);
+                throw new IOException(A2AErrorMessages.AUTHENTICATION_FAILED,
+                        new A2AClientHTTPError(HTTP_UNAUTHORIZED, A2AErrorMessages.AUTHENTICATION_FAILED,
+                                null, response.headers().map()));
             } else if (response.statusCode() == HTTP_FORBIDDEN) {
-                throw new IOException(A2AErrorMessages.AUTHORIZATION_FAILED);
+                throw new IOException(A2AErrorMessages.AUTHORIZATION_FAILED,
+                        new A2AClientHTTPError(HTTP_FORBIDDEN, A2AErrorMessages.AUTHORIZATION_FAILED,
+                                null, response.headers().map()));
             }
 
             return new JdkHttpResponse(response);
@@ -342,9 +349,13 @@ public class JdkA2AHttpClient implements A2AHttpClient {
                     httpClient.send(request, BodyHandlers.ofString(StandardCharsets.UTF_8));
 
             if (response.statusCode() == HTTP_UNAUTHORIZED) {
-                throw new IOException(A2AErrorMessages.AUTHENTICATION_FAILED);
+                throw new IOException(A2AErrorMessages.AUTHENTICATION_FAILED,
+                        new A2AClientHTTPError(HTTP_UNAUTHORIZED, A2AErrorMessages.AUTHENTICATION_FAILED,
+                                null, response.headers().map()));
             } else if (response.statusCode() == HTTP_FORBIDDEN) {
-                throw new IOException(A2AErrorMessages.AUTHORIZATION_FAILED);
+                throw new IOException(A2AErrorMessages.AUTHORIZATION_FAILED,
+                        new A2AClientHTTPError(HTTP_FORBIDDEN, A2AErrorMessages.AUTHORIZATION_FAILED,
+                                null, response.headers().map()));
             }
 
             return new JdkHttpResponse(response);
@@ -384,31 +395,7 @@ public class JdkA2AHttpClient implements A2AHttpClient {
 
         @Override
         public A2AHttpHeaders headers() {
-            java.net.http.HttpHeaders jdkHeaders = response.headers();
-            return new A2AHttpHeaders() {
-                @Override
-                public @Nullable String firstValue(String name) {
-                    if (name == null) {
-                        return null;
-                    }
-                    return jdkHeaders.firstValue(name).orElse(null);
-                }
-
-                @Override
-                public List<String> allValues(String name) {
-                    if (name == null) {
-                        return List.of();
-                    }
-                    return jdkHeaders.allValues(name);
-                }
-
-                @Override
-                public Map<String, List<String>> toMap() {
-                    Map<String, List<String>> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-                    map.putAll(jdkHeaders.map());
-                    return Collections.unmodifiableMap(map);
-                }
-            };
+            return A2AHttpHeaders.of(response.headers().map());
         }
     }
 }

--- a/http-client/src/test/java/org/a2aproject/sdk/client/http/A2ACardResolverTest.java
+++ b/http-client/src/test/java/org/a2aproject/sdk/client/http/A2ACardResolverTest.java
@@ -1,6 +1,7 @@
 package org.a2aproject.sdk.client.http;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -17,6 +18,8 @@ import org.a2aproject.sdk.grpc.utils.JSONRPCUtils;
 import org.a2aproject.sdk.grpc.utils.ProtoUtils;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonProcessingException;
 import org.a2aproject.sdk.spec.A2AClientError;
+import org.a2aproject.sdk.spec.A2AClientException;
+import org.a2aproject.sdk.spec.A2AClientHTTPError;
 import org.a2aproject.sdk.spec.A2AClientJSONError;
 import org.a2aproject.sdk.spec.AgentCard;
 import org.junit.jupiter.api.Test;
@@ -134,8 +137,10 @@ public class A2ACardResolverTest {
         TestHttpClient client = createTestClient();
         client.status = 503;
         A2ACardResolver resolver = A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com/").build();
-        A2AClientError error = assertThrows(A2AClientError.class, resolver::getAgentCard);
+        A2AClientException error = assertThrows(A2AClientException.class, resolver::getAgentCard);
         assertTrue(error.getMessage().contains("503"));
+        A2AClientHTTPError httpError = assertInstanceOf(A2AClientHTTPError.class, error.getCause());
+        assertEquals(503, httpError.getCode());
     }
 
     @Test
@@ -147,7 +152,8 @@ public class A2ACardResolverTest {
                 .baseUrl("http://example.com")
                 .agentCardPath("/custom/agent.json")
                 .build();
-        assertThrows(A2AClientError.class, resolver::getAgentCard);
+        A2AClientException error = assertThrows(A2AClientException.class, resolver::getAgentCard);
+        assertInstanceOf(A2AClientHTTPError.class, error.getCause());
         assertEquals(1, client.urlsCalled.size());
         assertEquals("http://example.com/custom/agent.json", client.urlsCalled.get(0));
     }

--- a/http-client/src/test/java/org/a2aproject/sdk/client/http/A2ACardResolverTest.java
+++ b/http-client/src/test/java/org/a2aproject/sdk/client/http/A2ACardResolverTest.java
@@ -1,7 +1,6 @@
 package org.a2aproject.sdk.client.http;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -18,7 +17,6 @@ import org.a2aproject.sdk.grpc.utils.JSONRPCUtils;
 import org.a2aproject.sdk.grpc.utils.ProtoUtils;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonProcessingException;
 import org.a2aproject.sdk.spec.A2AClientError;
-import org.a2aproject.sdk.spec.A2AClientException;
 import org.a2aproject.sdk.spec.A2AClientHTTPError;
 import org.a2aproject.sdk.spec.A2AClientJSONError;
 import org.a2aproject.sdk.spec.AgentCard;
@@ -137,10 +135,9 @@ public class A2ACardResolverTest {
         TestHttpClient client = createTestClient();
         client.status = 503;
         A2ACardResolver resolver = A2ACardResolver.builder().httpClient(client).baseUrl("http://example.com/").build();
-        A2AClientException error = assertThrows(A2AClientException.class, resolver::getAgentCard);
+        A2AClientHTTPError error = assertThrows(A2AClientHTTPError.class, resolver::getAgentCard);
         assertTrue(error.getMessage().contains("503"));
-        A2AClientHTTPError httpError = assertInstanceOf(A2AClientHTTPError.class, error.getCause());
-        assertEquals(503, httpError.getCode());
+        assertEquals(503, error.getCode());
     }
 
     @Test
@@ -152,8 +149,8 @@ public class A2ACardResolverTest {
                 .baseUrl("http://example.com")
                 .agentCardPath("/custom/agent.json")
                 .build();
-        A2AClientException error = assertThrows(A2AClientException.class, resolver::getAgentCard);
-        assertInstanceOf(A2AClientHTTPError.class, error.getCause());
+        A2AClientHTTPError error = assertThrows(A2AClientHTTPError.class, resolver::getAgentCard);
+        assertEquals(404, error.getCode());
         assertEquals(1, client.urlsCalled.size());
         assertEquals("http://example.com/custom/agent.json", client.urlsCalled.get(0));
     }

--- a/http-client/src/test/java/org/a2aproject/sdk/client/http/AbstractA2AHttpClientIntegrationTest.java
+++ b/http-client/src/test/java/org/a2aproject/sdk/client/http/AbstractA2AHttpClientIntegrationTest.java
@@ -2,18 +2,22 @@ package org.a2aproject.sdk.client.http;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 import org.a2aproject.sdk.common.A2AErrorMessages;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockserver.integration.ClientAndServer;
-
-import java.io.IOException;
 
 public abstract class AbstractA2AHttpClientIntegrationTest {
 
@@ -212,5 +216,97 @@ public abstract class AbstractA2AHttpClientIntegrationTest {
         assertEquals(404, response.status());
         assertFalse(response.success());
         assertEquals("Not Found", response.body());
+    }
+
+    @Test
+    public void testResponseHeadersOnSuccess() throws Exception {
+        mockServer
+                .when(request().withMethod("GET").withPath("/test"))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withHeader("X-Custom-Header", "custom-value")
+                        .withHeader("X-Request-Id", "abc-123")
+                        .withBody("ok"));
+
+        A2AHttpResponse response = client.createGet()
+                .url(getBaseUrl() + "/test")
+                .get();
+
+        assertEquals(200, response.status());
+        A2AHttpHeaders headers = response.headers();
+        assertNotNull(headers);
+        assertEquals("custom-value", headers.firstValue("X-Custom-Header"));
+        assertEquals("abc-123", headers.firstValue("X-Request-Id"));
+    }
+
+    @Test
+    public void testResponseHeadersCaseInsensitive() throws Exception {
+        mockServer
+                .when(request().withMethod("GET").withPath("/test"))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{}"));
+
+        A2AHttpResponse response = client.createGet()
+                .url(getBaseUrl() + "/test")
+                .get();
+
+        A2AHttpHeaders headers = response.headers();
+        assertEquals(headers.firstValue("Content-Type"), headers.firstValue("content-type"));
+    }
+
+    @Test
+    public void testResponseHeadersOnErrorStatus() throws Exception {
+        mockServer
+                .when(request().withMethod("POST").withPath("/test"))
+                .respond(response()
+                        .withStatusCode(429)
+                        .withHeader("Retry-After", "120")
+                        .withBody("Too Many Requests"));
+
+        A2AHttpResponse response = client.createPost()
+                .url(getBaseUrl() + "/test")
+                .body("{}")
+                .post();
+
+        assertEquals(429, response.status());
+        assertFalse(response.success());
+        A2AHttpHeaders headers = response.headers();
+        assertEquals("120", headers.firstValue("Retry-After"));
+    }
+
+    @Test
+    public void testResponseHeadersMissingHeader() throws Exception {
+        mockServer
+                .when(request().withMethod("GET").withPath("/test"))
+                .respond(response().withStatusCode(200).withBody("ok"));
+
+        A2AHttpResponse response = client.createGet()
+                .url(getBaseUrl() + "/test")
+                .get();
+
+        A2AHttpHeaders headers = response.headers();
+        assertNull(headers.firstValue("X-Nonexistent"));
+        assertEquals(List.of(), headers.allValues("X-Nonexistent"));
+    }
+
+    @Test
+    public void testResponseHeadersToMap() throws Exception {
+        mockServer
+                .when(request().withMethod("GET").withPath("/test"))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withHeader("X-Test", "value1")
+                        .withBody("ok"));
+
+        A2AHttpResponse response = client.createGet()
+                .url(getBaseUrl() + "/test")
+                .get();
+
+        Map<String, List<String>> headerMap = response.headers().toMap();
+        assertNotNull(headerMap);
+        assertFalse(headerMap.isEmpty());
+        assertTrue(headerMap.containsKey("X-Test") || headerMap.containsKey("x-test"));
     }
 }

--- a/spec/src/main/java/org/a2aproject/sdk/spec/A2AClientHTTPError.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/A2AClientHTTPError.java
@@ -114,7 +114,7 @@ public class A2AClientHTTPError extends A2AClientError {
         TreeMap<String, List<String>> copy = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (Map.Entry<String, List<String>> entry : responseHeaders.entrySet()) {
             if (entry.getKey() != null && entry.getValue() != null) {
-                copy.put(entry.getKey(), entry.getValue().stream().filter(v -> v != null).toList());
+                copy.put(entry.getKey(), List.copyOf(entry.getValue()));
             }
         }
         this.responseHeaders = Collections.unmodifiableMap(copy);

--- a/spec/src/main/java/org/a2aproject/sdk/spec/A2AClientHTTPError.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/A2AClientHTTPError.java
@@ -1,11 +1,10 @@
 package org.a2aproject.sdk.spec;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.HttpHeaderUtils;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -111,13 +110,7 @@ public class A2AClientHTTPError extends A2AClientError {
         this.code = code;
         this.message = message;
         this.responseBody = responseBody;
-        TreeMap<String, List<String>> copy = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        for (Map.Entry<String, List<String>> entry : responseHeaders.entrySet()) {
-            if (entry.getKey() != null && entry.getValue() != null) {
-                copy.put(entry.getKey(), List.copyOf(entry.getValue()));
-            }
-        }
-        this.responseHeaders = Collections.unmodifiableMap(copy);
+        this.responseHeaders = HttpHeaderUtils.copyOfCaseInsensitive(responseHeaders);
     }
 
     /**

--- a/spec/src/main/java/org/a2aproject/sdk/spec/A2AClientHTTPError.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/A2AClientHTTPError.java
@@ -114,7 +114,7 @@ public class A2AClientHTTPError extends A2AClientError {
         TreeMap<String, List<String>> copy = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (Map.Entry<String, List<String>> entry : responseHeaders.entrySet()) {
             if (entry.getKey() != null && entry.getValue() != null) {
-                copy.put(entry.getKey(), List.copyOf(entry.getValue()));
+                copy.put(entry.getKey(), entry.getValue().stream().filter(v -> v != null).toList());
             }
         }
         this.responseHeaders = Collections.unmodifiableMap(copy);

--- a/spec/src/main/java/org/a2aproject/sdk/spec/A2AClientHTTPError.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/A2AClientHTTPError.java
@@ -85,7 +85,9 @@ public class A2AClientHTTPError extends A2AClientError {
      * @param code the HTTP status code (e.g. 401, 503)
      * @param message the error message
      * @param responseBody the raw HTTP response body, may be {@code null}
+     * @deprecated Use {@link #A2AClientHTTPError(int, String, String, Map)} instead to preserve the response headers.
      */
+    @Deprecated(since = "1.0.0.Beta1", forRemoval = true)
     public A2AClientHTTPError(int code, String message, @Nullable String responseBody) {
         Assert.checkNotNullParam("message", message);
         this.code = code;

--- a/spec/src/main/java/org/a2aproject/sdk/spec/A2AClientHTTPError.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/A2AClientHTTPError.java
@@ -1,5 +1,10 @@
 package org.a2aproject.sdk.spec;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
 import org.a2aproject.sdk.util.Assert;
 import org.jspecify.annotations.Nullable;
 
@@ -18,14 +23,17 @@ import org.jspecify.annotations.Nullable;
  * <p>
  * This exception is set as the cause of {@link A2AClientException} so that callers
  * can inspect the HTTP status code while remaining backward compatible:
- * <pre>{@code
+ * <pre>
  * } catch (A2AClientException e) {
  *     if (e.getCause() instanceof A2AClientHTTPError httpError) {
- *         int status = httpError.getCode();           // e.g. 401, 503
- *         String body = httpError.getResponseBody();  // raw response body, may be null
+ *         int status = httpError.getCode();
+ *         String body = httpError.getResponseBody();
+ *         Map&lt;String, List&lt;String&gt;&gt; headers = httpError.getResponseHeaders();
+ *         String retryAfter = headers.getOrDefault("Retry-After", List.of())
+ *             .stream().findFirst().orElse(null);
  *     }
  * }
- * }</pre>
+ * </pre>
  *
  * @see A2AClientError for the base client error class
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status">HTTP Status Codes</a>
@@ -48,13 +56,18 @@ public class A2AClientHTTPError extends A2AClientError {
     private final String responseBody;
 
     /**
+     * The HTTP response headers.
+     */
+    private final Map<String, List<String>> responseHeaders;
+
+    /**
      * Creates a new HTTP client error with the specified status code and message.
      *
      * @param code the HTTP status code
      * @param message the error message
      * @param data additional error data (may be the response body)
      * @throws IllegalArgumentException if code or message is null
-     * @deprecated Use {@link #A2AClientHTTPError(int, String, String)} instead to preserve the response body.
+     * @deprecated Use {@link #A2AClientHTTPError(int, String, String, Map)} instead to preserve the response body and headers.
      */
     @Deprecated(since = "1.0.0.Beta1", forRemoval = true)
     public A2AClientHTTPError(int code, String message, Object data) {
@@ -63,6 +76,7 @@ public class A2AClientHTTPError extends A2AClientError {
         this.code = code;
         this.message = message;
         this.responseBody = data instanceof String s ? s : "";
+        this.responseHeaders = Map.of();
     }
 
     /**
@@ -77,6 +91,31 @@ public class A2AClientHTTPError extends A2AClientError {
         this.code = code;
         this.message = message;
         this.responseBody = responseBody;
+        this.responseHeaders = Map.of();
+    }
+
+    /**
+     * Creates a new HTTP client error with the specified status code, message, response body, and headers.
+     *
+     * @param code the HTTP status code (e.g. 429, 503)
+     * @param message the error message
+     * @param responseBody the raw HTTP response body, may be {@code null}
+     * @param responseHeaders the HTTP response headers
+     */
+    public A2AClientHTTPError(int code, String message, @Nullable String responseBody,
+                              Map<String, List<String>> responseHeaders) {
+        Assert.checkNotNullParam("message", message);
+        Assert.checkNotNullParam("responseHeaders", responseHeaders);
+        this.code = code;
+        this.message = message;
+        this.responseBody = responseBody;
+        TreeMap<String, List<String>> copy = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (Map.Entry<String, List<String>> entry : responseHeaders.entrySet()) {
+            if (entry.getKey() != null && entry.getValue() != null) {
+                copy.put(entry.getKey(), List.copyOf(entry.getValue()));
+            }
+        }
+        this.responseHeaders = Collections.unmodifiableMap(copy);
     }
 
     /**
@@ -105,5 +144,17 @@ public class A2AClientHTTPError extends A2AClientError {
      */
     public @Nullable String getResponseBody() {
         return responseBody;
+    }
+
+    /**
+     * Returns the HTTP response headers.
+     *
+     * <p>Useful for examining headers like {@code Retry-After} on 429 responses
+     * or {@code WWW-Authenticate} on 401 responses.
+     *
+     * @return unmodifiable, case-insensitive map of header names to lists of values, never null
+     */
+    public Map<String, List<String>> getResponseHeaders() {
+        return responseHeaders;
     }
 }


### PR DESCRIPTION
…TPError

Add A2AHttpHeaders interface as a transport-independent abstraction over HTTP response headers, with implementations for JDK, Vert.x, and Android HTTP clients. Headers are also propagated into A2AClientHTTPError so callers can access headers like Retry-After (429) and WWW-Authenticate (401) from error responses.

This fixes #920
