### PR TITLE
fix: Shorten file names

### DIFF
--- a/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-1/src/main/java/org/a2aproject/sdk/extras/queuemanager/replicated/tests/multiinstance/app1/MIRApp1AgentCardProducer.java
+++ b/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-1/src/main/java/org/a2aproject/sdk/extras/queuemanager/replicated/tests/multiinstance/app1/MIRApp1AgentCardProducer.java
@@ -8,7 +8,7 @@ import org.a2aproject.sdk.server.PublicAgentCard;
 import org.a2aproject.sdk.spec.AgentCard;
 
 @ApplicationScoped
-public class MultiInstanceReplicationApp1AgentCardProducer {
+public class MIRApp1AgentCardProducer {
 
     @Produces
     @PublicAgentCard

--- a/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-1/src/main/java/org/a2aproject/sdk/extras/queuemanager/replicated/tests/multiinstance/app1/MIRApp1AgentExecutorProducer.java
+++ b/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-1/src/main/java/org/a2aproject/sdk/extras/queuemanager/replicated/tests/multiinstance/app1/MIRApp1AgentExecutorProducer.java
@@ -7,7 +7,7 @@ import org.a2aproject.sdk.extras.queuemanager.replicated.tests.multiinstance.com
 import org.a2aproject.sdk.server.agentexecution.AgentExecutor;
 
 @ApplicationScoped
-public class MultiInstanceReplicationApp1AgentExecutorProducer {
+public class MIRApp1AgentExecutorProducer {
 
     @Produces
     public AgentExecutor agentExecutor() {

--- a/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-2/src/main/java/org/a2aproject/sdk/extras/queuemanager/replicated/tests/multiinstance/app2/MIRApp2AgentCardProducer.java
+++ b/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-2/src/main/java/org/a2aproject/sdk/extras/queuemanager/replicated/tests/multiinstance/app2/MIRApp2AgentCardProducer.java
@@ -8,7 +8,7 @@ import org.a2aproject.sdk.server.PublicAgentCard;
 import org.a2aproject.sdk.spec.AgentCard;
 
 @ApplicationScoped
-public class MultiInstanceReplicationApp2AgentCardProducer {
+public class MIRApp2AgentCardProducer {
 
     @Produces
     @PublicAgentCard

--- a/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-2/src/main/java/org/a2aproject/sdk/extras/queuemanager/replicated/tests/multiinstance/app2/MIRApp2AgentExecutorProducer.java
+++ b/extras/queue-manager-replicated/tests-multi-instance/quarkus-app-2/src/main/java/org/a2aproject/sdk/extras/queuemanager/replicated/tests/multiinstance/app2/MIRApp2AgentExecutorProducer.java
@@ -7,7 +7,7 @@ import org.a2aproject.sdk.extras.queuemanager.replicated.tests.multiinstance.com
 import org.a2aproject.sdk.server.agentexecution.AgentExecutor;
 
 @ApplicationScoped
-public class MultiInstanceReplicationApp2AgentExecutorProducer {
+public class MIRApp2AgentExecutorProducer {
 
     @Produces
     public AgentExecutor agentExecutor() {


### PR DESCRIPTION
The Windows CI on the private security fix repo fails on checkout of these files since the names are too long
