### PR TITLE
chore: move nightly ITK run to midnight UTC

### DIFF
--- a/.github/workflows/itk-nightly.yaml
+++ b/.github/workflows/itk-nightly.yaml
@@ -2,7 +2,7 @@ name: Nightly ITK
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Run 4 hours earlier so results are available before the ITK dashboard deploys.
