### PR TITLE
feat: harden spec immutability

### DIFF
--- a/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/TaskStatusUpdateEventMapper_v0_3_Test.java
+++ b/compat-0.3/server-conversion/src/test/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/TaskStatusUpdateEventMapper_v0_3_Test.java
@@ -1,0 +1,57 @@
+package org.a2aproject.sdk.compat03.conversion.mappers.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.a2aproject.sdk.compat03.spec.TaskState_v0_3;
+import org.a2aproject.sdk.compat03.spec.TaskStatusUpdateEvent_v0_3;
+import org.a2aproject.sdk.compat03.spec.TaskStatus_v0_3;
+import org.a2aproject.sdk.spec.TaskState;
+import org.a2aproject.sdk.spec.TaskStatus;
+import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
+import org.junit.jupiter.api.Test;
+
+class TaskStatusUpdateEventMapper_v0_3_Test {
+
+    @Test
+    void toV10_preservesMetadataAndDefensiveCopy() {
+        Map<String, Object> mutableMetadata = new HashMap<>();
+        mutableMetadata.put("source", "sensor");
+
+        TaskStatusUpdateEvent_v0_3 v03 = new TaskStatusUpdateEvent_v0_3.Builder()
+                .taskId("task-123")
+                .status(new TaskStatus_v0_3(TaskState_v0_3.WORKING))
+                .contextId("context-456")
+                .isFinal(false)
+                .metadata(mutableMetadata)
+                .build();
+
+        TaskStatusUpdateEvent v10 = TaskStatusUpdateEventMapper_v0_3.INSTANCE.toV10(v03);
+        mutableMetadata.put("write", "should-not-leak");
+
+        assertEquals("task-123", v10.taskId());
+        assertEquals(TaskState.TASK_STATE_WORKING, v10.status().state());
+        assertEquals("context-456", v10.contextId());
+        assertEquals(Map.of("source", "sensor"), v10.metadata());
+        assertThrows(UnsupportedOperationException.class, () -> v10.metadata().put("another", "value"));
+    }
+
+    @Test
+    void fromV10_preservesMetadata() {
+        TaskStatusUpdateEvent v10 = new TaskStatusUpdateEvent(
+                "task-123",
+                new TaskStatus(TaskState.TASK_STATE_WORKING),
+                "context-456",
+                Map.of("source", "sensor"));
+
+        TaskStatusUpdateEvent_v0_3 v03 = TaskStatusUpdateEventMapper_v0_3.INSTANCE.fromV10(v10);
+
+        assertEquals("task-123", v03.taskId());
+        assertEquals(TaskState_v0_3.WORKING, v03.status().state());
+        assertEquals("context-456", v03.contextId());
+        assertEquals(Map.of("source", "sensor"), v03.metadata());
+    }
+}

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/InMemoryTaskStoreTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/InMemoryTaskStoreTest.java
@@ -1,0 +1,109 @@
+package org.a2aproject.sdk.server.tasks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.a2aproject.sdk.spec.Artifact;
+import org.a2aproject.sdk.spec.ListTasksParams;
+import org.a2aproject.sdk.spec.Message;
+import org.a2aproject.sdk.spec.Task;
+import org.a2aproject.sdk.spec.TaskState;
+import org.a2aproject.sdk.spec.TaskStatus;
+import org.a2aproject.sdk.spec.TextPart;
+import org.junit.jupiter.api.Test;
+
+public class InMemoryTaskStoreTest {
+
+    @Test
+    public void testSaveAndGet() {
+        InMemoryTaskStore store = new InMemoryTaskStore();
+        Task task = sampleTask("task-abc");
+
+        store.save(task, false);
+
+        Task retrieved = store.get(task.id());
+        assertSame(task, retrieved);
+    }
+
+    @Test
+    public void testGetNonExistent() {
+        InMemoryTaskStore store = new InMemoryTaskStore();
+
+        Task retrieved = store.get("nonexistent");
+        assertNull(retrieved);
+    }
+
+    @Test
+    public void testDelete() {
+        InMemoryTaskStore store = new InMemoryTaskStore();
+        Task task = sampleTask("task-abc");
+
+        store.save(task, false);
+        store.delete(task.id());
+
+        Task retrieved = store.get(task.id());
+        assertNull(retrieved);
+    }
+
+    @Test
+    public void testDeleteNonExistent() {
+        InMemoryTaskStore store = new InMemoryTaskStore();
+
+        store.delete("non-existent");
+    }
+
+    @Test
+    public void testListTransformsHistoryAndArtifacts() {
+        InMemoryTaskStore store = new InMemoryTaskStore();
+        Task task = Task.builder()
+                .id("task-abc")
+                .contextId("session-xyz")
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
+                .history(List.of(sampleMessage("msg-1"), sampleMessage("msg-2")))
+                .artifacts(List.of(sampleArtifact("artifact-1")))
+                .metadata(Map.of("origin", "test"))
+                .build();
+
+        store.save(task, false);
+
+        ListTasksParams params = ListTasksParams.builder().build();
+        List<Task> tasks = store.list(params, null).tasks();
+
+        assertEquals(1, tasks.size());
+        Task listed = tasks.get(0);
+        assertEquals(task.id(), listed.id());
+        assertEquals(task.contextId(), listed.contextId());
+        assertTrue(listed.history().isEmpty(), "Default list() should omit history");
+        assertTrue(listed.artifacts().isEmpty(), "Default list() should omit artifacts");
+        assertEquals(task.metadata(), listed.metadata());
+    }
+
+    private static Task sampleTask(String id) {
+        return Task.builder()
+                .id(id)
+                .contextId("session-xyz")
+                .status(new TaskStatus(TaskState.TASK_STATE_SUBMITTED))
+                .build();
+    }
+
+    private static Message sampleMessage(String messageId) {
+        return Message.builder()
+                .role(Message.Role.ROLE_USER)
+                .parts(List.of(new TextPart("content")))
+                .messageId(messageId)
+                .build();
+    }
+
+    private static Artifact sampleArtifact(String artifactId) {
+        return Artifact.builder()
+                .artifactId(artifactId)
+                .parts(List.of(new TextPart("artifact content")))
+                .build();
+    }
+}
+

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/TaskManagerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/TaskManagerTest.java
@@ -95,8 +95,6 @@ public class TaskManagerTest {
 
         assertEquals(initialTask.id(), updated.id());
         assertEquals(initialTask.contextId(), updated.contextId());
-        // TODO type does not get unmarshalled
-        //assertEquals(initialTask.getType(), updated.getType());
         assertSame(newStatus, updated.status());
     }
 

