### PR TITLE
fix: apply historyLength to SendStreamingMessage responses

### DIFF
--- a/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
@@ -312,7 +312,7 @@ public class DefaultRequestHandler implements RequestHandler {
      * Limits the history of a task to the most recent N messages.
      *
      * @param task the task to limit
-     * @param historyLength the maximum number of recent messages to keep (0 or negative = unlimited)
+     * @param historyLength the maximum number of recent messages to keep ({@code null} = no limit, 0 = empty history)
      * @return the task with limited history, or the original task if no limiting needed
      */
     private static Task limitTaskHistory(Task task, @Nullable Integer historyLength) {
@@ -736,6 +736,10 @@ public class DefaultRequestHandler implements RequestHandler {
                     @Override
                     public void onNext(StreamingEventKind item) {
                         LOGGER.debug("onNext: {} for task {}", item.getClass().getSimpleName(), taskId.get());
+                        if (item instanceof Task task) {
+                            Integer historyLength = params.configuration() != null ? params.configuration().historyLength() : null;
+                            item = limitTaskHistory(task, historyLength);
+                        }
                         subscriber.onNext(item);
                     }
 

--- a/tests/server-common/src/test/java/org/a2aproject/sdk/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/org/a2aproject/sdk/server/apps/common/AbstractA2AServerTest.java
@@ -3193,4 +3193,79 @@ public abstract class AbstractA2AServerTest {
         }
     }
 
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testSendStreamingMessageWithHistoryLengthZero() throws Exception {
+        AtomicReference<String> taskIdRef = new AtomicReference<>();
+
+        try {
+            Message initialMessage = Message.builder(MESSAGE)
+                    .parts(new TextPart("input-required:Trigger INPUT_REQUIRED"))
+                    .build();
+
+            CountDownLatch initialLatch = new CountDownLatch(1);
+            getClient().sendMessage(initialMessage, List.of((event, agentCard) -> {
+                if (event instanceof TaskEvent te) {
+                    taskIdRef.set(te.getTask().id());
+                    initialLatch.countDown();
+                } else if (event instanceof TaskUpdateEvent tue) {
+                    taskIdRef.set(tue.getTask().id());
+                    if (tue.getTask().status().state() == TaskState.TASK_STATE_INPUT_REQUIRED) {
+                        initialLatch.countDown();
+                    }
+                }
+            }), error -> {
+                if (!isStreamClosedError(error)) {
+                    initialLatch.countDown();
+                }
+            });
+
+            assertTrue(initialLatch.await(15, TimeUnit.SECONDS), "Initial streaming sendMessage should complete");
+            String taskId = taskIdRef.get();
+            assertNotNull(taskId, "Should have captured task ID");
+
+            Message followUp = Message.builder(MESSAGE)
+                    .taskId(taskId)
+                    .parts(new TextPart("input-required:User input"))
+                    .build();
+
+            MessageSendParams params = MessageSendParams.builder()
+                    .message(followUp)
+                    .configuration(MessageSendConfiguration.builder()
+                            .historyLength(0)
+                            .build())
+                    .build();
+
+            CountDownLatch followUpLatch = new CountDownLatch(1);
+            AtomicReference<Task> resultTaskRef = new AtomicReference<>();
+            getClient().sendMessage(params, List.of((BiConsumer<ClientEvent, AgentCard>) (event, agentCard) -> {
+                if (event instanceof TaskEvent te) {
+                    resultTaskRef.set(te.getTask());
+                    followUpLatch.countDown();
+                } else if (event instanceof TaskUpdateEvent tue) {
+                    resultTaskRef.set(tue.getTask());
+                    if (tue.getTask().status().state() == TaskState.TASK_STATE_COMPLETED) {
+                        followUpLatch.countDown();
+                    }
+                }
+            }), error -> {
+                if (!isStreamClosedError(error)) {
+                    followUpLatch.countDown();
+                }
+            }, null);
+
+            assertTrue(followUpLatch.await(15, TimeUnit.SECONDS), "Follow-up streaming sendMessage should complete");
+            Task resultTask = resultTaskRef.get();
+            assertNotNull(resultTask, "Should have received a Task response");
+            assertTrue(resultTask.history() == null || resultTask.history().isEmpty(),
+                    "historyLength=0 should return no history, but got " +
+                            (resultTask.history() != null ? resultTask.history().size() : 0) + " messages");
+        } finally {
+            String taskId = taskIdRef.get();
+            if (taskId != null) {
+                deleteTaskInTaskStore(taskId);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
The streaming path (onMessageSendStream) was not applying limitTaskHistory to Task events, causing historyLength to be silently ignored for streaming calls. Added the same limitTaskHistory call used in the non-streaming path to the streaming subscriber's onNext method.

This fixes #982
