### PR TITLE
fix: skip hidden directories in BOM verifier class discovery

### DIFF
--- a/boms/test-utils/src/main/java/org/a2aproject/sdk/bom/test/DynamicBomVerifier.java
+++ b/boms/test-utils/src/main/java/org/a2aproject/sdk/bom/test/DynamicBomVerifier.java
@@ -158,7 +158,7 @@ public abstract class DynamicBomVerifier {
                  .filter(p -> p.toString().endsWith(".java"))
                  .filter(p -> {
                      String relativePath = toForwardSlash(projectRoot.relativize(p).toString());
-                     return relativePath.contains("/src/main/java/") && pathFilter.test(relativePath);
+                     return !relativePath.startsWith(".") && relativePath.contains("/src/main/java/") && pathFilter.test(relativePath);
                  })
                  .forEach(javaFile -> {
                      try {


### PR DESCRIPTION
Files.walk traverses into .claude/worktrees/ which contains full repo copies, causing the same classes to appear in both the required and forbidden sets. Skip any path starting with "." to avoid scanning hidden directories like .claude/, .git/, etc.