--- a/spec/src/main/java/org/a2aproject/sdk/spec/A2AError.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/A2AError.java
@@ -3,6 +3,7 @@ package org.a2aproject.sdk.spec;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -54,7 +55,7 @@ public class A2AError extends RuntimeException implements Event {
     public A2AError(Integer code, String message, @Nullable Map<String, Object> details) {
         super(Assert.checkNotNullParam("message", message));
         this.code = Assert.checkNotNullParam("code", code);
-        this.details = details == null ? Map.of() : Map.copyOf(details);
+        this.details = details == null ? Map.of() : CollectionCopies.unmodifiableShallowMap(details);
     }
 
     /**

--- a/spec/src/main/java/org/a2aproject/sdk/spec/AgentCapabilities.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/AgentCapabilities.java
@@ -1,7 +1,9 @@
 package org.a2aproject.sdk.spec;
 
-import java.util.List;
+import org.a2aproject.sdk.util.CollectionCopies;
 import org.jspecify.annotations.Nullable;
+
+import java.util.List;
 
 /**
  * Defines optional capabilities supported by an agent in the A2A Protocol.
@@ -34,6 +36,10 @@ public record AgentCapabilities(boolean streaming,
                                 boolean pushNotifications,
                                 boolean extendedAgentCard,
                                 @Nullable List<AgentExtension> extensions) {
+
+    public AgentCapabilities {
+        extensions = CollectionCopies.immutableNullableList(extensions);
+    }
 
     /**
      * Create a new Builder

--- a/spec/src/main/java/org/a2aproject/sdk/spec/AgentCard.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/AgentCard.java
@@ -1,12 +1,11 @@
 package org.a2aproject.sdk.spec;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
+import org.jspecify.annotations.Nullable;
+
 import java.util.List;
 import java.util.Map;
-
-import org.a2aproject.sdk.util.Assert;
-import org.jspecify.annotations.Nullable;
 
 /**
  * The AgentCard is a self-describing manifest for an agent in the A2A Protocol.
@@ -89,6 +88,14 @@ public record AgentCard(
         Assert.checkNotNullParam("skills", skills);
         Assert.checkNotNullParam("supportedInterfaces", supportedInterfaces);
         Assert.checkNotNullParam("version", version);
+        defaultInputModes = CollectionCopies.immutableList(defaultInputModes);
+        defaultOutputModes = CollectionCopies.immutableList(defaultOutputModes);
+        skills = CollectionCopies.immutableList(skills);
+        securitySchemes = CollectionCopies.immutableNullableMap(securitySchemes);
+        securityRequirements = CollectionCopies.immutableNullableList(securityRequirements);
+        supportedInterfaces = CollectionCopies.immutableList(supportedInterfaces);
+        signatures = CollectionCopies.immutableNullableList(signatures);
+        additionalInterfaces = CollectionCopies.immutableNullableList(additionalInterfaces);
     }
 
     /**
@@ -184,17 +191,17 @@ public record AgentCard(
             this.version = card.version();
             this.documentationUrl = card.documentationUrl();
             this.capabilities = card.capabilities();
-            this.defaultInputModes = card.defaultInputModes() != null ? new ArrayList<>(card.defaultInputModes()) : Collections.emptyList();
-            this.defaultOutputModes = card.defaultOutputModes() != null ? new ArrayList<>(card.defaultOutputModes()) : Collections.emptyList();
-            this.skills = card.skills() != null ? new ArrayList<>(card.skills()) : Collections.emptyList();
-            this.securitySchemes = card.securitySchemes() != null ? Map.copyOf(card.securitySchemes()) : Collections.emptyMap();
-            this.securityRequirements = card.securityRequirements() != null ? new ArrayList<>(card.securityRequirements()) : Collections.emptyList();
+            this.defaultInputModes = CollectionCopies.mutableListCopyOrEmpty(card.defaultInputModes());
+            this.defaultOutputModes = CollectionCopies.mutableListCopyOrEmpty(card.defaultOutputModes());
+            this.skills = CollectionCopies.mutableListCopyOrEmpty(card.skills());
+            this.securitySchemes = CollectionCopies.mutableMapCopyOrEmpty(card.securitySchemes());
+            this.securityRequirements = CollectionCopies.mutableListCopyOrEmpty(card.securityRequirements());
             this.iconUrl = card.iconUrl();
-            this.supportedInterfaces = card.supportedInterfaces() != null ? new ArrayList<>(card.supportedInterfaces()) : Collections.emptyList();
-            this.signatures = card.signatures() != null ? new ArrayList<>(card.signatures()) : null;
-            this.url =  card.url();
-            this.preferredTransport= card.preferredTransport();
-            this.additionalInterfaces = card.additionalInterfaces() != null ? new ArrayList<>(card.additionalInterfaces()) : null;
+            this.supportedInterfaces = CollectionCopies.mutableListCopyOrEmpty(card.supportedInterfaces());
+            this.signatures = CollectionCopies.immutableNullableList(card.signatures());
+            this.url = card.url();
+            this.preferredTransport = card.preferredTransport();
+            this.additionalInterfaces = CollectionCopies.immutableNullableList(card.additionalInterfaces());
         }
 
         /**

--- a/spec/src/main/java/org/a2aproject/sdk/spec/AgentCardSignature.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/AgentCardSignature.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import com.google.gson.annotations.SerializedName;
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -46,6 +47,7 @@ public record AgentCardSignature(@Nullable Map<String, Object> header, @Serializ
     public AgentCardSignature {
         Assert.checkNotNullParam("protectedHeader", protectedHeader);
         Assert.checkNotNullParam("signature", signature);
+        header = CollectionCopies.unmodifiableNullableShallowMap(header);
     }
 
     /**

--- a/spec/src/main/java/org/a2aproject/sdk/spec/AgentExtension.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/AgentExtension.java
@@ -3,6 +3,7 @@ package org.a2aproject.sdk.spec;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -37,6 +38,7 @@ public record AgentExtension (@Nullable String description, @Nullable Map<String
      */
     public AgentExtension {
         Assert.checkNotNullParam("uri", uri);
+        params = CollectionCopies.unmodifiableNullableShallowMap(params);
     }
 
     /**

--- a/spec/src/main/java/org/a2aproject/sdk/spec/AgentSkill.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/AgentSkill.java
@@ -3,6 +3,7 @@ package org.a2aproject.sdk.spec;
 import java.util.List;
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -61,6 +62,11 @@ public record AgentSkill(String id, String name, String description, List<String
         Assert.checkNotNullParam("name", name);
         Assert.checkNotNullParam("description", description);
         Assert.checkNotNullParam("tags", tags);
+        tags = CollectionCopies.immutableList(tags);
+        examples = CollectionCopies.immutableNullableList(examples);
+        inputModes = CollectionCopies.immutableNullableList(inputModes);
+        outputModes = CollectionCopies.immutableNullableList(outputModes);
+        securityRequirements = CollectionCopies.immutableNullableList(securityRequirements);
     }
 
     /**
@@ -237,7 +243,7 @@ public record AgentSkill(String id, String name, String description, List<String
                     Assert.checkNotNullParam("id", id),
                     Assert.checkNotNullParam("name", name),
                     Assert.checkNotNullParam("description", description),
-                    Assert.checkNotNullParam("tags", tags), 
+                    Assert.checkNotNullParam("tags", tags),
                     examples,
                     inputModes,
                     outputModes,

--- a/spec/src/main/java/org/a2aproject/sdk/spec/Artifact.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/Artifact.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -50,6 +51,9 @@ public record Artifact(String artifactId, @Nullable String name, @Nullable Strin
         if (parts.isEmpty()) {
             throw new IllegalArgumentException("Parts cannot be empty");
         }
+        parts = CollectionCopies.immutableList(parts);
+        metadata = CollectionCopies.unmodifiableNullableShallowMap(metadata);
+        extensions = CollectionCopies.immutableNullableList(extensions);
     }
 
     /**
@@ -169,7 +173,7 @@ public record Artifact(String artifactId, @Nullable String name, @Nullable Strin
          * @return this builder for method chaining
          */
         public Builder parts(Part<?>... parts) {
-            this.parts = List.of(parts);
+            this.parts = CollectionCopies.immutableList(List.of(parts));
             return this;
         }
 
@@ -191,7 +195,7 @@ public record Artifact(String artifactId, @Nullable String name, @Nullable Strin
          * @return this builder for method chaining
          */
         public Builder extensions(@Nullable List<String> extensions) {
-            this.extensions = (extensions == null) ? null : List.copyOf(extensions);
+            this.extensions = CollectionCopies.immutableNullableList(extensions);
             return this;
         }
 

--- a/spec/src/main/java/org/a2aproject/sdk/spec/AuthorizationCodeOAuthFlow.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/AuthorizationCodeOAuthFlow.java
@@ -3,6 +3,7 @@ package org.a2aproject.sdk.spec;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 
 /**
  * Configuration for the OAuth 2.0 Authorization Code flow.
@@ -42,5 +43,6 @@ public record AuthorizationCodeOAuthFlow(String authorizationUrl, String refresh
         Assert.checkNotNullParam("authorizationUrl", authorizationUrl);
         Assert.checkNotNullParam("scopes", scopes);
         Assert.checkNotNullParam("tokenUrl", tokenUrl);
+        scopes = CollectionCopies.immutableMap(scopes);
     }
 }

--- a/spec/src/main/java/org/a2aproject/sdk/spec/CancelTaskParams.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/CancelTaskParams.java
@@ -1,8 +1,9 @@
 package org.a2aproject.sdk.spec;
 
-import org.a2aproject.sdk.util.Assert;
-import java.util.Collections;
 import java.util.Map;
+
+import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -27,6 +28,7 @@ public record CancelTaskParams(String id, @Nullable String tenant, Map<String, O
      */
     public CancelTaskParams {
         Assert.checkNotNullParam("id", id);
+        metadata = CollectionCopies.unmodifiableShallowMap(metadata);
     }
 
     /**
@@ -35,7 +37,7 @@ public record CancelTaskParams(String id, @Nullable String tenant, Map<String, O
      * @param id the task identifier (required)
      */
     public CancelTaskParams(String id) {
-        this(id, null, Collections.emptyMap());
+        this(id, null, Map.of());
     }
 
     /**
@@ -53,7 +55,7 @@ public record CancelTaskParams(String id, @Nullable String tenant, Map<String, O
     public static class Builder {
         private @Nullable String id;
         private @Nullable String tenant;
-        private Map<String, Object> metadata = Collections.emptyMap();
+        private Map<String, Object> metadata = Map.of();
 
         /**
          * Creates a new Builder with all fields unset.
@@ -90,7 +92,7 @@ public record CancelTaskParams(String id, @Nullable String tenant, Map<String, O
          * @return this builder
          */
         public Builder metadata(Map<String, Object> metadata) {
-            this.metadata = Map.copyOf(metadata);
+            this.metadata = CollectionCopies.unmodifiableShallowMap(metadata);
             return this;
         }
 

--- a/spec/src/main/java/org/a2aproject/sdk/spec/ClientCredentialsOAuthFlow.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/ClientCredentialsOAuthFlow.java
@@ -1,9 +1,9 @@
 package org.a2aproject.sdk.spec;
 
-
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 
 /**
  * Configuration for the OAuth 2.0 Client Credentials flow.
@@ -38,6 +38,7 @@ public record ClientCredentialsOAuthFlow(String refreshUrl, Map<String, String> 
     public ClientCredentialsOAuthFlow {
         Assert.checkNotNullParam("scopes", scopes);
         Assert.checkNotNullParam("tokenUrl", tokenUrl);
+        scopes = CollectionCopies.immutableMap(scopes);
     }
 
 }

--- a/spec/src/main/java/org/a2aproject/sdk/spec/DataPart.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/DataPart.java
@@ -6,6 +6,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.ToNumberPolicy;
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
 
@@ -68,7 +69,7 @@ public record DataPart(Object data, @Nullable Map<String, Object> metadata) impl
      */
     public DataPart (Object data, @Nullable Map<String, Object> metadata) {
         Assert.checkNotNullParam("data", data);
-        this.metadata = metadata == null ? null : Map.copyOf(metadata);
+        this.metadata = CollectionCopies.unmodifiableNullableShallowMap(metadata);
         this.data = data;
     }
 

--- a/spec/src/main/java/org/a2aproject/sdk/spec/DeviceCodeOAuthFlow.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/DeviceCodeOAuthFlow.java
@@ -3,6 +3,7 @@ package org.a2aproject.sdk.spec;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 
 /**
  * Configuration details for the OAuth 2.0 Device Code flow (RFC 8628).
@@ -33,7 +34,7 @@ public record DeviceCodeOAuthFlow(String deviceAuthorizationUrl, String tokenUrl
         Assert.checkNotNullParam("deviceAuthorizationUrl", deviceAuthorizationUrl);
         Assert.checkNotNullParam("tokenUrl", tokenUrl);
         Assert.checkNotNullParam("scopes", scopes);
-        scopes = Map.copyOf(scopes);
+        scopes = CollectionCopies.immutableMap(scopes);
     }
 
     /**
@@ -43,6 +44,6 @@ public record DeviceCodeOAuthFlow(String deviceAuthorizationUrl, String tokenUrl
      */
     @Override
     public Map<String, String> scopes() {
-        return Map.copyOf(scopes);
+        return scopes;
     }
 }

--- a/spec/src/main/java/org/a2aproject/sdk/spec/FilePart.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/FilePart.java
@@ -2,6 +2,7 @@ package org.a2aproject.sdk.spec;
 
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
 
@@ -57,7 +58,7 @@ public record FilePart(FileContent file, @Nullable Map<String, Object> metadata)
      */
     public FilePart (FileContent file, @Nullable Map<String, Object> metadata) {
         Assert.checkNotNullParam("file", file);
-        this.metadata = metadata == null ? null : Map.copyOf(metadata);
+        this.metadata = CollectionCopies.unmodifiableNullableShallowMap(metadata);
         this.file = file;
     }
 

--- a/spec/src/main/java/org/a2aproject/sdk/spec/ListTaskPushNotificationConfigsResult.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/ListTaskPushNotificationConfigsResult.java
@@ -3,6 +3,7 @@ package org.a2aproject.sdk.spec;
 import java.util.List;
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -23,8 +24,7 @@ public record ListTaskPushNotificationConfigsResult(List<TaskPushNotificationCon
      */
     public ListTaskPushNotificationConfigsResult {
         Assert.checkNotNullParam("configs", configs);
-        // Make defensive copy
-        configs = List.copyOf(configs);
+        configs = CollectionCopies.immutableList(configs);
     }
 
     /**

--- a/spec/src/main/java/org/a2aproject/sdk/spec/Message.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/Message.java
@@ -71,7 +71,7 @@ public record Message(Role role, List<Part<?>> parts,
         }
         parts = CollectionCopies.immutableList(parts);
         referenceTaskIds = CollectionCopies.immutableNullableList(referenceTaskIds);
-        metadata = CollectionCopies.immutableNullableMap(metadata);
+        metadata = CollectionCopies.unmodifiableNullableShallowMap(metadata);
         extensions = CollectionCopies.immutableNullableList(extensions);
     }
 

--- a/spec/src/main/java/org/a2aproject/sdk/spec/Message.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/Message.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -68,10 +69,10 @@ public record Message(Role role, List<Part<?>> parts,
         if (parts.isEmpty()) {
             throw new IllegalArgumentException("Parts cannot be empty");
         }
-        parts = List.copyOf(parts);
-        referenceTaskIds = referenceTaskIds != null ? List.copyOf(referenceTaskIds) : null;
-        metadata = (metadata != null) ? Map.copyOf(metadata) : null;
-        extensions = extensions != null ? List.copyOf(extensions) : null;
+        parts = CollectionCopies.immutableList(parts);
+        referenceTaskIds = CollectionCopies.immutableNullableList(referenceTaskIds);
+        metadata = CollectionCopies.immutableNullableMap(metadata);
+        extensions = CollectionCopies.immutableNullableList(extensions);
     }
 
     @Override
@@ -272,7 +273,7 @@ public record Message(Role role, List<Part<?>> parts,
          * @return this builder for method chaining
          */
         public Builder extensions(List<String> extensions) {
-            this.extensions = (extensions == null) ? null : List.copyOf(extensions);
+            this.extensions = CollectionCopies.immutableNullableList(extensions);
             return this;
         }
 

--- a/spec/src/main/java/org/a2aproject/sdk/spec/MessageSendConfiguration.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/MessageSendConfiguration.java
@@ -2,6 +2,7 @@ package org.a2aproject.sdk.spec;
 
 import java.util.List;
 
+import org.a2aproject.sdk.util.CollectionCopies;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -36,6 +37,7 @@ public record MessageSendConfiguration(@Nullable List<String> acceptedOutputMode
      * @throws IllegalArgumentException if historyLength is negative
      */
     public MessageSendConfiguration {
+        acceptedOutputModes = CollectionCopies.immutableNullableList(acceptedOutputModes);
         if (historyLength != null && historyLength < 0) {
             throw new IllegalArgumentException("Invalid history length");
         }

--- a/spec/src/main/java/org/a2aproject/sdk/spec/MessageSendParams.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/MessageSendParams.java
@@ -3,6 +3,7 @@ package org.a2aproject.sdk.spec;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -35,6 +36,7 @@ public record MessageSendParams(Message message, @Nullable MessageSendConfigurat
      */
     public MessageSendParams {
         Assert.checkNotNullParam("message", message);
+        metadata = CollectionCopies.unmodifiableNullableShallowMap(metadata);
     }
 
     /**

--- a/spec/src/main/java/org/a2aproject/sdk/spec/SecurityRequirement.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/SecurityRequirement.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 
 /**
  * Represents a security requirement in the A2A Protocol.
@@ -53,7 +54,11 @@ public record SecurityRequirement(Map<String, List<String>> schemes) {
      */
     public SecurityRequirement {
         Assert.checkNotNullParam("schemes", schemes);
-        schemes = unmodifiableMap(new LinkedHashMap<>(schemes));
+        LinkedHashMap<String, List<String>> copiedSchemes = new LinkedHashMap<>();
+        for (Map.Entry<String, List<String>> entry : schemes.entrySet()) {
+            copiedSchemes.put(entry.getKey(), CollectionCopies.immutableList(entry.getValue()));
+        }
+        schemes = unmodifiableMap(copiedSchemes);
     }
 
     /**
@@ -94,7 +99,7 @@ public record SecurityRequirement(Map<String, List<String>> schemes) {
          * @return this builder for method chaining
          */
         public Builder scheme(String schemeName, List<String> scopes) {
-            this.schemes.put(schemeName, List.copyOf(scopes));
+            this.schemes.put(schemeName, CollectionCopies.immutableList(scopes));
             return this;
         }
 

--- a/spec/src/main/java/org/a2aproject/sdk/spec/Task.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/Task.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -66,9 +67,9 @@ public record Task(String id, String contextId, TaskStatus status, @Nullable Lis
         Assert.checkNotNullParam("id", id);
         Assert.checkNotNullParam("contextId", contextId);
         Assert.checkNotNullParam("status", status);
-        artifacts = artifacts != null ? List.copyOf(artifacts) : List.of();
-        history = history != null ? List.copyOf(history) : List.of();
-        metadata = (metadata != null) ? Map.copyOf(metadata) : null;
+        artifacts = CollectionCopies.immutableListOrEmpty(artifacts);
+        history = CollectionCopies.immutableListOrEmpty(history);
+        metadata = CollectionCopies.immutableNullableMap(metadata);
     }
 
     @Override

--- a/spec/src/main/java/org/a2aproject/sdk/spec/Task.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/Task.java
@@ -69,7 +69,7 @@ public record Task(String id, String contextId, TaskStatus status, @Nullable Lis
         Assert.checkNotNullParam("status", status);
         artifacts = CollectionCopies.immutableListOrEmpty(artifacts);
         history = CollectionCopies.immutableListOrEmpty(history);
-        metadata = CollectionCopies.immutableNullableMap(metadata);
+        metadata = CollectionCopies.unmodifiableNullableShallowMap(metadata);
     }
 
     @Override

--- a/spec/src/main/java/org/a2aproject/sdk/spec/TaskArtifactUpdateEvent.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/TaskArtifactUpdateEvent.java
@@ -3,6 +3,7 @@ package org.a2aproject.sdk.spec;
 import java.util.Map;
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -62,6 +63,7 @@ public record TaskArtifactUpdateEvent(String taskId, Artifact artifact, String c
         Assert.checkNotNullParam("taskId", taskId);
         Assert.checkNotNullParam("artifact", artifact);
         Assert.checkNotNullParam("contextId", contextId);
+        metadata = CollectionCopies.unmodifiableNullableShallowMap(metadata);
     }
 
     @Override

--- a/spec/src/main/java/org/a2aproject/sdk/spec/TaskStatusUpdateEvent.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/TaskStatusUpdateEvent.java
@@ -1,15 +1,10 @@
 package org.a2aproject.sdk.spec;
 
-import static org.a2aproject.sdk.spec.TaskState.TASK_STATE_CANCELED;
-import static org.a2aproject.sdk.spec.TaskState.TASK_STATE_COMPLETED;
-import static org.a2aproject.sdk.spec.TaskState.TASK_STATE_FAILED;
-import static org.a2aproject.sdk.spec.TaskState.TASK_STATE_INPUT_REQUIRED;
-import static org.a2aproject.sdk.spec.TaskState.TASK_STATE_REJECTED;
+import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
-
-import org.a2aproject.sdk.util.Assert;
-import org.jspecify.annotations.Nullable;
 
 /**
  * An event sent by the agent to notify the client of a change in a task's status.
@@ -41,6 +36,7 @@ public record TaskStatusUpdateEvent(String taskId, TaskStatus status, String con
         Assert.checkNotNullParam("taskId", taskId);
         Assert.checkNotNullParam("status", status);
         Assert.checkNotNullParam("contextId", contextId);
+        metadata = CollectionCopies.unmodifiableNullableShallowMap(metadata);
     }
 
     @Override

--- a/spec/src/main/java/org/a2aproject/sdk/spec/TextPart.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/TextPart.java
@@ -2,6 +2,7 @@ package org.a2aproject.sdk.spec;
 
 
 import org.a2aproject.sdk.util.Assert;
+import org.a2aproject.sdk.util.CollectionCopies;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
 
@@ -45,7 +46,7 @@ public record TextPart(String text, @Nullable Map<String, Object> metadata) impl
      */
     public TextPart (String text, @Nullable Map<String, Object> metadata) {
         Assert.checkNotNullParam("text", text);
-        this.metadata = metadata == null ? null : Map.copyOf(metadata);
+        this.metadata = CollectionCopies.unmodifiableNullableShallowMap(metadata);
         this.text = text;
     }
 

--- a/spec/src/main/java/org/a2aproject/sdk/util/CollectionCopies.java
+++ b/spec/src/main/java/org/a2aproject/sdk/util/CollectionCopies.java
@@ -1,0 +1,164 @@
+package org.a2aproject.sdk.util;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility methods for creating defensive copies of collection fields.
+ * <p>
+ * The helpers make the immutability and null-handling choices explicit at call sites:
+ * <ul>
+ *     <li>{@code immutable*} methods are intended for record components and return immutable collections.</li>
+ *     <li>{@code nullable*} methods preserve the {@code null} value of optional components.</li>
+ *     <li>{@code *AllowingNulls} methods are intended for JSON-like maps such as metadata,
+ *     params, and headers, where {@code null} values may be valid protocol data.</li>
+ *     <li>{@code mutable*CopyOrEmpty} methods are intended for builders that need mutable copies.</li>
+ * </ul>
+ */
+public final class CollectionCopies {
+
+	private CollectionCopies() {
+	}
+
+	/**
+	 * Creates an immutable defensive copy of a non-null list.
+	 * <p>
+	 * This method uses {@link List#copyOf(java.util.Collection)} and therefore preserves
+	 * its null-handling semantics: null elements are not allowed.
+	 *
+	 * @param list the source list, must not be {@code null}
+	 * @param <E> the element type
+	 * @return an immutable defensive copy
+	 */
+	public static <E> List<E> immutableList(List<E> list) {
+		return List.copyOf(list);
+	}
+
+	/**
+	 * Creates an immutable defensive copy of a nullable list.
+	 * <p>
+	 * If the source list is {@code null}, this method returns {@code null}. Otherwise it
+	 * uses {@link List#copyOf(java.util.Collection)} and therefore does not allow null elements.
+	 *
+	 * @param list the source list, or {@code null}
+	 * @param <E> the element type
+	 * @return {@code null} if the source is {@code null}, otherwise an immutable defensive copy
+	 */
+	public static <E> @Nullable List<E> immutableNullableList(@Nullable List<E> list) {
+		return list == null ? null : List.copyOf(list);
+	}
+
+	/**
+	 * Creates an immutable defensive copy of a nullable list, defaulting to an empty immutable list.
+	 * <p>
+	 * This method is intended for fields where a missing list should be normalized to an empty list
+	 * rather than preserving {@code null}. It uses {@link List#copyOf(java.util.Collection)} for
+	 * non-null input and therefore does not allow null elements.
+	 *
+	 * @param list the source list, or {@code null}
+	 * @param <E> the element type
+	 * @return an immutable empty list if the source is {@code null}, otherwise an immutable defensive copy
+	 */
+	public static <E> List<E> immutableListOrEmpty(@Nullable List<E> list) {
+		return list == null ? List.of() : List.copyOf(list);
+	}
+
+	/**
+	 * Creates an immutable defensive copy of a non-null map.
+	 * <p>
+	 * This method uses {@link Map#copyOf(Map)} and is intended for typed maps where
+	 * null keys and null values are not valid data.
+	 *
+	 * @param map the source map, must not be {@code null}
+	 * @param <K> the key type
+	 * @param <V> the value type
+	 * @return an immutable defensive copy
+	 */
+	public static <K, V> Map<K, V> immutableMap(Map<K, V> map) {
+		return Map.copyOf(map);
+	}
+
+	/**
+	 * Creates an immutable defensive copy of a nullable map.
+	 * <p>
+	 * If the source map is {@code null}, this method returns {@code null}. Otherwise it
+	 * uses {@link Map#copyOf(Map)} and is intended for typed maps where null keys and
+	 * null values are not valid data.
+	 *
+	 * @param map the source map, or {@code null}
+	 * @param <K> the key type
+	 * @param <V> the value type
+	 * @return {@code null} if the source is {@code null}, otherwise an immutable defensive copy
+	 */
+	public static <K, V> @Nullable Map<K, V> immutableNullableMap(@Nullable Map<K, V> map) {
+		return map == null ? null : Map.copyOf(map);
+	}
+
+	/**
+	 * Creates an unmodifiable shallow defensive copy of a non-null map while preserving null values.
+	 * <p>
+	 * This method is intended for JSON-like maps such as metadata, params, and headers,
+	 * where null values may be valid protocol data. It intentionally does not use
+	 * {@link Map#copyOf(Map)}, because {@code Map.copyOf} throws {@link NullPointerException}
+	 * when the source map contains null keys or values.
+	 * <p>
+	 * The returned map cannot be structurally modified, but this method does not deep-copy
+	 * mutable keys or values.
+	 *
+	 * @param map the source map, must not be {@code null}
+	 * @param <K> the key type
+	 * @param <V> the value type
+	 * @return an unmodifiable shallow copy preserving null values
+	 */
+	public static <K, V> Map<K, V> unmodifiableShallowMap(Map<K, V> map) {
+		return Collections.unmodifiableMap(new HashMap<>(map));
+	}
+
+	/**
+	 * Creates an unmodifiable shallow defensive copy of a nullable map while preserving null values.
+	 * <p>
+	 * If the source map is {@code null}, this method returns {@code null}. Otherwise it behaves like
+	 * {@link #unmodifiableShallowMap(Map)}.
+	 *
+	 * @param map the source map, or {@code null}
+	 * @param <K> the key type
+	 * @param <V> the value type
+	 * @return {@code null} if the source is {@code null}, otherwise an unmodifiable shallow copy
+	 * preserving null values
+	 */
+	public static <K, V> @Nullable Map<K, V> unmodifiableNullableShallowMap(@Nullable Map<K, V> map) {
+		return map == null ? null : unmodifiableShallowMap(map);
+	}
+
+	/**
+	 * Creates a mutable defensive copy of a nullable list.
+	 * <p>
+	 * This method is intended for builders that need mutable collection state.
+	 *
+	 * @param list the source list, or {@code null}
+	 * @param <E> the element type
+	 * @return a mutable defensive copy, or an empty mutable list if the source is {@code null}
+	 */
+	public static <E> List<E> mutableListCopyOrEmpty(@Nullable List<E> list) {
+		return list == null ? new ArrayList<>() : new ArrayList<>(list);
+	}
+
+	/**
+	 * Creates a mutable defensive copy of a nullable map.
+	 * <p>
+	 * This method is intended for builders that need mutable collection state.
+	 *
+	 * @param map the source map, or {@code null}
+	 * @param <K> the key type
+	 * @param <V> the value type
+	 * @return a mutable defensive copy, or an empty mutable map if the source is {@code null}
+	 */
+	public static <K, V> Map<K, V> mutableMapCopyOrEmpty(@Nullable Map<K, V> map) {
+		return map == null ? new HashMap<>() : new HashMap<>(map);
+	}
+}

--- a/spec/src/main/java/org/a2aproject/sdk/util/CollectionCopies.java
+++ b/spec/src/main/java/org/a2aproject/sdk/util/CollectionCopies.java
@@ -22,143 +22,143 @@ import java.util.Map;
  */
 public final class CollectionCopies {
 
-	private CollectionCopies() {
-	}
+    private CollectionCopies() {
+    }
 
-	/**
-	 * Creates an immutable defensive copy of a non-null list.
-	 * <p>
-	 * This method uses {@link List#copyOf(java.util.Collection)} and therefore preserves
-	 * its null-handling semantics: null elements are not allowed.
-	 *
-	 * @param list the source list, must not be {@code null}
-	 * @param <E> the element type
-	 * @return an immutable defensive copy
-	 */
-	public static <E> List<E> immutableList(List<E> list) {
-		return List.copyOf(list);
-	}
+    /**
+     * Creates an immutable defensive copy of a non-null list.
+     * <p>
+     * This method uses {@link List#copyOf(java.util.Collection)} and therefore preserves
+     * its null-handling semantics: null elements are not allowed.
+     *
+     * @param list the source list, must not be {@code null}
+     * @param <E> the element type
+     * @return an immutable defensive copy
+     */
+    public static <E> List<E> immutableList(List<E> list) {
+        return List.copyOf(list);
+    }
 
-	/**
-	 * Creates an immutable defensive copy of a nullable list.
-	 * <p>
-	 * If the source list is {@code null}, this method returns {@code null}. Otherwise it
-	 * uses {@link List#copyOf(java.util.Collection)} and therefore does not allow null elements.
-	 *
-	 * @param list the source list, or {@code null}
-	 * @param <E> the element type
-	 * @return {@code null} if the source is {@code null}, otherwise an immutable defensive copy
-	 */
-	public static <E> @Nullable List<E> immutableNullableList(@Nullable List<E> list) {
-		return list == null ? null : List.copyOf(list);
-	}
+    /**
+     * Creates an immutable defensive copy of a nullable list.
+     * <p>
+     * If the source list is {@code null}, this method returns {@code null}. Otherwise it
+     * uses {@link List#copyOf(java.util.Collection)} and therefore does not allow null elements.
+     *
+     * @param list the source list, or {@code null}
+     * @param <E> the element type
+     * @return {@code null} if the source is {@code null}, otherwise an immutable defensive copy
+     */
+    public static <E> @Nullable List<E> immutableNullableList(@Nullable List<E> list) {
+        return list == null ? null : List.copyOf(list);
+    }
 
-	/**
-	 * Creates an immutable defensive copy of a nullable list, defaulting to an empty immutable list.
-	 * <p>
-	 * This method is intended for fields where a missing list should be normalized to an empty list
-	 * rather than preserving {@code null}. It uses {@link List#copyOf(java.util.Collection)} for
-	 * non-null input and therefore does not allow null elements.
-	 *
-	 * @param list the source list, or {@code null}
-	 * @param <E> the element type
-	 * @return an immutable empty list if the source is {@code null}, otherwise an immutable defensive copy
-	 */
-	public static <E> List<E> immutableListOrEmpty(@Nullable List<E> list) {
-		return list == null ? List.of() : List.copyOf(list);
-	}
+    /**
+     * Creates an immutable defensive copy of a nullable list, defaulting to an empty immutable list.
+     * <p>
+     * This method is intended for fields where a missing list should be normalized to an empty list
+     * rather than preserving {@code null}. It uses {@link List#copyOf(java.util.Collection)} for
+     * non-null input and therefore does not allow null elements.
+     *
+     * @param list the source list, or {@code null}
+     * @param <E> the element type
+     * @return an immutable empty list if the source is {@code null}, otherwise an immutable defensive copy
+     */
+    public static <E> List<E> immutableListOrEmpty(@Nullable List<E> list) {
+        return list == null ? List.of() : List.copyOf(list);
+    }
 
-	/**
-	 * Creates an immutable defensive copy of a non-null map.
-	 * <p>
-	 * This method uses {@link Map#copyOf(Map)} and is intended for typed maps where
-	 * null keys and null values are not valid data.
-	 *
-	 * @param map the source map, must not be {@code null}
-	 * @param <K> the key type
-	 * @param <V> the value type
-	 * @return an immutable defensive copy
-	 */
-	public static <K, V> Map<K, V> immutableMap(Map<K, V> map) {
-		return Map.copyOf(map);
-	}
+    /**
+     * Creates an immutable defensive copy of a non-null map.
+     * <p>
+     * This method uses {@link Map#copyOf(Map)} and is intended for typed maps where
+     * null keys and null values are not valid data.
+     *
+     * @param map the source map, must not be {@code null}
+     * @param <K> the key type
+     * @param <V> the value type
+     * @return an immutable defensive copy
+     */
+    public static <K, V> Map<K, V> immutableMap(Map<K, V> map) {
+        return Map.copyOf(map);
+    }
 
-	/**
-	 * Creates an immutable defensive copy of a nullable map.
-	 * <p>
-	 * If the source map is {@code null}, this method returns {@code null}. Otherwise it
-	 * uses {@link Map#copyOf(Map)} and is intended for typed maps where null keys and
-	 * null values are not valid data.
-	 *
-	 * @param map the source map, or {@code null}
-	 * @param <K> the key type
-	 * @param <V> the value type
-	 * @return {@code null} if the source is {@code null}, otherwise an immutable defensive copy
-	 */
-	public static <K, V> @Nullable Map<K, V> immutableNullableMap(@Nullable Map<K, V> map) {
-		return map == null ? null : Map.copyOf(map);
-	}
+    /**
+     * Creates an immutable defensive copy of a nullable map.
+     * <p>
+     * If the source map is {@code null}, this method returns {@code null}. Otherwise it
+     * uses {@link Map#copyOf(Map)} and is intended for typed maps where null keys and
+     * null values are not valid data.
+     *
+     * @param map the source map, or {@code null}
+     * @param <K> the key type
+     * @param <V> the value type
+     * @return {@code null} if the source is {@code null}, otherwise an immutable defensive copy
+     */
+    public static <K, V> @Nullable Map<K, V> immutableNullableMap(@Nullable Map<K, V> map) {
+        return map == null ? null : Map.copyOf(map);
+    }
 
-	/**
-	 * Creates an unmodifiable shallow defensive copy of a non-null map while preserving null values.
-	 * <p>
-	 * This method is intended for JSON-like maps such as metadata, params, and headers,
-	 * where null values may be valid protocol data. It intentionally does not use
-	 * {@link Map#copyOf(Map)}, because {@code Map.copyOf} throws {@link NullPointerException}
-	 * when the source map contains null keys or values.
-	 * <p>
-	 * The returned map cannot be structurally modified, but this method does not deep-copy
-	 * mutable keys or values.
-	 *
-	 * @param map the source map, must not be {@code null}
-	 * @param <K> the key type
-	 * @param <V> the value type
-	 * @return an unmodifiable shallow copy preserving null values
-	 */
-	public static <K, V> Map<K, V> unmodifiableShallowMap(Map<K, V> map) {
-		return Collections.unmodifiableMap(new HashMap<>(map));
-	}
+    /**
+     * Creates an unmodifiable shallow defensive copy of a non-null map while preserving null values.
+     * <p>
+     * This method is intended for JSON-like maps such as metadata, params, and headers,
+     * where null values may be valid protocol data. It intentionally does not use
+     * {@link Map#copyOf(Map)}, because {@code Map.copyOf} throws {@link NullPointerException}
+     * when the source map contains null keys or values.
+     * <p>
+     * The returned map cannot be structurally modified, but this method does not deep-copy
+     * mutable keys or values.
+     *
+     * @param map the source map, must not be {@code null}
+     * @param <K> the key type
+     * @param <V> the value type
+     * @return an unmodifiable shallow copy preserving null values
+     */
+    public static <K, V> Map<K, V> unmodifiableShallowMap(Map<K, V> map) {
+        return Collections.unmodifiableMap(new HashMap<>(map));
+    }
 
-	/**
-	 * Creates an unmodifiable shallow defensive copy of a nullable map while preserving null values.
-	 * <p>
-	 * If the source map is {@code null}, this method returns {@code null}. Otherwise it behaves like
-	 * {@link #unmodifiableShallowMap(Map)}.
-	 *
-	 * @param map the source map, or {@code null}
-	 * @param <K> the key type
-	 * @param <V> the value type
-	 * @return {@code null} if the source is {@code null}, otherwise an unmodifiable shallow copy
-	 * preserving null values
-	 */
-	public static <K, V> @Nullable Map<K, V> unmodifiableNullableShallowMap(@Nullable Map<K, V> map) {
-		return map == null ? null : unmodifiableShallowMap(map);
-	}
+    /**
+     * Creates an unmodifiable shallow defensive copy of a nullable map while preserving null values.
+     * <p>
+     * If the source map is {@code null}, this method returns {@code null}. Otherwise it behaves like
+     * {@link #unmodifiableShallowMap(Map)}.
+     *
+     * @param map the source map, or {@code null}
+     * @param <K> the key type
+     * @param <V> the value type
+     * @return {@code null} if the source is {@code null}, otherwise an unmodifiable shallow copy
+     * preserving null values
+     */
+    public static <K, V> @Nullable Map<K, V> unmodifiableNullableShallowMap(@Nullable Map<K, V> map) {
+        return map == null ? null : unmodifiableShallowMap(map);
+    }
 
-	/**
-	 * Creates a mutable defensive copy of a nullable list.
-	 * <p>
-	 * This method is intended for builders that need mutable collection state.
-	 *
-	 * @param list the source list, or {@code null}
-	 * @param <E> the element type
-	 * @return a mutable defensive copy, or an empty mutable list if the source is {@code null}
-	 */
-	public static <E> List<E> mutableListCopyOrEmpty(@Nullable List<E> list) {
-		return list == null ? new ArrayList<>() : new ArrayList<>(list);
-	}
+    /**
+     * Creates a mutable defensive copy of a nullable list.
+     * <p>
+     * This method is intended for builders that need mutable collection state.
+     *
+     * @param list the source list, or {@code null}
+     * @param <E> the element type
+     * @return a mutable defensive copy, or an empty mutable list if the source is {@code null}
+     */
+    public static <E> List<E> mutableListCopyOrEmpty(@Nullable List<E> list) {
+        return list == null ? new ArrayList<>() : new ArrayList<>(list);
+    }
 
-	/**
-	 * Creates a mutable defensive copy of a nullable map.
-	 * <p>
-	 * This method is intended for builders that need mutable collection state.
-	 *
-	 * @param map the source map, or {@code null}
-	 * @param <K> the key type
-	 * @param <V> the value type
-	 * @return a mutable defensive copy, or an empty mutable map if the source is {@code null}
-	 */
-	public static <K, V> Map<K, V> mutableMapCopyOrEmpty(@Nullable Map<K, V> map) {
-		return map == null ? new HashMap<>() : new HashMap<>(map);
-	}
+    /**
+     * Creates a mutable defensive copy of a nullable map.
+     * <p>
+     * This method is intended for builders that need mutable collection state.
+     *
+     * @param map the source map, or {@code null}
+     * @param <K> the key type
+     * @param <V> the value type
+     * @return a mutable defensive copy, or an empty mutable map if the source is {@code null}
+     */
+    public static <K, V> Map<K, V> mutableMapCopyOrEmpty(@Nullable Map<K, V> map) {
+        return map == null ? new HashMap<>() : new HashMap<>(map);
+    }
 }

--- a/spec/src/test/java/org/a2aproject/sdk/spec/AgentCapabilitiesTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/AgentCapabilitiesTest.java
@@ -1,0 +1,26 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class AgentCapabilitiesTest {
+
+    @Test
+    void testConstruction_defensivelyCopiesExtensions() {
+        List<AgentExtension> extensions = new ArrayList<>();
+        extensions.add(new AgentExtension("Custom auth", Map.of("authType", "bearer"), true, "https://example.com/ext"));
+
+        AgentCapabilities capabilities = new AgentCapabilities(true, false, true, extensions);
+        extensions.add(new AgentExtension("Another", Map.of("x", "y"), false, "https://example.com/ext2"));
+
+        assertEquals(1, capabilities.extensions().size());
+        assertThrows(UnsupportedOperationException.class, () -> capabilities.extensions().add(
+                new AgentExtension("Mutated", Map.of(), false, "https://example.com/ext3")));
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/AgentCardSignatureTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/AgentCardSignatureTest.java
@@ -1,0 +1,39 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class AgentCardSignatureTest {
+
+    @Test
+    void testConstruction_defensivelyCopiesHeader() {
+        Map<String, Object> header = new HashMap<>();
+        header.put("kid", "2024-01");
+
+        AgentCardSignature signature = new AgentCardSignature(header, "protected", "signature");
+        header.put("alg", "ES256");
+
+        assertEquals(Map.of("kid", "2024-01"), signature.header());
+        assertThrows(UnsupportedOperationException.class, () -> signature.header().put("x", "y"));
+    }
+
+    @Test
+    void testConstruction_preservesNullHeaderValues() {
+        Map<String, Object> header = new HashMap<>();
+        header.put("foo", null);
+
+        AgentCardSignature signature = new AgentCardSignature(header, "protected", "signature");
+
+        assertEquals(1, signature.header().size());
+        assertTrue(signature.header().containsKey("foo"));
+        assertNull(signature.header().get("foo"));
+        assertThrows(UnsupportedOperationException.class, () -> signature.header().put("bar", "baz"));
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/AgentCardTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/AgentCardTest.java
@@ -1,0 +1,64 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class AgentCardTest {
+
+    @Test
+    void testConstruction_defensivelyCopiesCollections() {
+        List<String> defaultInputModes = new ArrayList<>();
+        defaultInputModes.add("text");
+        List<String> defaultOutputModes = new ArrayList<>();
+        defaultOutputModes.add("text");
+        List<AgentSkill> skills = new ArrayList<>();
+        skills.add(AgentSkill.builder()
+                .id("weather_query")
+                .name("Weather Queries")
+                .description("Get weather information")
+                .tags(List.of("weather"))
+                .build());
+        List<AgentInterface> supportedInterfaces = new ArrayList<>();
+        supportedInterfaces.add(new AgentInterface("JSONRPC", "http://localhost:9999", null, "1.0"));
+
+        AgentCard card = new AgentCard(
+                "Weather Agent",
+                "Provides weather information",
+                null,
+                "1.0.0",
+                null,
+                AgentCapabilities.builder().streaming(true).build(),
+                defaultInputModes,
+                defaultOutputModes,
+                skills,
+                null,
+                null,
+                null,
+                supportedInterfaces,
+                null,
+                null,
+                null,
+                null);
+
+        defaultInputModes.add("audio");
+        defaultOutputModes.add("audio");
+        skills.add(AgentSkill.builder()
+                .id("translate")
+                .name("Translation")
+                .description("Translate text")
+                .tags(List.of("translate"))
+                .build());
+        supportedInterfaces.add(new AgentInterface("GRPC", "grpc://localhost:9090", null, "1.0"));
+
+        assertEquals(List.of("text"), card.defaultInputModes());
+        assertEquals(List.of("text"), card.defaultOutputModes());
+        assertEquals(1, card.skills().size());
+        assertEquals(1, card.supportedInterfaces().size());
+        assertThrows(UnsupportedOperationException.class, () -> card.defaultInputModes().add("video"));
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/AgentExtensionTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/AgentExtensionTest.java
@@ -1,0 +1,39 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class AgentExtensionTest {
+
+    @Test
+    void testConstruction_defensivelyCopiesParams() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("authType", "bearer");
+
+        AgentExtension extension = new AgentExtension("Custom auth", params, true, "https://example.com/ext");
+        params.put("mutated", true);
+
+        assertEquals(Map.of("authType", "bearer"), extension.params());
+        assertThrows(UnsupportedOperationException.class, () -> extension.params().put("x", "y"));
+    }
+
+    @Test
+    void testConstruction_preservesNullParamsValues() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("foo", null);
+
+        AgentExtension extension = new AgentExtension("Custom auth", params, true, "https://example.com/ext");
+
+        assertEquals(1, extension.params().size());
+        assertTrue(extension.params().containsKey("foo"));
+        assertNull(extension.params().get("foo"));
+        assertThrows(UnsupportedOperationException.class, () -> extension.params().put("bar", "baz"));
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/AgentSkillTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/AgentSkillTest.java
@@ -1,0 +1,45 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class AgentSkillTest {
+
+    @Test
+    void testConstruction_defensivelyCopiesCollections() {
+        List<String> tags = new ArrayList<>();
+        tags.add("weather");
+        List<String> examples = new ArrayList<>();
+        examples.add("What's the weather in Tokyo?");
+        List<String> inputModes = new ArrayList<>();
+        inputModes.add("text");
+        List<String> outputModes = new ArrayList<>();
+        outputModes.add("text");
+
+        AgentSkill skill = new AgentSkill(
+                "weather_query",
+                "Weather Queries",
+                "Get weather information",
+                tags,
+                examples,
+                inputModes,
+                outputModes,
+                null);
+
+        tags.add("mutated");
+        examples.add("mutated");
+        inputModes.add("audio");
+        outputModes.add("audio");
+
+        assertEquals(List.of("weather"), skill.tags());
+        assertEquals(List.of("What's the weather in Tokyo?"), skill.examples());
+        assertEquals(List.of("text"), skill.inputModes());
+        assertEquals(List.of("text"), skill.outputModes());
+        assertThrows(UnsupportedOperationException.class, () -> skill.tags().add("x"));
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/ArtifactTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/ArtifactTest.java
@@ -1,0 +1,50 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class ArtifactTest {
+
+    @Test
+    void testConstruction_defensivelyCopiesCollections() {
+        List<Part<?>> parts = new ArrayList<>();
+        parts.add(new TextPart("hello"));
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("source", "web");
+        List<String> extensions = new ArrayList<>();
+        extensions.add("ext-1");
+
+        Artifact artifact = new Artifact("artifact-1", "name", "desc", parts, metadata, extensions);
+        parts.add(new TextPart("mutated"));
+        metadata.put("write", "should-not-leak");
+        extensions.add("ext-2");
+
+        assertEquals(1, artifact.parts().size());
+        assertEquals(Map.of("source", "web"), artifact.metadata());
+        assertEquals(List.of("ext-1"), artifact.extensions());
+        assertThrows(UnsupportedOperationException.class, () -> artifact.parts().add(new TextPart("x")));
+    }
+
+    @Test
+    void testConstruction_preservesNullMetadataValues() {
+        List<Part<?>> parts = List.of(new TextPart("hello"));
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("foo", null);
+
+        Artifact artifact = new Artifact("artifact-2", null, null, parts, metadata, null);
+
+        assertEquals(1, artifact.metadata().size());
+        assertTrue(artifact.metadata().containsKey("foo"));
+        assertNull(artifact.metadata().get("foo"));
+        assertThrows(UnsupportedOperationException.class, () -> artifact.metadata().put("bar", "baz"));
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/AuthorizationCodeOAuthFlowTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/AuthorizationCodeOAuthFlowTest.java
@@ -1,0 +1,30 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class AuthorizationCodeOAuthFlowTest {
+
+    @Test
+    void testConstruction_defensivelyCopiesScopes() {
+        Map<String, String> scopes = new HashMap<>();
+        scopes.put("read", "Read access");
+
+        AuthorizationCodeOAuthFlow flow = new AuthorizationCodeOAuthFlow(
+                "https://auth.example.com/authorize",
+                "https://auth.example.com/refresh",
+                scopes,
+                "https://auth.example.com/token",
+                true);
+
+        scopes.put("write", "Write access");
+
+        assertEquals(Map.of("read", "Read access"), flow.scopes());
+        assertThrows(UnsupportedOperationException.class, () -> flow.scopes().put("x", "y"));
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/CancelTaskParamsTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/CancelTaskParamsTest.java
@@ -1,0 +1,43 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class CancelTaskParamsTest {
+
+    @Test
+    void testConstruction_defensivelyCopiesMetadata() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("reason", "timeout");
+
+        CancelTaskParams params = new CancelTaskParams("task-1", "tenant-1", metadata);
+        metadata.put("mutated", true);
+
+        assertEquals(Map.of("reason", "timeout"), params.metadata());
+        assertThrows(UnsupportedOperationException.class, () -> params.metadata().put("x", "y"));
+    }
+
+    @Test
+    void testBuilderPreservesNullMetadataValues() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("foo", null);
+
+        CancelTaskParams params = CancelTaskParams.builder()
+                .id("task-1")
+                .tenant("tenant-1")
+                .metadata(metadata)
+                .build();
+
+        assertEquals(1, params.metadata().size());
+        assertTrue(params.metadata().containsKey("foo"));
+        assertNull(params.metadata().get("foo"));
+        assertThrows(UnsupportedOperationException.class, () -> params.metadata().put("bar", "baz"));
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/ClientCredentialsOAuthFlowTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/ClientCredentialsOAuthFlowTest.java
@@ -1,0 +1,28 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class ClientCredentialsOAuthFlowTest {
+
+    @Test
+    void testConstruction_defensivelyCopiesScopes() {
+        Map<String, String> scopes = new HashMap<>();
+        scopes.put("read", "Read access");
+
+        ClientCredentialsOAuthFlow flow = new ClientCredentialsOAuthFlow(
+                "https://auth.example.com/refresh",
+                scopes,
+                "https://auth.example.com/token");
+
+        scopes.put("write", "Write access");
+
+        assertEquals(Map.of("read", "Read access"), flow.scopes());
+        assertThrows(UnsupportedOperationException.class, () -> flow.scopes().put("x", "y"));
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/DataPartTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/DataPartTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -68,6 +70,18 @@ class DataPartTest {
 
         assertInstanceOf(Map.class, part.data());
         assertEquals("sensor", part.metadata().get("source"));
+    }
+
+    @Test
+    void testConstructor_withNullMetadataValuePreservesValueAndIsImmutable() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("source", null);
+
+        DataPart part = new DataPart(Map.of("temperature", 22.5), metadata);
+
+        assertTrue(part.metadata().containsKey("source"));
+        assertNull(part.metadata().get("source"));
+        assertThrows(UnsupportedOperationException.class, () -> part.metadata().put("another", "value"));
     }
 
     @Test

--- a/spec/src/test/java/org/a2aproject/sdk/spec/DeviceCodeOAuthFlowTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/DeviceCodeOAuthFlowTest.java
@@ -103,5 +103,6 @@ class DeviceCodeOAuthFlowTest {
         mutableScopes.put("write", "Write access");
         assertNotEquals(mutableScopes.size(), flow.scopes().size(),
                 "Record should be immutable and perform a defensive copy of the scopes map");
+        assertThrows(UnsupportedOperationException.class, () -> flow.scopes().put("admin", "Admin access"));
     }
 }

--- a/spec/src/test/java/org/a2aproject/sdk/spec/FilePartTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/FilePartTest.java
@@ -1,0 +1,28 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class FilePartTest {
+
+    @Test
+    void testConstructor_withNullMetadataValuePreservesValueAndIsImmutable() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("source", null);
+
+        FilePart part = new FilePart(new FileWithUri("text/plain", "example.txt", "https://example.com/example.txt"),
+                metadata);
+
+        assertEquals("example.txt", part.file().name());
+        assertTrue(part.metadata().containsKey("source"));
+        assertNull(part.metadata().get("source"));
+        assertThrows(UnsupportedOperationException.class, () -> part.metadata().put("another", "value"));
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/MessageSendConfigurationTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/MessageSendConfigurationTest.java
@@ -1,0 +1,71 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class MessageSendConfigurationTest {
+
+    @Test
+    void testConstruction_withAllFields() {
+        List<String> acceptedOutputModes = List.of("text", "audio");
+        TaskPushNotificationConfig config = TaskPushNotificationConfig.builder()
+                .id("id")
+                .taskId("task-123")
+                .url("https://example.com")
+                .build();
+
+        MessageSendConfiguration result = new MessageSendConfiguration(acceptedOutputModes, 3, config, Boolean.TRUE);
+
+        assertEquals(acceptedOutputModes, result.acceptedOutputModes());
+        assertEquals(Integer.valueOf(3), result.historyLength());
+        assertEquals(config, result.taskPushNotificationConfig());
+        assertEquals(Boolean.TRUE, result.returnImmediately());
+    }
+
+    @Test
+    void testConstruction_withNullAcceptedOutputModes() {
+        MessageSendConfiguration result = new MessageSendConfiguration(null, null, null, null);
+
+        assertNull(result.acceptedOutputModes());
+        assertNull(result.historyLength());
+        assertNull(result.taskPushNotificationConfig());
+        assertNull(result.returnImmediately());
+    }
+
+    @Test
+    void testConstruction_negativeHistoryLength_throwsException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new MessageSendConfiguration(List.of("text"), -1, null, null));
+    }
+
+    @Test
+    void testAcceptedOutputModes_areDefensivelyCopied() {
+        List<String> mutableModes = new ArrayList<>();
+        mutableModes.add("text");
+
+        MessageSendConfiguration result = new MessageSendConfiguration(mutableModes, null, null, null);
+        mutableModes.add("audio");
+
+        assertEquals(List.of("text"), result.acceptedOutputModes());
+        assertThrows(UnsupportedOperationException.class, () -> result.acceptedOutputModes().add("video"));
+    }
+
+    @Test
+    void testBuilderAcceptedOutputModes_areDefensivelyCopiedByRecord() {
+        List<String> mutableModes = new ArrayList<>();
+        mutableModes.add("text");
+
+        MessageSendConfiguration result = MessageSendConfiguration.builder()
+                .acceptedOutputModes(mutableModes)
+                .build();
+        mutableModes.add("audio");
+
+        assertEquals(List.of("text"), result.acceptedOutputModes());
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/MessageSendParamsTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/MessageSendParamsTest.java
@@ -1,0 +1,82 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class MessageSendParamsTest {
+
+    @Test
+    void testConstruction_withAllFields() {
+        Message message = Message.builder()
+                .role(Message.Role.ROLE_USER)
+                .parts(new TextPart("hello"))
+                .build();
+        MessageSendConfiguration configuration = new MessageSendConfiguration(List.of("text"), 2, null, Boolean.TRUE);
+        Map<String, Object> metadata = Map.of("source", "web");
+
+        MessageSendParams params = new MessageSendParams(message, configuration, metadata);
+
+        assertEquals(message, params.message());
+        assertEquals(configuration, params.configuration());
+        assertEquals(metadata, params.metadata());
+        assertNull(params.tenant());
+    }
+
+    @Test
+    void testConstruction_nullMetadata() {
+        Message message = Message.builder()
+                .role(Message.Role.ROLE_USER)
+                .parts(new TextPart("hello"))
+                .build();
+
+        MessageSendParams params = new MessageSendParams(message, null, null);
+
+        assertNull(params.metadata());
+    }
+
+    @Test
+    void testConstruction_nullMessage_throwsException() {
+        assertThrows(IllegalArgumentException.class, () -> new MessageSendParams(null, null, null));
+    }
+
+    @Test
+    void testMetadata_isDefensivelyCopied() {
+        Message message = Message.builder()
+                .role(Message.Role.ROLE_USER)
+                .parts(new TextPart("hello"))
+                .build();
+        Map<String, Object> mutableMetadata = new HashMap<>();
+        mutableMetadata.put("source", "web");
+
+        MessageSendParams params = new MessageSendParams(message, null, mutableMetadata);
+        mutableMetadata.put("write", "should-not-leak");
+
+        assertEquals(Map.of("source", "web"), params.metadata());
+        assertThrows(UnsupportedOperationException.class, () -> params.metadata().put("another", "value"));
+    }
+
+    @Test
+    void testMetadata_preservesNullValues() {
+        Message message = Message.builder()
+                .role(Message.Role.ROLE_USER)
+                .parts(new TextPart("hello"))
+                .build();
+        Map<String, Object> mutableMetadata = new HashMap<>();
+        mutableMetadata.put("foo", null);
+
+        MessageSendParams params = new MessageSendParams(message, null, mutableMetadata);
+
+        assertEquals(1, params.metadata().size());
+        assertTrue(params.metadata().containsKey("foo"));
+        assertNull(params.metadata().get("foo"));
+        assertThrows(UnsupportedOperationException.class, () -> params.metadata().put("another", "value"));
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/SecurityRequirementTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/SecurityRequirementTest.java
@@ -1,0 +1,30 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class SecurityRequirementTest {
+
+    @Test
+    void testConstruction_defensivelyCopiesNestedScopes() {
+        List<String> scopes = new ArrayList<>();
+        scopes.add("read");
+        Map<String, List<String>> schemes = new HashMap<>();
+        schemes.put("oauth2", scopes);
+
+        SecurityRequirement requirement = new SecurityRequirement(schemes);
+        scopes.add("write");
+        schemes.put("apiKey", List.of());
+
+        assertEquals(List.of("read"), requirement.schemes().get("oauth2"));
+        assertThrows(UnsupportedOperationException.class, () -> requirement.schemes().put("x", List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> requirement.schemes().get("oauth2").add("x"));
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/TaskArtifactUpdateEventTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/TaskArtifactUpdateEventTest.java
@@ -1,0 +1,53 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class TaskArtifactUpdateEventTest {
+
+    @Test
+    void testConstruction_defensivelyCopiesMetadata() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("source", "web");
+
+        TaskArtifactUpdateEvent event = new TaskArtifactUpdateEvent(
+                "task-1",
+                new Artifact("artifact-1", null, null, List.of(new TextPart("hello")), null, null),
+                "context-1",
+                true,
+                false,
+                metadata);
+
+        metadata.put("write", "should-not-leak");
+
+        assertEquals(Map.of("source", "web"), event.metadata());
+        assertThrows(UnsupportedOperationException.class, () -> event.metadata().put("x", "y"));
+    }
+
+    @Test
+    void testConstruction_preservesNullMetadataValues() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("foo", null);
+
+        TaskArtifactUpdateEvent event = new TaskArtifactUpdateEvent(
+                "task-1",
+                new Artifact("artifact-1", null, null, List.of(new TextPart("hello")), null, null),
+                "context-1",
+                true,
+                false,
+                metadata);
+
+        assertEquals(1, event.metadata().size());
+        assertTrue(event.metadata().containsKey("foo"));
+        assertNull(event.metadata().get("foo"));
+        assertThrows(UnsupportedOperationException.class, () -> event.metadata().put("bar", "baz"));
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/TaskStatusUpdateEventTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/TaskStatusUpdateEventTest.java
@@ -1,0 +1,110 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class TaskStatusUpdateEventTest {
+
+    private static final String TASK_ID = "task-123";
+    private static final String CONTEXT_ID = "context-456";
+
+    @Test
+    void testConstruction_withAllFields() {
+        Map<String, Object> metadata = Map.of("source", "sensor");
+        TaskStatus status = new TaskStatus(TaskState.TASK_STATE_WORKING);
+
+        TaskStatusUpdateEvent event = new TaskStatusUpdateEvent(TASK_ID, status, CONTEXT_ID, metadata);
+
+        assertEquals(TASK_ID, event.taskId());
+        assertEquals(status, event.status());
+        assertEquals(CONTEXT_ID, event.contextId());
+        assertEquals(metadata, event.metadata());
+    }
+
+    @Test
+    void testConstruction_withNullMetadata() {
+        TaskStatusUpdateEvent event = new TaskStatusUpdateEvent(
+                TASK_ID,
+                new TaskStatus(TaskState.TASK_STATE_WORKING),
+                CONTEXT_ID,
+                null);
+
+        assertNull(event.metadata());
+    }
+
+    @Test
+    void testConstruction_nullTaskId_throwsException() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new TaskStatusUpdateEvent(null, new TaskStatus(TaskState.TASK_STATE_WORKING), CONTEXT_ID, Map.of()));
+    }
+
+    @Test
+    void testConstruction_nullStatus_throwsException() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new TaskStatusUpdateEvent(TASK_ID, null, CONTEXT_ID, Map.of()));
+    }
+
+    @Test
+    void testConstruction_nullContextId_throwsException() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new TaskStatusUpdateEvent(TASK_ID, new TaskStatus(TaskState.TASK_STATE_WORKING), null, Map.of()));
+    }
+
+    @Test
+    void testMetadataImmutability() {
+        Map<String, Object> mutableMetadata = new HashMap<>();
+        mutableMetadata.put("source", "sensor");
+
+        TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
+                .taskId(TASK_ID)
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
+                .contextId(CONTEXT_ID)
+                .metadata(mutableMetadata)
+                .build();
+
+        mutableMetadata.put("write", "should-not-leak");
+
+        assertEquals(Map.of("source", "sensor"), event.metadata());
+        assertThrows(UnsupportedOperationException.class, () -> event.metadata().put("another", "value"));
+    }
+
+    @Test
+    void testConstruction_preservesNullMetadataValues() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("foo", null);
+
+        TaskStatusUpdateEvent event = new TaskStatusUpdateEvent(
+                TASK_ID,
+                new TaskStatus(TaskState.TASK_STATE_WORKING),
+                CONTEXT_ID,
+                metadata);
+
+        assertEquals(1, event.metadata().size());
+        assertTrue(event.metadata().containsKey("foo"));
+        assertNull(event.metadata().get("foo"));
+        assertThrows(UnsupportedOperationException.class, () -> event.metadata().put("bar", "baz"));
+    }
+
+    @Test
+    void testBuilderFromExistingEvent_keepsEqualValues() {
+        TaskStatusUpdateEvent original = new TaskStatusUpdateEvent(
+                TASK_ID,
+                new TaskStatus(TaskState.TASK_STATE_WORKING),
+                CONTEXT_ID,
+                Map.of("source", "sensor"));
+
+        TaskStatusUpdateEvent copied = TaskStatusUpdateEvent.builder(original).build();
+
+        assertEquals(original, copied);
+        assertEquals(original.hashCode(), copied.hashCode());
+        assertNotEquals(original, null);
+    }
+}

--- a/spec/src/test/java/org/a2aproject/sdk/spec/TextPartTest.java
+++ b/spec/src/test/java/org/a2aproject/sdk/spec/TextPartTest.java
@@ -1,0 +1,27 @@
+package org.a2aproject.sdk.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class TextPartTest {
+
+    @Test
+    void testConstructor_withNullMetadataValuePreservesValueAndIsImmutable() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("language", null);
+
+        TextPart part = new TextPart("hello", metadata);
+
+        assertEquals("hello", part.text());
+        assertTrue(part.metadata().containsKey("language"));
+        assertNull(part.metadata().get("language"));
+        assertThrows(UnsupportedOperationException.class, () -> part.metadata().put("another", "value"));
+    }
+}


### PR DESCRIPTION
Spec cleanup: immutable records and copy semantics                                                                                                                                                                           
                                                                                                                                                                                                                               
  Build fails after `actions/checkout` was bumped from v6 to v7 in PR #948:                                                                                                                                                    
  https://github.com/a2aproject/a2a-java/pull/948 