### PR TITLE
fix: handle already-active CDI request context in deferred destruction

### DIFF
--- a/reference/common/src/main/java/org/a2aproject/sdk/server/common/quarkus/VertxSecurityHelper.java
+++ b/reference/common/src/main/java/org/a2aproject/sdk/server/common/quarkus/VertxSecurityHelper.java
@@ -96,11 +96,18 @@ public final class VertxSecurityHelper {
      * the worker thread using {@code await().indefinitely()}, which is safe on worker threads
      * but would block the event loop on event loop threads.
      *
+     * <p><b>Context cleanup:</b> Unlike {@link #runInRequestContextDeferred}, this method calls
+     * {@code terminate()} immediately in the {@code finally} block, so there is no need to register
+     * {@code endHandler}/{@code closeHandler} callbacks — the context and its beans are destroyed
+     * before this method returns. Use this for non-streaming requests where the task runs synchronously
+     * on the calling thread.
+     *
      * @param ctx the Vert.x routing context containing the HTTP request
      * @param task the code to execute within the authenticated request context
      * @throws io.quarkus.security.UnauthorizedException if authentication fails
      * @throws io.quarkus.security.ForbiddenException if authorization fails
      * @throws RuntimeException if the task throws an exception
+     * @see #runInRequestContextDeferred(RoutingContext, Runnable)
      */
     public void runInRequestContext(RoutingContext ctx, Runnable task) {
         if (Context.isOnEventLoopThread()) {
@@ -132,19 +139,27 @@ public final class VertxSecurityHelper {
      * <p>Unlike {@link #runInRequestContext}, this method does <b>not</b> terminate the CDI request
      * context when the task completes. Instead, it:
      * <ol>
-     *   <li>Activates the CDI request context and captures its {@link InjectableContext.ContextState}</li>
+     *   <li>Activates the CDI request context (or captures the existing active state)</li>
      *   <li>Triggers HTTP authentication</li>
      *   <li>Executes the task</li>
-     *   <li><b>Deactivates</b> the context (detaches from the worker thread without destroying beans)</li>
+     *   <li><b>Deactivates</b> the context on the calling thread (without destroying beans) — this
+     *       prevents any external lifecycle manager (e.g. Quarkus's request filter) from calling
+     *       {@code terminate()} and destroying beans while the agent thread is still running</li>
      *   <li>Destroys the context state when the HTTP response ends or the connection closes</li>
      * </ol>
      *
      * <p>This is required for streaming (SSE) requests where the task dispatches work to a background
      * thread (via {@code CompletableFuture.runAsync} with a {@code ManagedExecutor}) and returns
      * immediately. The {@code ManagedExecutor} captures the CDI context at submit time and propagates
-     * it to the agent thread — but only if the context hasn't been destroyed yet. By deferring
+     * it to the agent thread via {@link AsyncManagedExecutorProducer} — but only if the context
+     * hasn't been destroyed yet. By deactivating (not destroying) in the finally block and deferring
      * destruction to the response lifecycle, the agent thread can access all {@code @RequestScoped}
      * beans (including OIDC token credentials for token propagation).
+     *
+     * <p>When the CDI context is already active (e.g. activated by a Quarkus request filter), this
+     * method takes ownership of its destruction lifecycle to ensure it is not prematurely terminated
+     * when the blocking handler thread returns. The context is destroyed by the SSE response
+     * {@code endHandler} / {@code closeHandler} instead.
      *
      * <p>This method is also safe for non-streaming requests: {@code response.end()} is called
      * synchronously inside the task, and the {@code endHandler} fires the cleanup shortly after.
@@ -154,6 +169,8 @@ public final class VertxSecurityHelper {
      * @throws io.quarkus.security.UnauthorizedException if authentication fails
      * @throws io.quarkus.security.ForbiddenException if authorization fails
      * @throws RuntimeException if the task throws an exception
+     * @see #runInRequestContext(RoutingContext, Runnable)
+     * @see AsyncManagedExecutorProducer
      */
     public void runInRequestContextDeferred(RoutingContext ctx, Runnable task) {
         if (Context.isOnEventLoopThread()) {
@@ -161,17 +178,14 @@ public final class VertxSecurityHelper {
                     "Cannot perform blocking authentication on event loop thread. Use blockingHandler().");
         }
         ManagedContext requestContext = Arc.container().requestContext();
-        boolean wasActive = requestContext.isActive();
-        if (wasActive) {
-            if (!httpAuthenticator.isUnsatisfied()) {
-                var identity = httpAuthenticator.get().attemptAuthentication(ctx).await().indefinitely();
-                currentIdentityAssociation.get().setIdentity(identity);
-            }
-            task.run();
-            return;
-        }
-
-        InjectableContext.ContextState state = requestContext.activate();
+        // If already active, capture the existing state; otherwise activate a fresh context.
+        // Either way we take ownership of destruction — deactivate() in finally prevents any
+        // external manager (Quarkus request filter) from calling terminate() and destroying beans
+        // while the ManagedExecutor agent thread is still running. Actual destruction is deferred
+        // to the SSE response endHandler / closeHandler.
+        InjectableContext.ContextState state = requestContext.isActive()
+                ? requestContext.getState()
+                : requestContext.activate();
 
         AtomicBoolean destroyed = new AtomicBoolean(false);
         Runnable cleanup = () -> {
@@ -196,6 +210,9 @@ public final class VertxSecurityHelper {
             cleanup.run();
             throw t;
         } finally {
+            // Deactivate on the calling thread so that Arc's terminate() (called by any external
+            // lifecycle manager when this thread returns) sees isActive() == false and skips its
+            // own destroy(). Destruction is handled exclusively by the cleanup registered above.
             requestContext.deactivate();
         }
     }
@@ -252,4 +269,5 @@ public final class VertxSecurityHelper {
                 .end("Internal Server Error");
         }
     }
+
 }

--- a/reference/common/src/test/java/org/a2aproject/sdk/server/common/quarkus/VertxSecurityHelperTest.java
+++ b/reference/common/src/test/java/org/a2aproject/sdk/server/common/quarkus/VertxSecurityHelperTest.java
@@ -1,0 +1,290 @@
+package org.a2aproject.sdk.server.common.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.inject.Instance;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InjectableContext;
+import io.quarkus.arc.ManagedContext;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class VertxSecurityHelperTest {
+
+    @Mock
+    ArcContainer arcContainer;
+    @Mock
+    ManagedContext requestContext;
+    @Mock
+    InjectableContext.ContextState contextState;
+    @Mock
+    RoutingContext routingContext;
+    @Mock
+    HttpServerResponse response;
+    @Mock
+    Instance<io.quarkus.vertx.http.runtime.security.HttpAuthenticator> httpAuthenticator;
+    @Mock
+    Instance<io.quarkus.security.identity.CurrentIdentityAssociation> currentIdentityAssociation;
+
+    MockedStatic<Arc> arcStatic;
+    MockedStatic<Context> vertxContextStatic;
+
+    VertxSecurityHelper helper;
+
+    AtomicReference<Handler<Void>> capturedEndHandler;
+    AtomicReference<Handler<Void>> capturedCloseHandler;
+
+    @BeforeEach
+    void setUp() {
+        capturedEndHandler = new AtomicReference<>();
+        capturedCloseHandler = new AtomicReference<>();
+
+        arcStatic = mockStatic(Arc.class);
+        vertxContextStatic = mockStatic(Context.class);
+
+        arcStatic.when(Arc::container).thenReturn(arcContainer);
+        vertxContextStatic.when(Context::isOnEventLoopThread).thenReturn(false);
+
+        when(arcContainer.requestContext()).thenReturn(requestContext);
+        when(routingContext.response()).thenReturn(response);
+        when(httpAuthenticator.isUnsatisfied()).thenReturn(true);
+
+        doAnswer(inv -> {
+            capturedEndHandler.set(inv.getArgument(0));
+            return response;
+        }).when(response).endHandler(any());
+        doAnswer(inv -> {
+            capturedCloseHandler.set(inv.getArgument(0));
+            return response;
+        }).when(response).closeHandler(any());
+
+        helper = new VertxSecurityHelper();
+        helper.httpAuthenticator = httpAuthenticator;
+        helper.currentIdentityAssociation = currentIdentityAssociation;
+    }
+
+    @AfterEach
+    void tearDown() {
+        arcStatic.close();
+        vertxContextStatic.close();
+    }
+
+    @Nested
+    class RunInRequestContextDeferredTests {
+
+        @Test
+        void freshContext_activatesAndRegistersCleanupHandlers() {
+            when(requestContext.isActive()).thenReturn(false);
+            doAnswer(inv -> contextState).when(requestContext).activate();
+
+            helper.runInRequestContextDeferred(routingContext, () -> {});
+
+            verify(requestContext).activate();
+            verify(requestContext, never()).getState();
+            verify(response).endHandler(any());
+            verify(response).closeHandler(any());
+            verify(requestContext).deactivate();
+        }
+
+        @Test
+        void preActiveContext_capturesStateInsteadOfActivating() {
+            when(requestContext.isActive()).thenReturn(true);
+            when(requestContext.getState()).thenReturn(contextState);
+
+            helper.runInRequestContextDeferred(routingContext, () -> {});
+
+            verify(requestContext).getState();
+            verify(requestContext, never()).activate();
+        }
+
+        @Test
+        void preActiveContext_registersCleanupHandlersAndDeactivates() {
+            when(requestContext.isActive()).thenReturn(true);
+            when(requestContext.getState()).thenReturn(contextState);
+
+            helper.runInRequestContextDeferred(routingContext, () -> {});
+
+            verify(response).endHandler(any());
+            verify(response).closeHandler(any());
+            verify(requestContext).deactivate();
+        }
+
+        @Test
+        void deactivateCalledInFinally_evenOnSuccess() {
+            when(requestContext.isActive()).thenReturn(false);
+            doAnswer(inv -> contextState).when(requestContext).activate();
+
+            helper.runInRequestContextDeferred(routingContext, () -> {});
+
+            verify(requestContext).deactivate();
+            verify(requestContext, never()).destroy(any(InjectableContext.ContextState.class));
+        }
+
+        @Test
+        void endHandler_destroysContextState() {
+            when(requestContext.isActive()).thenReturn(false);
+            doAnswer(inv -> contextState).when(requestContext).activate();
+
+            helper.runInRequestContextDeferred(routingContext, () -> {});
+
+            capturedEndHandler.get().handle(null);
+
+            verify(requestContext).destroy(contextState);
+        }
+
+        @Test
+        void closeHandler_destroysContextState() {
+            when(requestContext.isActive()).thenReturn(false);
+            doAnswer(inv -> contextState).when(requestContext).activate();
+
+            helper.runInRequestContextDeferred(routingContext, () -> {});
+
+            capturedCloseHandler.get().handle(null);
+
+            verify(requestContext).destroy(contextState);
+        }
+
+        @Test
+        void cleanupIsIdempotent_bothHandlersFire_destroysOnlyOnce() {
+            when(requestContext.isActive()).thenReturn(false);
+            doAnswer(inv -> contextState).when(requestContext).activate();
+
+            helper.runInRequestContextDeferred(routingContext, () -> {});
+
+            capturedEndHandler.get().handle(null);
+            capturedCloseHandler.get().handle(null);
+
+            verify(requestContext, times(1)).destroy(contextState);
+        }
+
+        @Test
+        void taskException_destroysImmediatelyAndDeactivates() {
+            when(requestContext.isActive()).thenReturn(false);
+            doAnswer(inv -> contextState).when(requestContext).activate();
+
+            assertThrows(RuntimeException.class, () ->
+                    helper.runInRequestContextDeferred(routingContext, () -> {
+                        throw new RuntimeException("task failed");
+                    }));
+
+            verify(requestContext).destroy(contextState);
+            verify(requestContext).deactivate();
+        }
+
+        @Test
+        void taskException_subsequentEndHandlerDoesNotDestroyAgain() {
+            when(requestContext.isActive()).thenReturn(false);
+            doAnswer(inv -> contextState).when(requestContext).activate();
+
+            assertThrows(RuntimeException.class, () ->
+                    helper.runInRequestContextDeferred(routingContext, () -> {
+                        throw new RuntimeException();
+                    }));
+
+            capturedEndHandler.get().handle(null);
+
+            verify(requestContext, times(1)).destroy(contextState);
+        }
+
+        @Test
+        void preActiveContext_endHandlerDestroysTheCapturedState() {
+            when(requestContext.isActive()).thenReturn(true);
+            when(requestContext.getState()).thenReturn(contextState);
+
+            helper.runInRequestContextDeferred(routingContext, () -> {});
+
+            capturedEndHandler.get().handle(null);
+
+            verify(requestContext).destroy(contextState);
+        }
+
+        @Test
+        void eventLoopThread_throwsIllegalStateException() {
+            vertxContextStatic.when(Context::isOnEventLoopThread).thenReturn(true);
+
+            assertThrows(IllegalStateException.class, () ->
+                    helper.runInRequestContextDeferred(routingContext, () -> {}));
+        }
+
+        @Test
+        void taskIsExecuted() {
+            when(requestContext.isActive()).thenReturn(false);
+            doAnswer(inv -> contextState).when(requestContext).activate();
+            boolean[] taskRan = {false};
+
+            helper.runInRequestContextDeferred(routingContext, () -> taskRan[0] = true);
+
+            assertTrue(taskRan[0]);
+        }
+    }
+
+    @Nested
+    class RunInRequestContextTests {
+
+        @Test
+        void freshContext_activatesAndTerminates() {
+            when(requestContext.isActive()).thenReturn(false);
+
+            helper.runInRequestContext(routingContext, () -> {});
+
+            verify(requestContext).activate();
+            verify(requestContext).terminate();
+        }
+
+        @Test
+        void preActiveContext_doesNotActivateOrTerminate() {
+            when(requestContext.isActive()).thenReturn(true);
+
+            helper.runInRequestContext(routingContext, () -> {});
+
+            verify(requestContext, never()).activate();
+            verify(requestContext, never()).terminate();
+        }
+
+        @Test
+        void taskException_stillTerminatesWhenFreshContext() {
+            when(requestContext.isActive()).thenReturn(false);
+
+            assertThrows(RuntimeException.class, () ->
+                    helper.runInRequestContext(routingContext, () -> {
+                        throw new RuntimeException("task failed");
+                    }));
+
+            verify(requestContext).terminate();
+        }
+
+        @Test
+        void eventLoopThread_throwsIllegalStateException() {
+            vertxContextStatic.when(Context::isOnEventLoopThread).thenReturn(true);
+
+            assertThrows(IllegalStateException.class, () ->
+                    helper.runInRequestContext(routingContext, () -> {}));
+        }
+    }
+}

--- a/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
@@ -936,7 +936,7 @@ public class DefaultRequestHandler implements RequestHandler {
                 } catch (A2AError e) {
                     // Log A2A errors at WARN level with full stack trace
                     // These are expected business errors but should be tracked
-                    LOGGER.warn("Agent execution threw A2AError for task {}: {} - {}", 
+                    LOGGER.warn("Agent execution threw A2AError for task {}: {} - {}",
                         taskId, e.getClass().getSimpleName(), e.getMessage(), e);
                     emitter.fail(e);
                 } catch (RuntimeException e) {
@@ -958,7 +958,7 @@ public class DefaultRequestHandler implements RequestHandler {
         // CRITICAL: Add callback BEFORE starting CompletableFuture to avoid race condition
         // If agent completes very fast, whenComplete can fire before caller adds callbacks
         runnable.addDoneCallback(doneCallback);
-        
+
         // Mark as started to prevent further callback additions (enforced by runtime check)
         runnable.markStarted();
 


### PR DESCRIPTION
When a Quarkus request filter has already activated the CDI request context before runWithDeferredContextDestruction() is called, the method previously skipped the deferred-destruction logic and ran the task directly. This allowed the request filter to call terminate() and destroy @RequestScoped beans while the ManagedExecutor agent thread was still running, causing failures when accessing OIDC token credentials.

Now the method always takes ownership of the context lifecycle: it captures the existing state (or activates a fresh context), deactivates in the finally block so Arc's terminate() becomes a no-op, and defers actual destruction to the SSE response endHandler/closeHandler.

Fixes #949 🦕