### PR TITLE
fix: improve correctness and remove dead code across modules

### DIFF
--- a/client/transport/rest/src/main/java/org/a2aproject/sdk/client/transport/rest/RestTransport.java
+++ b/client/transport/rest/src/main/java/org/a2aproject/sdk/client/transport/rest/RestTransport.java
@@ -430,11 +430,16 @@ public class RestTransport implements ClientTransport {
     }
 
     private String sendPostRequest(String url, PayloadAndHeaders payloadAndHeaders) throws IOException, InterruptedException, JsonProcessingException {
-        A2AHttpClient.PostBuilder builder = createPostBuilder(url, payloadAndHeaders);
+        MessageOrBuilder payload = (MessageOrBuilder) payloadAndHeaders.getPayload();
+        String body = payload != null ? ProtoJsonUtils.toJson(JsonFormat.printer(), payload) : "";
+        if (log.isLoggable(Level.FINE)) {
+            log.fine(body);
+        }
+        A2AHttpClient.PostBuilder builder = buildPost(url, payloadAndHeaders, body);
         A2AHttpResponse response = builder.post();
         if (!response.success()) {
             if (log.isLoggable(Level.FINE)) {
-                log.fine("Error on POST processing " + ProtoJsonUtils.toJson(JsonFormat.printer(), (MessageOrBuilder) payloadAndHeaders.getPayload()));
+                log.fine("Error on POST processing " + body);
             }
             throw RestErrorMapper.mapRestError(response);
         }
@@ -446,6 +451,10 @@ public class RestTransport implements ClientTransport {
         if (log.isLoggable(Level.FINE)) {
             log.fine(body);
         }
+        return buildPost(url, payloadAndHeaders, body);
+    }
+
+    private A2AHttpClient.PostBuilder buildPost(String url, PayloadAndHeaders payloadAndHeaders, String body) throws JsonProcessingException {
         A2AHttpClient.PostBuilder postBuilder = httpClient.createPost()
                 .url(url)
                 .addHeader("Content-Type", "application/json")

--- a/common/src/main/java/org/a2aproject/sdk/util/HtmlEscapeUtils.java
+++ b/common/src/main/java/org/a2aproject/sdk/util/HtmlEscapeUtils.java
@@ -14,6 +14,9 @@ public final class HtmlEscapeUtils {
      * {@code htmlSafe} is enabled (the default). Restores literal
      * {@code <}, {@code >}, {@code &}, {@code =}, and {@code '}.
      * <p>
+     * Both lowercase ({@code <}) and uppercase ({@code <}) hex digits are handled,
+     * as the JSON specification permits either case for unicode escapes.
+     * <p>
      * Gson also escapes U+2028 (line separator) and U+2029 (paragraph separator) in HTML-safe
      * mode, but those are left as-is because they are valid JSON encodings that preserve the
      * original characters without data corruption.
@@ -22,10 +25,16 @@ public final class HtmlEscapeUtils {
      * @return the JSON string with literal characters restored
      */
     public static String removeHtmlEscaping(String json) {
-        return json.replace("\\u003c", "<")
-                .replace("\\u003e", ">")
+        if (json == null || json.isEmpty()) {
+            return json;
+        }
+        if (!json.contains("\\u00")) {
+            return json;
+        }
+        return json.replace("\\u003c", "<").replace("\\u003C", "<")
+                .replace("\\u003e", ">").replace("\\u003E", ">")
                 .replace("\\u0026", "&")
-                .replace("\\u003d", "=")
+                .replace("\\u003d", "=").replace("\\u003D", "=")
                 .replace("\\u0027", "'");
     }
 }

--- a/common/src/test/java/org/a2aproject/sdk/util/HtmlEscapeUtilsTest.java
+++ b/common/src/test/java/org/a2aproject/sdk/util/HtmlEscapeUtilsTest.java
@@ -43,4 +43,19 @@ public class HtmlEscapeUtilsTest {
         assertEquals("", HtmlEscapeUtils.removeHtmlEscaping(""));
     }
 
+    @Test
+    public void removeHtmlEscaping_restoresUppercaseAngleBrackets() {
+        assertEquals("<event-topic>", HtmlEscapeUtils.removeHtmlEscaping("\\u003Cevent-topic\\u003E"));
+    }
+
+    @Test
+    public void removeHtmlEscaping_restoresUppercaseEquals() {
+        assertEquals("a=b", HtmlEscapeUtils.removeHtmlEscaping("a\\u003Db"));
+    }
+
+    @Test
+    public void removeHtmlEscaping_handlesMixedCase() {
+        assertEquals("<tag>=value", HtmlEscapeUtils.removeHtmlEscaping("\\u003ctag\\u003E\\u003Dvalue"));
+    }
+
 }

--- a/compat-0.3/client/transport/rest/src/main/java/org/a2aproject/sdk/compat03/client/transport/rest/RestTransport_v0_3.java
+++ b/compat-0.3/client/transport/rest/src/main/java/org/a2aproject/sdk/compat03/client/transport/rest/RestTransport_v0_3.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import org.a2aproject.sdk.grpc.utils.ProtoJsonUtils;
 import org.jspecify.annotations.Nullable;
 
 public class RestTransport_v0_3 implements ClientTransport_v0_3 {
@@ -374,11 +375,16 @@ public class RestTransport_v0_3 implements ClientTransport_v0_3 {
     }
 
     private String sendPostRequest(String url, PayloadAndHeaders_v0_3 payloadAndHeaders) throws IOException, InterruptedException, JsonProcessingException_v0_3 {
-        A2AHttpClient.PostBuilder builder = createPostBuilder(url, payloadAndHeaders);
+        MessageOrBuilder payload = (MessageOrBuilder) payloadAndHeaders.getPayload();
+        String body = payload != null ? ProtoJsonUtils.toJson(JsonFormat.printer(), payload) : "";
+        if (log.isLoggable(Level.FINE)) {
+            log.fine(body);
+        }
+        A2AHttpClient.PostBuilder builder = buildPost(url, payloadAndHeaders, body);
         A2AHttpResponse response = builder.post();
         if (!response.success()) {
             if (log.isLoggable(Level.FINE)) {
-                log.fine("Error on POST processing " + ProtoJsonUtils_v0_3.toJson(JsonFormat.printer(), (MessageOrBuilder) payloadAndHeaders.getPayload()));
+                log.fine("Error on POST processing " + body);
             }
             throw RestErrorMapper_v0_3.mapRestError(response);
         }
@@ -390,6 +396,10 @@ public class RestTransport_v0_3 implements ClientTransport_v0_3 {
         if (log.isLoggable(Level.FINE)) {
             log.fine(body);
         }
+        return buildPost(url, payloadAndHeaders, body);
+    }
+
+    private A2AHttpClient.PostBuilder buildPost(String url, PayloadAndHeaders_v0_3 payloadAndHeaders, String body) throws JsonProcessingException_v0_3 {
         A2AHttpClient.PostBuilder postBuilder = httpClient.createPost()
                 .url(url)
                 .addHeader("Content-Type", "application/json")

--- a/compat-0.3/reference/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/server/apps/quarkus/A2AServerRoutes_v0_3.java
+++ b/compat-0.3/reference/jsonrpc/src/main/java/org/a2aproject/sdk/compat03/server/apps/quarkus/A2AServerRoutes_v0_3.java
@@ -300,7 +300,7 @@ public class A2AServerRoutes_v0_3 {
                 user = UnauthenticatedUser.INSTANCE;
             } else {
                 String subject = rc.user().subject();
-                user = new AuthenticatedUser(subject != null ? subject : "");
+                user = subject != null ? new AuthenticatedUser(subject) : UnauthenticatedUser.INSTANCE;
             }
             Map<String, Object> state = new HashMap<>();
 

--- a/compat-0.3/reference/rest/src/main/java/org/a2aproject/sdk/compat03/server/rest/quarkus/A2AServerRoutes_v0_3.java
+++ b/compat-0.3/reference/rest/src/main/java/org/a2aproject/sdk/compat03/server/rest/quarkus/A2AServerRoutes_v0_3.java
@@ -408,7 +408,7 @@ public class A2AServerRoutes_v0_3 {
                 user = UnauthenticatedUser.INSTANCE;
             } else {
                 String subject = rc.user().subject();
-                user = new AuthenticatedUser(subject != null ? subject : "");
+                user = subject != null ? new AuthenticatedUser(subject) : UnauthenticatedUser.INSTANCE;
             }
             Map<String, Object> state = new HashMap<>();
 

--- a/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/util/Utils_v0_3.java
+++ b/compat-0.3/spec/src/main/java/org/a2aproject/sdk/compat03/util/Utils_v0_3.java
@@ -3,7 +3,6 @@ package org.a2aproject.sdk.compat03.util;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.gson.Gson;
 import org.a2aproject.sdk.compat03.json.JsonProcessingException_v0_3;
 import org.a2aproject.sdk.compat03.json.JsonUtil_v0_3;
 
@@ -24,34 +23,17 @@ import java.util.logging.Logger;
  * <p>
  * Key capabilities:
  * <ul>
- * <li>JSON processing with pre-configured {@link Gson}</li>
+ * <li>JSON serialization via {@link #toJsonString(Object)}</li>
  * <li>Null-safe value defaults via {@link #defaultIfNull(Object, Object)}</li>
  * <li>Artifact streaming support via {@link #appendArtifactToTask(Task_v0_3, TaskArtifactUpdateEvent_v0_3, String)}</li>
- * <li>Type-safe exception rethrowing via {@link #rethrow(Throwable)}</li>
  * </ul>
  *
- * @see Gson for JSON processing
  * @see TaskArtifactUpdateEvent_v0_3 for streaming artifact updates
  */
 public class Utils_v0_3 {
 
 
     private static final Logger log = Logger.getLogger(Utils_v0_3.class.getName());
-
-    /**
-     * Deserializes JSON string into a typed object using Gson.
-     * <p>
-     * This method uses the pre-configured {@link JsonUtil_v0_3#OBJECT_MAPPER} to parse JSON.
-     *
-     * @param <T> the target type
-     * @param data JSON string to deserialize
-     * @param typeRef class reference specifying the target type
-     * @return deserialized object of type T
-     * @throws JsonProcessingException_v0_3 if JSON parsing fails
-     */
-    public static <T> T unmarshalFrom(String data, Class<T> typeRef) throws JsonProcessingException_v0_3 {
-        return JsonUtil_v0_3.fromJson(data, typeRef);
-    }
 
     public static String toJsonString(Object data) {
         try {
@@ -66,10 +48,6 @@ public class Utils_v0_3 {
             return defaultValue;
         }
         return value;
-    }
-
-    public static <T extends Throwable> void rethrow(Throwable t) throws T {
-        throw (T) t;
     }
 
     /**

--- a/reference/jsonrpc/src/main/java/org/a2aproject/sdk/server/apps/quarkus/A2AServerRoutes.java
+++ b/reference/jsonrpc/src/main/java/org/a2aproject/sdk/server/apps/quarkus/A2AServerRoutes.java
@@ -559,7 +559,7 @@ public class A2AServerRoutes {
                 user = UnauthenticatedUser.INSTANCE;
             } else {
                 String subject = rc.user().subject();
-                user = new AuthenticatedUser(subject != null ? subject : "");
+                user = subject != null ? new AuthenticatedUser(subject) : UnauthenticatedUser.INSTANCE;
             }
             Map<String, Object> state = new HashMap<>();
             // TODO Python's impl has

--- a/reference/rest/src/main/java/org/a2aproject/sdk/server/rest/quarkus/A2AServerRoutes.java
+++ b/reference/rest/src/main/java/org/a2aproject/sdk/server/rest/quarkus/A2AServerRoutes.java
@@ -890,7 +890,7 @@ public class A2AServerRoutes {
                 user = UnauthenticatedUser.INSTANCE;
             } else {
                 String subject = rc.user().subject();
-                user = new AuthenticatedUser(subject != null ? subject : "");
+                user = subject != null ? new AuthenticatedUser(subject) : UnauthenticatedUser.INSTANCE;
             }
             Map<String, Object> state = new HashMap<>();
 

--- a/server-common/src/main/java/org/a2aproject/sdk/server/ServerCallContext.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/ServerCallContext.java
@@ -31,8 +31,6 @@ public class ServerCallContext {
      */
     public static final String EXECUTION_WRAPPER_KEY = "executionWrapper";
 
-    // TODO Not totally sure yet about these field types
-    private final Map<Object, Object> modelConfig = new ConcurrentHashMap<>();
     private final Map<String, Object> state;
     private final User user;
     private final Set<String> requestedExtensions;

--- a/server-common/src/main/java/org/a2aproject/sdk/server/agentexecution/RequestContext.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/agentexecution/RequestContext.java
@@ -373,14 +373,6 @@ public class RequestContext {
             return task;
         }
 
-        public @Nullable List<Task> getRelatedTasks() {
-            return relatedTasks;
-        }
-
-        public @Nullable ServerCallContext getServerCallContext() {
-            return serverCallContext;
-        }
-
         /**
          * Builds the RequestContext with ID generation and validation.
          *

--- a/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/AuthorizationRequestHandlerDecorator.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/AuthorizationRequestHandlerDecorator.java
@@ -22,6 +22,7 @@ import org.a2aproject.sdk.spec.GetTaskPushNotificationConfigParams;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsParams;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsResult;
 import org.a2aproject.sdk.spec.ListTasksParams;
+import org.a2aproject.sdk.spec.Message;
 import org.a2aproject.sdk.spec.MessageSendParams;
 import org.a2aproject.sdk.spec.StreamingEventKind;
 import org.a2aproject.sdk.spec.Task;
@@ -137,6 +138,9 @@ public class AuthorizationRequestHandlerDecorator implements RequestHandler {
             return e.taskId();
         } else if (event instanceof TaskArtifactUpdateEvent e) {
             return e.taskId();
+        } else if (event instanceof Message m) {
+            // Message.taskId() is set by AgentEmitter when a task context exists
+            return m.taskId();
         }
         return null;
     }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/util/async/AsyncExecutorProducer.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/util/async/AsyncExecutorProducer.java
@@ -133,22 +133,6 @@ public class AsyncExecutorProducer {
         return executor;
     }
 
-    /**
-     * Log current executor pool statistics for diagnostics.
-     * Useful for debugging pool exhaustion or sizing issues.
-     */
-    public void logPoolStats() {
-        if (executor instanceof ThreadPoolExecutor tpe) {
-            LOGGER.info("Executor pool stats: active={}/{}, queued={}/{}, completed={}, total={}",
-                    tpe.getActiveCount(),
-                    tpe.getPoolSize(),
-                    tpe.getQueue().size(),
-                    queueCapacity,
-                    tpe.getCompletedTaskCount(),
-                    tpe.getTaskCount());
-        }
-    }
-
     private static class A2AThreadFactory implements ThreadFactory {
         private final AtomicInteger threadNumber = new AtomicInteger(1);
         private final String namePrefix = "a2a-agent-executor-";

--- a/spec/src/main/java/org/a2aproject/sdk/spec/A2AClientHTTPError.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/A2AClientHTTPError.java
@@ -60,42 +60,6 @@ public class A2AClientHTTPError extends A2AClientError {
     private final Map<String, List<String>> responseHeaders;
 
     /**
-     * Creates a new HTTP client error with the specified status code and message.
-     *
-     * @param code the HTTP status code
-     * @param message the error message
-     * @param data additional error data (may be the response body)
-     * @throws IllegalArgumentException if code or message is null
-     * @deprecated Use {@link #A2AClientHTTPError(int, String, String, Map)} instead to preserve the response body and headers.
-     */
-    @Deprecated(since = "1.0.0.Beta1", forRemoval = true)
-    public A2AClientHTTPError(int code, String message, Object data) {
-        Assert.checkNotNullParam("code", code);
-        Assert.checkNotNullParam("message", message);
-        this.code = code;
-        this.message = message;
-        this.responseBody = data instanceof String s ? s : "";
-        this.responseHeaders = Map.of();
-    }
-
-    /**
-     * Creates a new HTTP client error with the specified status code, message, and response body.
-     *
-     * @param code the HTTP status code (e.g. 401, 503)
-     * @param message the error message
-     * @param responseBody the raw HTTP response body, may be {@code null}
-     * @deprecated Use {@link #A2AClientHTTPError(int, String, String, Map)} instead to preserve the response headers.
-     */
-    @Deprecated(since = "1.0.0.Beta1", forRemoval = true)
-    public A2AClientHTTPError(int code, String message, @Nullable String responseBody) {
-        Assert.checkNotNullParam("message", message);
-        this.code = code;
-        this.message = message;
-        this.responseBody = responseBody;
-        this.responseHeaders = Map.of();
-    }
-
-    /**
      * Creates a new HTTP client error with the specified status code, message, response body, and headers.
      *
      * @param code the HTTP status code (e.g. 429, 503)


### PR DESCRIPTION
- Fix null subject handling in server routes: use UnauthenticatedUser
  instead of AuthenticatedUser with empty string when subject is null
- Handle uppercase hex digits in HtmlEscapeUtils unicode unescaping
  (< in addition to <), with tests
- Extract buildPost() in REST transports to serialize the request body
  once instead of twice (once for logging, once for sending)
- Add Message event handling in AuthorizationRequestHandlerDecorator to
  extract taskId from streaming messages
- Remove deprecated A2AClientHTTPError constructors
- Remove unused methods and fields: Utils_v0_3.unmarshalFrom(),
  Utils_v0_3.rethrow(), ServerCallContext.modelConfig,
  RequestContext.Builder getters, AsyncExecutorProducer.logPoolStats()