### PR TITLE
fix: Deprecate isFinal overrides in AgentEmitter interrupted state me…

### DIFF
--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/AgentEmitter.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/AgentEmitter.java
@@ -115,10 +115,6 @@ public class AgentEmitter {
         this.contextId = context.getContextId();
     }
 
-    private void updateStatus(TaskState taskState) {
-        updateStatus(taskState, null, taskState.isFinal());
-    }
-
     /**
      * Updates the task status to the given state with an optional message.
      *
@@ -126,17 +122,7 @@ public class AgentEmitter {
      * @param message optional message to include with the status update
      */
     public void updateStatus(TaskState taskState, @Nullable Message message) {
-        updateStatus(taskState, message, taskState.isFinal());
-    }
-
-    /**
-     * Updates the task status to the given state with an optional message and finality flag.
-     *
-     * @param state the new task state
-     * @param message optional message to include with the status update
-     * @param isFinal whether this is a final status (prevents further updates)
-     */
-    private void updateStatus(TaskState state, @Nullable Message message, boolean isFinal) {
+        boolean isFinal = taskState.isFinal();
         // Check terminal state first (fail fast)
         if (terminalStateReached.get()) {
             throw new IllegalStateException("Cannot update task status - terminal state already reached");
@@ -152,7 +138,7 @@ public class AgentEmitter {
         TaskStatusUpdateEvent event = TaskStatusUpdateEvent.builder()
                 .taskId(taskId)
                 .contextId(contextId)
-                .status(new TaskStatus(state, message, null))
+                .status(new TaskStatus(taskState, message, null))
                 .build();
         eventQueue.enqueueEvent(event);
     }
@@ -371,7 +357,7 @@ public class AgentEmitter {
      * Marks the task as INPUT_REQUIRED, indicating the agent needs user input to continue.
      */
     public void requiresInput() {
-        requiresInput(null, false);
+        requiresInput(null);
     }
 
     /**
@@ -380,33 +366,39 @@ public class AgentEmitter {
      * @param message optional message to include
      */
     public void requiresInput(@Nullable Message message) {
-        requiresInput(message, false);
+        updateStatus(TaskState.TASK_STATE_INPUT_REQUIRED, message);
     }
 
     /**
-     * Marks the task as INPUT_REQUIRED with a finality flag.
+     * Marks the task as INPUT_REQUIRED.
      *
-     * @param isFinal whether this is a final status (prevents further updates)
+     * @param isFinal ignored — interrupted states are not final per the A2A specification.
+     *                Use {@link #requiresInput()} instead.
+     * @deprecated The {@code isFinal} parameter has no effect. Use {@link #requiresInput()} instead.
      */
+    @Deprecated(forRemoval = true)
     public void requiresInput(boolean isFinal) {
-        requiresInput(null, isFinal);
+        requiresInput();
     }
 
     /**
-     * Marks the task as INPUT_REQUIRED with an optional message and finality flag.
+     * Marks the task as INPUT_REQUIRED with an optional message.
      *
      * @param message optional message to include
-     * @param isFinal whether this is a final status (prevents further updates)
+     * @param isFinal ignored — interrupted states are not final per the A2A specification.
+     *                Use {@link #requiresInput(Message)} instead.
+     * @deprecated The {@code isFinal} parameter has no effect. Use {@link #requiresInput(Message)} instead.
      */
+    @Deprecated(forRemoval = true)
     public void requiresInput(@Nullable Message message, boolean isFinal) {
-        updateStatus(TaskState.TASK_STATE_INPUT_REQUIRED, message, isFinal);
+        requiresInput(message);
     }
 
     /**
      * Marks the task as AUTH_REQUIRED, indicating the agent needs authentication to continue.
      */
     public void requiresAuth() {
-        requiresAuth(null, false);
+        requiresAuth(null);
     }
 
     /**
@@ -415,26 +407,32 @@ public class AgentEmitter {
      * @param message optional message to include
      */
     public void requiresAuth(@Nullable Message message) {
-        requiresAuth(message, false);
+        updateStatus(TaskState.TASK_STATE_AUTH_REQUIRED, message);
     }
 
     /**
-     * Marks the task as AUTH_REQUIRED with a finality flag.
+     * Marks the task as AUTH_REQUIRED.
      *
-     * @param isFinal whether this is a final status (prevents further updates)
+     * @param isFinal ignored — interrupted states are not final per the A2A specification.
+     *                Use {@link #requiresAuth()} instead.
+     * @deprecated The {@code isFinal} parameter has no effect. Use {@link #requiresAuth()} instead.
      */
+    @Deprecated(forRemoval = true)
     public void requiresAuth(boolean isFinal) {
-        requiresAuth(null, isFinal);
+        requiresAuth();
     }
 
     /**
-     * Marks the task as AUTH_REQUIRED with an optional message and finality flag.
+     * Marks the task as AUTH_REQUIRED with an optional message.
      *
      * @param message optional message to include
-     * @param isFinal whether this is a final status (prevents further updates)
+     * @param isFinal ignored — interrupted states are not final per the A2A specification.
+     *                Use {@link #requiresAuth(Message)} instead.
+     * @deprecated The {@code isFinal} parameter has no effect. Use {@link #requiresAuth(Message)} instead.
      */
+    @Deprecated(forRemoval = true)
     public void requiresAuth(@Nullable Message message, boolean isFinal) {
-        updateStatus(TaskState.TASK_STATE_AUTH_REQUIRED, message, isFinal);
+        requiresAuth(message);
     }
 
     /**
@@ -569,7 +567,6 @@ public class AgentEmitter {
      *         .taskId(context.getTaskId())
      *         .contextId(context.getContextId())
      *         .status(new TaskStatus(TaskState.WORKING))
-     *         .isFinal(false)
      *         .build();
      *     emitter.emitEvent(event);
      * }

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/AgentEmitterTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/AgentEmitterTest.java
@@ -184,12 +184,14 @@ public class AgentEmitterTest {
         checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_INPUT_REQUIRED, SAMPLE_MESSAGE);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testRequiresInputWithFinalTrue() throws Exception {
         agentEmitter.requiresInput(true);
         checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_INPUT_REQUIRED, null);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testRequiresInputWithMessageAndFinalTrue() throws Exception {
         agentEmitter.requiresInput(SAMPLE_MESSAGE, true);
@@ -208,12 +210,14 @@ public class AgentEmitterTest {
         checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_AUTH_REQUIRED, SAMPLE_MESSAGE);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testRequiresAuthWithFinalTrue() throws Exception {
         agentEmitter.requiresAuth(true);
         checkTaskStatusUpdateEventOnQueue(false, TaskState.TASK_STATE_AUTH_REQUIRED, null);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testRequiresAuthWithMessageAndFinalTrue() throws Exception {
         agentEmitter.requiresAuth(SAMPLE_MESSAGE, true);


### PR DESCRIPTION
…thods


Fixes #975 🦕

This is an alternative to #980 for the reasons mentioned in https://github.com/a2aproject/a2a-java/pull/980#issuecomment-5044314390