### PR TITLE
fix!: TaskState.UNRECOGNIZED is called TASK_STATE_UNSPECIFIED in spec

### DIFF
--- a/client/base/src/main/java/org/a2aproject/sdk/client/ClientTaskManager.java
+++ b/client/base/src/main/java/org/a2aproject/sdk/client/ClientTaskManager.java
@@ -60,7 +60,7 @@ class ClientTaskManager {
         Task task = currentTask;
         if (task == null) {
             task = Task.builder()
-                    .status(new TaskStatus(TaskState.UNRECOGNIZED))
+                    .status(new TaskStatus(TaskState.TASK_STATE_UNSPECIFIED))
                     .id(taskId)
                     .contextId(contextId == null ? "" : contextId)
                     .build();
@@ -96,7 +96,7 @@ class ClientTaskManager {
         Task task = currentTask;
         if (task == null) {
             task = Task.builder()
-                    .status(new TaskStatus(TaskState.UNRECOGNIZED))
+                    .status(new TaskStatus(TaskState.TASK_STATE_UNSPECIFIED))
                     .id(taskId)
                     .contextId(contextId == null ? "" : contextId)
                     .build();

--- a/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/TaskStateMapper_v0_3.java
+++ b/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/TaskStateMapper_v0_3.java
@@ -15,12 +15,12 @@ import org.mapstruct.Mapper;
  *   <li>v1.0: {@code TASK_STATE_SUBMITTED, TASK_STATE_WORKING, ...}</li>
  * </ul>
  * <p>
- * Additionally, the {@code UNKNOWN} state in v0.3 maps to {@code UNRECOGNIZED} in v1.0.
+ * Additionally, the {@code UNKNOWN} state in v0.3 maps to {@code TASK_STATE_UNSPECIFIED} in v1.0.
  * <p>
  * This mapper uses manual switch statements instead of {@code @ValueMapping} to:
  * <ul>
  *   <li>Avoid mapstruct-spi-protobuf enum strategy initialization issues</li>
- *   <li>Handle explicit null mapping (null → UNRECOGNIZED/UNKNOWN)</li>
+ *   <li>Handle explicit null mapping (null → TASK_STATE_UNSPECIFIED/UNKNOWN)</li>
  *   <li>Provide clear, compile-time-safe enum conversions</li>
  * </ul>
  *
@@ -50,8 +50,8 @@ public interface TaskStateMapper_v0_3 {
      * CANCELED               → TASK_STATE_CANCELED
      * FAILED                 → TASK_STATE_FAILED
      * REJECTED               → TASK_STATE_REJECTED
-     * UNKNOWN                → UNRECOGNIZED
-     * null                   → UNRECOGNIZED
+     * UNKNOWN                → TASK_STATE_UNSPECIFIED
+     * null                   → TASK_STATE_UNSPECIFIED
      * </pre>
      *
      * @param v03 the v0.3 task state (may be null)
@@ -89,7 +89,7 @@ public interface TaskStateMapper_v0_3 {
      * TASK_STATE_CANCELED          → CANCELED
      * TASK_STATE_FAILED            → FAILED
      * TASK_STATE_REJECTED          → REJECTED
-     * UNRECOGNIZED                 → UNKNOWN
+     * TASK_STATE_UNSPECIFIED        → UNKNOWN
      * null                         → UNKNOWN
      * </pre>
      *

--- a/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/TaskStateMapper_v0_3.java
+++ b/compat-0.3/server-conversion/src/main/java/org/a2aproject/sdk/compat03/conversion/mappers/domain/TaskStateMapper_v0_3.java
@@ -59,7 +59,7 @@ public interface TaskStateMapper_v0_3 {
      */
     default TaskState toV10(TaskState_v0_3 v03) {
         if (v03 == null) {
-            return TaskState.UNRECOGNIZED;
+            return TaskState.TASK_STATE_UNSPECIFIED;
         }
         return switch (v03) {
             case SUBMITTED -> TaskState.TASK_STATE_SUBMITTED;
@@ -70,7 +70,7 @@ public interface TaskStateMapper_v0_3 {
             case CANCELED -> TaskState.TASK_STATE_CANCELED;
             case FAILED -> TaskState.TASK_STATE_FAILED;
             case REJECTED -> TaskState.TASK_STATE_REJECTED;
-            case UNKNOWN -> TaskState.UNRECOGNIZED;
+            case UNKNOWN -> TaskState.TASK_STATE_UNSPECIFIED;
         };
     }
 
@@ -109,7 +109,7 @@ public interface TaskStateMapper_v0_3 {
             case TASK_STATE_CANCELED -> TaskState_v0_3.CANCELED;
             case TASK_STATE_FAILED -> TaskState_v0_3.FAILED;
             case TASK_STATE_REJECTED -> TaskState_v0_3.REJECTED;
-            case UNRECOGNIZED -> TaskState_v0_3.UNKNOWN;
+            case TASK_STATE_UNSPECIFIED -> TaskState_v0_3.UNKNOWN;
         };
     }
 }

--- a/spec-grpc/src/main/java/org/a2aproject/sdk/grpc/mapper/A2ACommonFieldMapper.java
+++ b/spec-grpc/src/main/java/org/a2aproject/sdk/grpc/mapper/A2ACommonFieldMapper.java
@@ -445,7 +445,7 @@ public interface A2ACommonFieldMapper {
         // Reject invalid enum values (e.g., "INVALID_STATUS" from JSON)
         if (state == org.a2aproject.sdk.grpc.TaskState.UNRECOGNIZED) {
             String validStates = java.util.Arrays.stream(org.a2aproject.sdk.spec.TaskState.values())
-                    .filter(s -> s != org.a2aproject.sdk.spec.TaskState.UNRECOGNIZED)
+                    .filter(s -> s != org.a2aproject.sdk.spec.TaskState.TASK_STATE_UNSPECIFIED)
                     .map(Enum::name)
                     .collect(java.util.stream.Collectors.joining(", "));
             throw new InvalidParamsError(null,

--- a/spec-grpc/src/main/java/org/a2aproject/sdk/grpc/mapper/TaskStateMapper.java
+++ b/spec-grpc/src/main/java/org/a2aproject/sdk/grpc/mapper/TaskStateMapper.java
@@ -38,7 +38,7 @@ public interface TaskStateMapper {
             case TASK_STATE_CANCELED -> org.a2aproject.sdk.grpc.TaskState.TASK_STATE_CANCELED;
             case TASK_STATE_FAILED -> org.a2aproject.sdk.grpc.TaskState.TASK_STATE_FAILED;
             case TASK_STATE_REJECTED -> org.a2aproject.sdk.grpc.TaskState.TASK_STATE_REJECTED;
-            case UNRECOGNIZED -> org.a2aproject.sdk.grpc.TaskState.UNRECOGNIZED;
+            case TASK_STATE_UNSPECIFIED -> org.a2aproject.sdk.grpc.TaskState.UNRECOGNIZED;
         };
     }
 
@@ -50,7 +50,7 @@ public interface TaskStateMapper {
      */
     default org.a2aproject.sdk.spec.TaskState fromProto(org.a2aproject.sdk.grpc.TaskState proto) {
         if (proto == null) {
-            return org.a2aproject.sdk.spec.TaskState.UNRECOGNIZED;
+            return org.a2aproject.sdk.spec.TaskState.TASK_STATE_UNSPECIFIED;
         }
 
         return switch (proto) {
@@ -62,7 +62,7 @@ public interface TaskStateMapper {
             case TASK_STATE_CANCELED -> org.a2aproject.sdk.spec.TaskState.TASK_STATE_CANCELED;
             case TASK_STATE_FAILED -> org.a2aproject.sdk.spec.TaskState.TASK_STATE_FAILED;
             case TASK_STATE_REJECTED -> org.a2aproject.sdk.spec.TaskState.TASK_STATE_REJECTED;
-            case TASK_STATE_UNSPECIFIED, UNRECOGNIZED -> org.a2aproject.sdk.spec.TaskState.UNRECOGNIZED;
+            case TASK_STATE_UNSPECIFIED, UNRECOGNIZED -> org.a2aproject.sdk.spec.TaskState.TASK_STATE_UNSPECIFIED;
         };
     }
 }

--- a/spec-grpc/src/main/java/org/a2aproject/sdk/grpc/mapper/TaskStateMapper.java
+++ b/spec-grpc/src/main/java/org/a2aproject/sdk/grpc/mapper/TaskStateMapper.java
@@ -38,7 +38,7 @@ public interface TaskStateMapper {
             case TASK_STATE_CANCELED -> org.a2aproject.sdk.grpc.TaskState.TASK_STATE_CANCELED;
             case TASK_STATE_FAILED -> org.a2aproject.sdk.grpc.TaskState.TASK_STATE_FAILED;
             case TASK_STATE_REJECTED -> org.a2aproject.sdk.grpc.TaskState.TASK_STATE_REJECTED;
-            case TASK_STATE_UNSPECIFIED -> org.a2aproject.sdk.grpc.TaskState.UNRECOGNIZED;
+            case TASK_STATE_UNSPECIFIED -> org.a2aproject.sdk.grpc.TaskState.TASK_STATE_UNSPECIFIED;
         };
     }
 
@@ -46,7 +46,7 @@ public interface TaskStateMapper {
      * Converts proto TaskState to domain TaskState.
      *
      * @param proto the proto task state
-     * @return the domain task state, or UNKNOWN if input is null or unrecognized
+     * @return the domain task state, or TASK_STATE_UNSPECIFIED if input is null or unrecognized
      */
     default org.a2aproject.sdk.spec.TaskState fromProto(org.a2aproject.sdk.grpc.TaskState proto) {
         if (proto == null) {

--- a/spec/src/main/java/org/a2aproject/sdk/spec/TaskState.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/TaskState.java
@@ -64,7 +64,7 @@ public enum TaskState {
     TASK_STATE_REJECTED(true, false),
 
     /** Task state is unknown or cannot be determined (terminal state). */
-    UNRECOGNIZED(true, false);
+    TASK_STATE_UNSPECIFIED(true, false);
 
     private final boolean isFinal;
     private final boolean isInterrupted;

--- a/spec/src/main/java/org/a2aproject/sdk/spec/TaskState.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/TaskState.java
@@ -27,7 +27,7 @@ package org.a2aproject.sdk.spec;
  *   <li><b>TASK_STATE_CANCELED:</b> Task was explicitly canceled by the user or system</li>
  *   <li><b>TASK_STATE_FAILED:</b> Task failed due to an error during execution</li>
  *   <li><b>TASK_STATE_REJECTED:</b> Task was rejected by the agent (e.g., invalid request, policy violation)</li>
- *   <li><b>UNRECOGNIZED:</b> Task state cannot be determined (error recovery state)</li>
+ *   <li><b>TASK_STATE_UNSPECIFIED:</b> Task state cannot be determined (error recovery state)</li>
  * </ul>
  * <p>
  * The {@link #isFinal()} method can be used to determine if a state is terminal, which is
@@ -81,7 +81,7 @@ public enum TaskState {
      * not transition to any other state. This is used by the event queue system
      * to determine when to close queues and by clients to know when to stop polling.
      * <p>
-     * Terminal states: COMPLETED, FAILED, CANCELED, REJECTED, UNRECOGNIZED.
+     * Terminal states: TASK_STATE_COMPLETED, TASK_STATE_FAILED, TASK_STATE_CANCELED, TASK_STATE_REJECTED, TASK_STATE_UNSPECIFIED.
      *
      * @return {@code true} if this is a terminal state, {@code false} else.
      */

--- a/spec/src/main/java/org/a2aproject/sdk/spec/TaskState.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/TaskState.java
@@ -64,7 +64,7 @@ public enum TaskState {
     TASK_STATE_REJECTED(true, false),
 
     /** Task state is unknown or cannot be determined (terminal state). */
-    TASK_STATE_UNSPECIFIED(true, false);
+    TASK_STATE_UNSPECIFIED(false, false);
 
     private final boolean isFinal;
     private final boolean isInterrupted;


### PR DESCRIPTION

BREAKING CHANGE: This is an actual bug in our implementation so it was seen as suitable for a micro release. Users compiling against UNRECOGNIZED will need to replace this with TASK_STATE_UNSPECIFIED.

Fixes #958 🦕