### PR TITLE
fix: add no-args constructors to response/request classes for Gson compa…

### DIFF
--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/CancelTaskRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/CancelTaskRequest_v0_3.java
@@ -12,6 +12,10 @@ import org.a2aproject.sdk.util.Assert;
  */
 public final class CancelTaskRequest_v0_3 extends NonStreamingJSONRPCRequest_v0_3<TaskIdParams_v0_3> {
 
+    private CancelTaskRequest_v0_3() {
+    }
+
+
     public static final String METHOD = "tasks/cancel";
 
     public CancelTaskRequest_v0_3(String jsonrpc, Object id, String method, TaskIdParams_v0_3 params) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/CancelTaskResponse_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/CancelTaskResponse_v0_3.java
@@ -6,6 +6,9 @@ package org.a2aproject.sdk.compat03.spec;
 
 public final class CancelTaskResponse_v0_3 extends JSONRPCResponse_v0_3<Task_v0_3> {
 
+    private CancelTaskResponse_v0_3() {
+    }
+
     public CancelTaskResponse_v0_3(String jsonrpc, Object id, Task_v0_3 result, JSONRPCError_v0_3 error) {
         super(jsonrpc, id, result, error, Task_v0_3.class);
     }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/DeleteTaskPushNotificationConfigRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/DeleteTaskPushNotificationConfigRequest_v0_3.java
@@ -10,6 +10,10 @@ import org.a2aproject.sdk.compat03.util.Utils_v0_3;
  */
 public final class DeleteTaskPushNotificationConfigRequest_v0_3 extends NonStreamingJSONRPCRequest_v0_3<DeleteTaskPushNotificationConfigParams_v0_3> {
 
+    private DeleteTaskPushNotificationConfigRequest_v0_3() {
+    }
+
+
     public static final String METHOD = "tasks/pushNotificationConfig/delete";
 
     public DeleteTaskPushNotificationConfigRequest_v0_3(String jsonrpc, Object id, String method, DeleteTaskPushNotificationConfigParams_v0_3 params) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/DeleteTaskPushNotificationConfigResponse_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/DeleteTaskPushNotificationConfigResponse_v0_3.java
@@ -5,6 +5,9 @@ package org.a2aproject.sdk.compat03.spec;
  */
 public final class DeleteTaskPushNotificationConfigResponse_v0_3 extends JSONRPCResponse_v0_3<Void> {
 
+    private DeleteTaskPushNotificationConfigResponse_v0_3() {
+    }
+
     public DeleteTaskPushNotificationConfigResponse_v0_3(String jsonrpc, Object id, Void result, JSONRPCError_v0_3 error) {
         super(jsonrpc, id, result, error, Void.class);
     }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetAuthenticatedExtendedCardRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetAuthenticatedExtendedCardRequest_v0_3.java
@@ -11,6 +11,10 @@ import org.a2aproject.sdk.compat03.util.Utils_v0_3;
  */
 public final class GetAuthenticatedExtendedCardRequest_v0_3 extends NonStreamingJSONRPCRequest_v0_3<Void> {
 
+    private GetAuthenticatedExtendedCardRequest_v0_3() {
+    }
+
+
     public static final String METHOD = "agent/getAuthenticatedExtendedCard";
 
     public GetAuthenticatedExtendedCardRequest_v0_3(String jsonrpc, Object id, String method, Void params) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetAuthenticatedExtendedCardResponse_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetAuthenticatedExtendedCardResponse_v0_3.java
@@ -5,6 +5,9 @@ package org.a2aproject.sdk.compat03.spec;
  */
 public final class GetAuthenticatedExtendedCardResponse_v0_3 extends JSONRPCResponse_v0_3<AgentCard_v0_3> {
 
+    private GetAuthenticatedExtendedCardResponse_v0_3() {
+    }
+
     public GetAuthenticatedExtendedCardResponse_v0_3(String jsonrpc, Object id, AgentCard_v0_3 result, JSONRPCError_v0_3 error) {
         super(jsonrpc, id, result, error, AgentCard_v0_3.class);
     }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetTaskPushNotificationConfigRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetTaskPushNotificationConfigRequest_v0_3.java
@@ -10,6 +10,10 @@ import java.util.UUID;
  */
 public final class GetTaskPushNotificationConfigRequest_v0_3 extends NonStreamingJSONRPCRequest_v0_3<GetTaskPushNotificationConfigParams_v0_3> {
 
+    private GetTaskPushNotificationConfigRequest_v0_3() {
+    }
+
+
     public static final String METHOD = "tasks/pushNotificationConfig/get";
 
     public GetTaskPushNotificationConfigRequest_v0_3(String jsonrpc, Object id, String method, GetTaskPushNotificationConfigParams_v0_3 params) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetTaskPushNotificationConfigResponse_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetTaskPushNotificationConfigResponse_v0_3.java
@@ -5,6 +5,9 @@ package org.a2aproject.sdk.compat03.spec;
  */
 public final class GetTaskPushNotificationConfigResponse_v0_3 extends JSONRPCResponse_v0_3<TaskPushNotificationConfig_v0_3> {
 
+    private GetTaskPushNotificationConfigResponse_v0_3() {
+    }
+
     public GetTaskPushNotificationConfigResponse_v0_3(String jsonrpc, Object id, TaskPushNotificationConfig_v0_3 result, JSONRPCError_v0_3 error) {
         super(jsonrpc, id, result, error, TaskPushNotificationConfig_v0_3.class);
     }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetTaskRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetTaskRequest_v0_3.java
@@ -12,6 +12,10 @@ import org.a2aproject.sdk.util.Assert;
  */
 public final class GetTaskRequest_v0_3 extends NonStreamingJSONRPCRequest_v0_3<TaskQueryParams_v0_3> {
 
+    private GetTaskRequest_v0_3() {
+    }
+
+
     public static final String METHOD = "tasks/get";
 
     public GetTaskRequest_v0_3(String jsonrpc, Object id, String method, TaskQueryParams_v0_3 params) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetTaskResponse_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/GetTaskResponse_v0_3.java
@@ -5,6 +5,9 @@ package org.a2aproject.sdk.compat03.spec;
  */
 public final class GetTaskResponse_v0_3 extends JSONRPCResponse_v0_3<Task_v0_3> {
 
+    private GetTaskResponse_v0_3() {
+    }
+
     public GetTaskResponse_v0_3(String jsonrpc, Object id, Task_v0_3 result, JSONRPCError_v0_3 error) {
         super(jsonrpc, id, result, error, Task_v0_3.class);
     }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/JSONRPCErrorResponse_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/JSONRPCErrorResponse_v0_3.java
@@ -7,6 +7,9 @@ import org.a2aproject.sdk.util.Assert;
  */
 public final class JSONRPCErrorResponse_v0_3 extends JSONRPCResponse_v0_3<Void> {
 
+    private JSONRPCErrorResponse_v0_3() {
+    }
+
     /**
      * Constructs a JSON-RPC error response with all fields.
      * <p>

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/ListTaskPushNotificationConfigRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/ListTaskPushNotificationConfigRequest_v0_3.java
@@ -10,6 +10,10 @@ import org.a2aproject.sdk.compat03.util.Utils_v0_3;
  */
 public final class ListTaskPushNotificationConfigRequest_v0_3 extends NonStreamingJSONRPCRequest_v0_3<ListTaskPushNotificationConfigParams_v0_3> {
 
+    private ListTaskPushNotificationConfigRequest_v0_3() {
+    }
+
+
     public static final String METHOD = "tasks/pushNotificationConfig/list";
 
     public ListTaskPushNotificationConfigRequest_v0_3(String jsonrpc, Object id, String method, ListTaskPushNotificationConfigParams_v0_3 params) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/ListTaskPushNotificationConfigResponse_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/ListTaskPushNotificationConfigResponse_v0_3.java
@@ -7,6 +7,9 @@ import java.util.List;
  */
 public final class ListTaskPushNotificationConfigResponse_v0_3 extends JSONRPCResponse_v0_3<List<TaskPushNotificationConfig_v0_3>> {
 
+    private ListTaskPushNotificationConfigResponse_v0_3() {
+    }
+
     public ListTaskPushNotificationConfigResponse_v0_3(String jsonrpc, Object id, List<TaskPushNotificationConfig_v0_3> result, JSONRPCError_v0_3 error) {
         super(jsonrpc, id, result, error, (Class<List<TaskPushNotificationConfig_v0_3>>) (Class<?>) List.class);
     }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SendMessageRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SendMessageRequest_v0_3.java
@@ -11,6 +11,10 @@ import org.a2aproject.sdk.util.Assert;
  */
 public final class SendMessageRequest_v0_3 extends NonStreamingJSONRPCRequest_v0_3<MessageSendParams_v0_3> {
 
+    private SendMessageRequest_v0_3() {
+    }
+
+
     public static final String METHOD = "message/send";
 
     /**

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SendMessageResponse_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SendMessageResponse_v0_3.java
@@ -5,6 +5,9 @@ package org.a2aproject.sdk.compat03.spec;
  */
 public final class SendMessageResponse_v0_3 extends JSONRPCResponse_v0_3<EventKind_v0_3> {
 
+    private SendMessageResponse_v0_3() {
+    }
+
     public SendMessageResponse_v0_3(String jsonrpc, Object id, EventKind_v0_3 result, JSONRPCError_v0_3 error) {
         super(jsonrpc, id, result, error, EventKind_v0_3.class);
     }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SendStreamingMessageRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SendStreamingMessageRequest_v0_3.java
@@ -11,6 +11,10 @@ import java.util.UUID;
  */
 public final class SendStreamingMessageRequest_v0_3 extends StreamingJSONRPCRequest_v0_3<MessageSendParams_v0_3> {
 
+    private SendStreamingMessageRequest_v0_3() {
+    }
+
+
     public static final String METHOD = "message/stream";
 
     public SendStreamingMessageRequest_v0_3(String jsonrpc, Object id, String method, MessageSendParams_v0_3 params) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SendStreamingMessageResponse_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SendStreamingMessageResponse_v0_3.java
@@ -5,6 +5,9 @@ package org.a2aproject.sdk.compat03.spec;
  */
 public final class SendStreamingMessageResponse_v0_3 extends JSONRPCResponse_v0_3<StreamingEventKind_v0_3> {
 
+    private SendStreamingMessageResponse_v0_3() {
+    }
+
     public SendStreamingMessageResponse_v0_3(String jsonrpc, Object id, StreamingEventKind_v0_3 result, JSONRPCError_v0_3 error) {
         super(jsonrpc, id, result, error, StreamingEventKind_v0_3.class);
     }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SetTaskPushNotificationConfigRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SetTaskPushNotificationConfigRequest_v0_3.java
@@ -11,6 +11,10 @@ import org.a2aproject.sdk.util.Assert;
  */
 public final class SetTaskPushNotificationConfigRequest_v0_3 extends NonStreamingJSONRPCRequest_v0_3<TaskPushNotificationConfig_v0_3> {
 
+    private SetTaskPushNotificationConfigRequest_v0_3() {
+    }
+
+
     public static final String METHOD = "tasks/pushNotificationConfig/set";
 
     public SetTaskPushNotificationConfigRequest_v0_3(String jsonrpc, Object id, String method, TaskPushNotificationConfig_v0_3 params) {

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SetTaskPushNotificationConfigResponse_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/SetTaskPushNotificationConfigResponse_v0_3.java
@@ -5,6 +5,9 @@ package org.a2aproject.sdk.compat03.spec;
  */
 public final class SetTaskPushNotificationConfigResponse_v0_3 extends JSONRPCResponse_v0_3<TaskPushNotificationConfig_v0_3> {
 
+    private SetTaskPushNotificationConfigResponse_v0_3() {
+    }
+
     public SetTaskPushNotificationConfigResponse_v0_3(String jsonrpc, Object id, TaskPushNotificationConfig_v0_3 result, JSONRPCError_v0_3 error) {
         super(jsonrpc, id, result, error, TaskPushNotificationConfig_v0_3.class);
     }

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/TaskResubscriptionRequest_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/spec/TaskResubscriptionRequest_v0_3.java
@@ -11,6 +11,10 @@ import java.util.UUID;
  */
 public final class TaskResubscriptionRequest_v0_3 extends StreamingJSONRPCRequest_v0_3<TaskIdParams_v0_3> {
 
+    private TaskResubscriptionRequest_v0_3() {
+    }
+
+
     public static final String METHOD = "tasks/resubscribe";
 
     public TaskResubscriptionRequest_v0_3(String jsonrpc, Object id, String method, TaskIdParams_v0_3 params) {

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/A2AErrorResponse.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/A2AErrorResponse.java
@@ -23,6 +23,10 @@ import org.a2aproject.sdk.util.Assert;
  */
 public final class A2AErrorResponse extends A2AResponse<Void> {
 
+    private A2AErrorResponse() {
+    }
+
+
     /**
      * Constructs a JSON-RPC error response with all fields.
      * <p>

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/CancelTaskRequest.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/CancelTaskRequest.java
@@ -28,6 +28,10 @@ import org.a2aproject.sdk.spec.TaskState;
  */
 public final class CancelTaskRequest extends NonStreamingJSONRPCRequest<CancelTaskParams> {
 
+    private CancelTaskRequest() {
+    }
+
+
     /**
      * Creates a new CancelTaskRequest with the specified JSON-RPC parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/CancelTaskResponse.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/CancelTaskResponse.java
@@ -24,6 +24,10 @@ import org.a2aproject.sdk.spec.TaskState;
 
 public final class CancelTaskResponse extends A2AResponse<Task> {
 
+    private CancelTaskResponse() {
+    }
+
+
     /**
      * Constructs a CancelTaskResponse with full parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/CreateTaskPushNotificationConfigRequest.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/CreateTaskPushNotificationConfigRequest.java
@@ -21,6 +21,10 @@ import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
  */
 public final class CreateTaskPushNotificationConfigRequest extends NonStreamingJSONRPCRequest<TaskPushNotificationConfig> {
 
+    private CreateTaskPushNotificationConfigRequest() {
+    }
+
+
     /**
      * Constructs request with all parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/CreateTaskPushNotificationConfigResponse.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/CreateTaskPushNotificationConfigResponse.java
@@ -21,6 +21,10 @@ import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
  */
 public final class CreateTaskPushNotificationConfigResponse extends A2AResponse<TaskPushNotificationConfig> {
 
+    private CreateTaskPushNotificationConfigResponse() {
+    }
+
+
     /**
      * Constructs response with all parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/DeleteTaskPushNotificationConfigRequest.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/DeleteTaskPushNotificationConfigRequest.java
@@ -22,6 +22,10 @@ import static org.a2aproject.sdk.spec.A2AMethods.DELETE_TASK_PUSH_NOTIFICATION_C
  */
 public final class DeleteTaskPushNotificationConfigRequest extends NonStreamingJSONRPCRequest<DeleteTaskPushNotificationConfigParams> {
 
+    private DeleteTaskPushNotificationConfigRequest() {
+    }
+
+
     /**
      * Creates a new DeleteTaskPushNotificationConfigRequest with the specified JSON-RPC parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/DeleteTaskPushNotificationConfigResponse.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/DeleteTaskPushNotificationConfigResponse.java
@@ -15,6 +15,10 @@ import org.a2aproject.sdk.spec.A2AError;
  */
 public final class DeleteTaskPushNotificationConfigResponse extends A2AResponse<Void> {
 
+    private DeleteTaskPushNotificationConfigResponse() {
+    }
+
+
     /**
      * Creates a new DeleteTaskPushNotificationConfigResponse with full JSON-RPC parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/GetExtendedAgentCardRequest.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/GetExtendedAgentCardRequest.java
@@ -34,6 +34,10 @@ import org.a2aproject.sdk.spec.ExtendedAgentCardNotConfiguredError;
  */
 public final class GetExtendedAgentCardRequest extends NonStreamingJSONRPCRequest<Void> {
 
+    private GetExtendedAgentCardRequest() {
+    }
+
+
     /**
      * Constructs request with full parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/GetExtendedAgentCardResponse.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/GetExtendedAgentCardResponse.java
@@ -22,6 +22,10 @@ import org.a2aproject.sdk.spec.ExtendedAgentCardNotConfiguredError;
  */
 public final class GetExtendedAgentCardResponse extends A2AResponse<AgentCard> {
 
+    private GetExtendedAgentCardResponse() {
+    }
+
+
     /**
      * Constructs response with full parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/GetTaskPushNotificationConfigRequest.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/GetTaskPushNotificationConfigRequest.java
@@ -22,6 +22,10 @@ import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
  */
 public final class GetTaskPushNotificationConfigRequest extends NonStreamingJSONRPCRequest<GetTaskPushNotificationConfigParams> {
 
+    private GetTaskPushNotificationConfigRequest() {
+    }
+
+
     /**
      * Constructs request with all parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/GetTaskPushNotificationConfigResponse.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/GetTaskPushNotificationConfigResponse.java
@@ -18,6 +18,10 @@ import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
  */
 public final class GetTaskPushNotificationConfigResponse extends A2AResponse<TaskPushNotificationConfig> {
 
+    private GetTaskPushNotificationConfigResponse() {
+    }
+
+
     /**
      * Constructs response with full parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/GetTaskRequest.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/GetTaskRequest.java
@@ -23,6 +23,10 @@ import org.a2aproject.sdk.spec.TaskQueryParams;
  */
 public final class GetTaskRequest extends NonStreamingJSONRPCRequest<TaskQueryParams> {
 
+    private GetTaskRequest() {
+    }
+
+
     /**
      * Constructs request with all parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/GetTaskResponse.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/GetTaskResponse.java
@@ -20,6 +20,10 @@ import org.a2aproject.sdk.spec.TaskNotFoundError;
  */
 public final class GetTaskResponse extends A2AResponse<Task> {
 
+    private GetTaskResponse() {
+    }
+
+
     /**
      * Constructs response with full parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/ListTaskPushNotificationConfigsRequest.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/ListTaskPushNotificationConfigsRequest.java
@@ -23,6 +23,10 @@ import static org.a2aproject.sdk.spec.A2AMethods.LIST_TASK_PUSH_NOTIFICATION_CON
  */
 public final class ListTaskPushNotificationConfigsRequest extends NonStreamingJSONRPCRequest<ListTaskPushNotificationConfigsParams> {
 
+    private ListTaskPushNotificationConfigsRequest() {
+    }
+
+
     /**
      * Constructs request with all parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/ListTaskPushNotificationConfigsResponse.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/ListTaskPushNotificationConfigsResponse.java
@@ -20,6 +20,10 @@ import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
  */
 public final class ListTaskPushNotificationConfigsResponse extends A2AResponse<ListTaskPushNotificationConfigsResult> {
 
+    private ListTaskPushNotificationConfigsResponse() {
+    }
+
+
     /**
      * Constructs response with all parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/ListTasksRequest.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/ListTasksRequest.java
@@ -11,6 +11,10 @@ import org.a2aproject.sdk.spec.ListTasksParams;
  */
 public final class ListTasksRequest extends NonStreamingJSONRPCRequest<ListTasksParams> {
 
+    private ListTasksRequest() {
+    }
+
+
     /**
      * Constructs request with all parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/ListTasksResponse.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/ListTasksResponse.java
@@ -7,6 +7,10 @@ import org.a2aproject.sdk.spec.A2AError;
  */
 public final class ListTasksResponse extends A2AResponse<ListTasksResult> {
 
+    private ListTasksResponse() {
+    }
+
+
     /**
      * Constructs response with all parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/NonStreamingJSONRPCRequest.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/NonStreamingJSONRPCRequest.java
@@ -10,6 +10,9 @@ public abstract sealed class NonStreamingJSONRPCRequest<T> extends A2ARequest<T>
         SendMessageRequest, DeleteTaskPushNotificationConfigRequest, ListTaskPushNotificationConfigsRequest,
         GetExtendedAgentCardRequest, ListTasksRequest {
 
+    NonStreamingJSONRPCRequest() {
+    }
+
     NonStreamingJSONRPCRequest(String jsonrpc, String method, Object id, T params) {
         validateAndSetJsonParameters(jsonrpc, method, id, params, true);
     }

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/SendMessageRequest.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/SendMessageRequest.java
@@ -34,6 +34,10 @@ import org.a2aproject.sdk.spec.Task;
  */
 public final class SendMessageRequest extends NonStreamingJSONRPCRequest<MessageSendParams> {
 
+    private SendMessageRequest() {
+    }
+
+
     /**
      * Constructs a SendMessageRequest with the specified JSON-RPC fields.
      * <p>

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/SendMessageResponse.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/SendMessageResponse.java
@@ -8,6 +8,10 @@ import org.a2aproject.sdk.spec.EventKind;
  */
 public final class SendMessageResponse extends A2AResponse<EventKind> {
 
+    private SendMessageResponse() {
+    }
+
+
     /**
      * Constructs response with all parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/SendStreamingMessageRequest.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/SendStreamingMessageRequest.java
@@ -26,6 +26,10 @@ import org.a2aproject.sdk.spec.StreamingEventKind;
  */
 public final class SendStreamingMessageRequest extends StreamingJSONRPCRequest<MessageSendParams> {
 
+    private SendStreamingMessageRequest() {
+    }
+
+
     /**
      * Constructs request with all parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/SendStreamingMessageResponse.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/SendStreamingMessageResponse.java
@@ -26,6 +26,10 @@ import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
  */
 public final class SendStreamingMessageResponse extends A2AResponse<StreamingEventKind> {
 
+    private SendStreamingMessageResponse() {
+    }
+
+
     /**
      * Constructs response with all parameters.
      *

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/StreamingJSONRPCRequest.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/StreamingJSONRPCRequest.java
@@ -32,6 +32,9 @@ import org.a2aproject.sdk.spec.StreamingEventKind;
 public abstract sealed class StreamingJSONRPCRequest<T> extends A2ARequest<T> permits SubscribeToTaskRequest,
         SendStreamingMessageRequest {
 
+    StreamingJSONRPCRequest() {
+    }
+
     StreamingJSONRPCRequest(String jsonrpc, String method, Object id, T params) {
         validateAndSetJsonParameters(jsonrpc, method, id, params, true);
     }

--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/SubscribeToTaskRequest.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/wrappers/SubscribeToTaskRequest.java
@@ -29,6 +29,10 @@ import org.a2aproject.sdk.spec.TaskIdParams;
  */
 public final class SubscribeToTaskRequest extends StreamingJSONRPCRequest<TaskIdParams> {
 
+    private SubscribeToTaskRequest() {
+    }
+
+
     /**
      * Constructs request with all parameters.
      *


### PR DESCRIPTION
…tibility

Gson's reflective adapter falls back to sun.misc.Unsafe.allocateInstance() when no no-args constructor is available. This fails in modular environments like WildFly's JBoss Modules. Adding no-args constructors lets Gson instantiate these classes directly without Unsafe.

Upstream https://github.com/a2aproject/a2a-java/pull/937