### PR TITLE
ci: split release profile CI into two tiers

### DIFF
--- a/.github/workflows/build-with-release-profile-run.yml
+++ b/.github/workflows/build-with-release-profile-run.yml
@@ -17,8 +17,14 @@ jobs:
   build:
     # Only run for successful trigger workflow from main repository
     if: >
-      ${{ github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.repository.full_name == 'a2aproject/a2a-java' }}
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.repository.full_name == 'a2aproject/a2a-java' &&
+      (
+        (github.event.workflow_run.event == 'push' &&
+         contains(fromJSON('["main", "0.3.x"]'), github.event.workflow_run.head_branch)) ||
+        github.event.workflow_run.event == 'workflow_dispatch' ||
+        contains(fromJSON('["kkhan", "jmesnil", "ehsavoie", "maeste"]'), github.event.workflow_run.actor.login)
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -70,9 +76,11 @@ jobs:
       - name: Checkout PR code
         uses: actions/checkout@v7
         with:
-          # Checkout the exact commit from the PR (or push)
-          # This is safe because the workflow code (this file) is always from main
           ref: ${{ steps.pr_info.outputs.pr_sha }}
+          # Safe: the job-level if condition restricts this to allow-listed actors
+          # and protected branch pushes. This file is always loaded from the default
+          # branch, so fork PRs cannot modify the allow-list.
+          allow-unsafe-pr-checkout: true
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -94,6 +102,19 @@ jobs:
         run: |
           mkdir -p ~/.m2
           echo "<settings><servers><server><id>central-a2asdk-temp</id><username>${{ secrets.CENTRAL_TOKEN_USERNAME }}</username><password>${{ secrets.CENTRAL_TOKEN_PASSWORD }}</password></server></servers></settings>" > ~/.m2/settings.xml
+
+      - name: Validate Maven Central credentials
+        run: |
+          TOKEN=$(printf "%s:%s" "${{ secrets.CENTRAL_TOKEN_USERNAME }}" "${{ secrets.CENTRAL_TOKEN_PASSWORD }}" | base64)
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer $TOKEN" \
+            -X POST \
+            "https://central.sonatype.com/api/v1/publisher/status?id=nonexistent")
+          if [ "$HTTP_STATUS" != "404" ]; then
+            echo "::error::Maven Central credentials validation failed (HTTP $HTTP_STATUS, expected 404)"
+            exit 1
+          fi
+          echo "Maven Central credentials are valid"
 
       # Build with the same settings as the deploy job
       # -s uses the settings file we created.

--- a/.github/workflows/build-with-release-profile.yml
+++ b/.github/workflows/build-with-release-profile.yml
@@ -28,6 +28,24 @@ jobs:
       contents: read
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build with release profile (no secrets)
+        run: >
+          mvn -B install
+          -Prelease
+          -DskipTests
+          -Dgpg.skip=true
+          -Drelease.auto.publish=false
+
       - name: Prepare PR info
         run: |
           mkdir -p pr_info

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -79,14 +79,20 @@ Open PR on GitHub with title: `chore: release 0.4.0.Alpha1`
 
 ### 4. CI Verification
 
-The `build-with-release-profile.yml` workflow automatically verifies:
-- ✅ Build succeeds with `-Prelease` profile
-- ✅ All JavaDoc generation succeeds
-- ✅ GPG signing works correctly
-- ✅ JBang version validation passes
-- ✅ No compilation or test failures
+The release profile CI runs in two tiers:
 
-**Important**: This workflow tests the actual PR branch (not main) to catch issues before merge.
+**Tier 1** (all PRs, no secrets):
+- ✅ Build succeeds with `-Prelease` profile (`-DskipTests -Dgpg.skip=true -Drelease.auto.publish=false`)
+- ✅ All JavaDoc generation succeeds
+- ✅ JBang version validation passes
+- ✅ No compilation failures
+
+**Tier 2** (allow-listed maintainers and pushes to `main`/`0.3.x`, with secrets):
+- ✅ GPG signing works correctly
+- ✅ Maven Central credentials are valid
+- ✅ Full release profile build succeeds
+
+**Important**: Tier 2 only runs for allow-listed actors (see `build-with-release-profile-run.yml`). Fork PRs from other contributors get Tier 1 only.
 
 Wait for all CI checks to pass before proceeding.
 
@@ -249,10 +255,15 @@ Follow semantic versioning with qualifiers:
 
 ## Workflows Reference
 
-### build-with-release-profile.yml
-- **Triggers**: All PRs, all pushes
-- **Purpose**: Verify builds with `-Prelease` profile
-- **Special**: Tests actual PR branch (not main) using `pull_request_target` with explicit checkout
+### build-with-release-profile.yml (Tier 1 — Trigger)
+- **Triggers**: All PRs, all pushes, manual dispatch
+- **Purpose**: Build with `-Prelease` profile without secrets; upload PR info for Tier 2
+- **Catches**: Compilation, javadoc, plugin configuration issues
+
+### build-with-release-profile-run.yml (Tier 2 — Secrets)
+- **Triggers**: `workflow_run` on Tier 1 completion
+- **Purpose**: Full release profile build with GPG signing and Maven Central credential validation
+- **Access**: Allow-listed maintainers, pushes to `main`/`0.3.x`, manual dispatch
 - **Requires**: GPG and Maven Central secrets
 
 ### release-to-maven-central.yml


### PR DESCRIPTION
Tier 1 (all PRs, no secrets): runs mvn install -Prelease with GPG and publishing skipped to catch compilation/javadoc issues early.

Tier 2 (allow-listed actors + protected branch pushes, with secrets): adds actor allow-list, allow-unsafe-pr-checkout, and Sonatype credential validation. Fixes actions/checkout@v7 fork-checkout block.