### PR TITLE
fix(server): reconcile blocking result with TaskStore

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -40,6 +40,9 @@ a2a.blocking.agent.timeout.seconds=30
 
 # Timeout for event consumption in blocking calls (default: 5 seconds)
 a2a.blocking.consumption.timeout.seconds=5
+
+# Timeout for TaskStore reconciliation polling in blocking calls (default: 1 second)
+a2a.blocking.reconciliation.timeout.seconds=1
 ```
 
 ### Tuning Guidelines
@@ -48,6 +51,7 @@ a2a.blocking.consumption.timeout.seconds=5
 - **Resource Management**: The dedicated executor prevents streaming operations from competing with the ForkJoinPool.
 - **Concurrency**: In production with high concurrent streaming, increase pool sizes accordingly.
 - **Agent Timeouts**: LLM-based agents may need longer timeouts (60-120s) compared to simple agents.
+- **Reconciliation Timeout**: Increase if blocking calls fail with "Could not find a Task/Message" under heavy load or with slow TaskStore implementations.
 
 ## MicroProfile Config Integration
 

--- a/integrations/microprofile-config/README.md
+++ b/integrations/microprofile-config/README.md
@@ -37,6 +37,7 @@ a2a.executor.max-pool-size=100
 # Timeout configuration
 a2a.blocking.agent.timeout.seconds=60
 a2a.blocking.consumption.timeout.seconds=10
+a2a.blocking.reconciliation.timeout.seconds=2
 ```
 
 **Environment variables:**

--- a/integrations/microprofile-config/src/test/java/org/a2aproject/sdk/integrations/microprofile/MicroProfileConfigProviderTest.java
+++ b/integrations/microprofile-config/src/test/java/org/a2aproject/sdk/integrations/microprofile/MicroProfileConfigProviderTest.java
@@ -24,6 +24,8 @@ public class MicroProfileConfigProviderTest {
     private static final String A2A_EXECUTOR_CORE_POOL_SIZE = "a2a.executor.core-pool-size";
     private static final String A2A_EXECUTOR_MAX_POOL_SIZE = "a2a.executor.max-pool-size";
     private static final String A2A_EXECUTOR_KEEP_ALIVE_SECONDS = "a2a.executor.keep-alive-seconds";
+    private static final String A2A_BLOCKING_RECONCILIATION_TIMEOUT_SECONDS =
+            "a2a.blocking.reconciliation.timeout.seconds";
 
     @Inject
     A2AConfigProvider configProvider;
@@ -57,6 +59,12 @@ public class MicroProfileConfigProviderTest {
         // Test another default property to ensure fallback works
         String value = configProvider.getValue(A2A_EXECUTOR_KEEP_ALIVE_SECONDS);
         assertEquals("60", value, "Should fall back to default value");
+    }
+
+    @Test
+    public void testGetReconciliationTimeoutDefault() {
+        String value = configProvider.getValue(A2A_BLOCKING_RECONCILIATION_TIMEOUT_SECONDS);
+        assertEquals("1", value, "Should fall back to the reconciliation timeout default");
     }
 
     @Test

--- a/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
@@ -142,8 +142,9 @@ import org.slf4j.LoggerFactory;
  *   <li><b>Blocking (configuration.blocking=true):</b> Client waits for first event or final task state</li>
  *   <li><b>Streaming:</b> Client receives events as they arrive via reactive streams</li>
  *   <li>Both modes support fire-and-forget (agent continues after client disconnect)</li>
- *   <li>Configurable timeouts via {@code a2a.blocking.agent.timeout.seconds} and
- *       {@code a2a.blocking.consumption.timeout.seconds}</li>
+ *   <li>Configurable timeouts via {@code a2a.blocking.agent.timeout.seconds},
+ *       {@code a2a.blocking.consumption.timeout.seconds}, and
+ *       {@code a2a.blocking.reconciliation.timeout.seconds}</li>
  * </ul>
  *
  * <h2>CDI Dependencies</h2>
@@ -189,6 +190,7 @@ public class DefaultRequestHandler implements RequestHandler {
 
     private static final String A2A_BLOCKING_AGENT_TIMEOUT_SECONDS = "a2a.blocking.agent.timeout.seconds";
     private static final String A2A_BLOCKING_CONSUMPTION_TIMEOUT_SECONDS = "a2a.blocking.consumption.timeout.seconds";
+    private static final String A2A_BLOCKING_RECONCILIATION_TIMEOUT_SECONDS = "a2a.blocking.reconciliation.timeout.seconds";
 
     @Inject
     A2AConfigProvider configProvider;
@@ -214,6 +216,19 @@ public class DefaultRequestHandler implements RequestHandler {
      * (e.g., MicroProfileConfigProvider in reference implementations).
      */
     int consumptionCompletionTimeoutSeconds;
+
+    /**
+     * Timeout in seconds for TaskStore reconciliation polling in blocking calls.
+     * When the in-memory event capture is empty, the aggregator polls TaskStore
+     * with a bounded timeout to handle the race where MainEventBusProcessor
+     * has not yet persisted the task.
+     * <p>
+     * Property: {@code a2a.blocking.reconciliation.timeout.seconds}<br>
+     * Default: 1 second<br>
+     * Note: Property override requires a configurable {@link A2AConfigProvider} on the classpath
+     * (e.g., MicroProfileConfigProvider in reference implementations).
+     */
+    int reconciliationTimeoutSeconds;
 
     // Fields set by constructor injection cannot be final. We need a noargs constructor for
     // Jakarta compatibility, and it seems that making fields set by constructor injection
@@ -276,6 +291,8 @@ public class DefaultRequestHandler implements RequestHandler {
                 configProvider.getValue(A2A_BLOCKING_AGENT_TIMEOUT_SECONDS));
         consumptionCompletionTimeoutSeconds = Integer.parseInt(
                 configProvider.getValue(A2A_BLOCKING_CONSUMPTION_TIMEOUT_SECONDS));
+        reconciliationTimeoutSeconds = Integer.parseInt(
+                configProvider.getValue(A2A_BLOCKING_RECONCILIATION_TIMEOUT_SECONDS));
     }
 
 
@@ -291,6 +308,7 @@ public class DefaultRequestHandler implements RequestHandler {
                         mainEventBusProcessor, executor, eventConsumerExecutor);
         handler.agentCompletionTimeoutSeconds = 5;
         handler.consumptionCompletionTimeoutSeconds = 2;
+        handler.reconciliationTimeoutSeconds = 1;
 
         return handler;
     }
@@ -377,7 +395,8 @@ public class DefaultRequestHandler implements RequestHandler {
                 taskStore,
                 null);
 
-        ResultAggregator resultAggregator = new ResultAggregator(taskManager, null, executor, eventConsumerExecutor);
+        ResultAggregator resultAggregator = new ResultAggregator(taskManager, null, executor, eventConsumerExecutor,
+                        SECONDS.toNanos(reconciliationTimeoutSeconds));
 
         EventQueue queue = queueManager.createOrTap(task.id());
         EventConsumer consumer = new EventConsumer(queue, eventConsumerExecutor);
@@ -450,7 +469,8 @@ public class DefaultRequestHandler implements RequestHandler {
         // Create queue with real taskId (no tempId parameter needed)
         EventQueue queue = queueManager.createOrTap(queueTaskId);
         final java.util.concurrent.atomic.AtomicReference<@NonNull String> taskId = new java.util.concurrent.atomic.AtomicReference<>(queueTaskId);
-        ResultAggregator resultAggregator = new ResultAggregator(mss.taskManager, null, executor, eventConsumerExecutor);
+        ResultAggregator resultAggregator = new ResultAggregator(mss.taskManager, null, executor, eventConsumerExecutor,
+                        SECONDS.toNanos(reconciliationTimeoutSeconds));
 
         // Default to blocking per A2A spec (returnImmediately defaults to false, meaning wait for completion)
         boolean returnImmediately = params.configuration() != null && Boolean.TRUE.equals(params.configuration().returnImmediately());
@@ -668,7 +688,8 @@ public class DefaultRequestHandler implements RequestHandler {
                     .taskId(taskId.get()).build(), version);
         }
 
-        ResultAggregator resultAggregator = new ResultAggregator(mss.taskManager, null, executor, eventConsumerExecutor);
+        ResultAggregator resultAggregator = new ResultAggregator(mss.taskManager, null, executor, eventConsumerExecutor,
+                        SECONDS.toNanos(reconciliationTimeoutSeconds));
 
         // Create consumer BEFORE starting agent - callback is registered inside registerAndExecuteAgentAsync
         EventConsumer consumer = new EventConsumer(queue, eventConsumerExecutor);
@@ -857,7 +878,8 @@ public class DefaultRequestHandler implements RequestHandler {
         }
 
         TaskManager taskManager = new TaskManager(task.id(), task.contextId(), taskStore, null);
-        ResultAggregator resultAggregator = new ResultAggregator(taskManager, null, executor, eventConsumerExecutor);
+        ResultAggregator resultAggregator = new ResultAggregator(taskManager, null, executor, eventConsumerExecutor,
+                        SECONDS.toNanos(reconciliationTimeoutSeconds));
         EventQueue queue = queueManager.tap(task.id());
         LOGGER.debug("onSubscribeToTask - tapped queue: {}", queue != null ? System.identityHashCode(queue) : "null");
 

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/ResultAggregator.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/ResultAggregator.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -28,6 +29,8 @@ import org.slf4j.LoggerFactory;
 
 public class ResultAggregator {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResultAggregator.class);
+    private static final long TASK_STORE_RECONCILIATION_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(1);
+    private static final long TASK_STORE_RECONCILIATION_POLL_MILLIS = 10;
 
     private final TaskManager taskManager;
     private final Executor executor;
@@ -235,7 +238,7 @@ public class ResultAggregator {
             Utils.rethrow(error);
         }
 
-        // Return Message if captured, otherwise Task if captured, otherwise fetch from TaskStore
+        // Return Message if captured, otherwise Task if captured, otherwise reconcile with TaskStore.
         EventKind eventKind = message.get();
         if (eventKind == null) {
             eventKind = capturedTask.get();
@@ -244,7 +247,7 @@ public class ResultAggregator {
             }
         }
         if (eventKind == null) {
-            eventKind = taskManager.getTask();
+            eventKind = reconcileTaskStore(blocking);
             if (LOGGER.isDebugEnabled() && eventKind instanceof Task t) {
                 LOGGER.debug("Returning task from TaskStore: id={}, state={}", t.id(), t.status().state());
             }
@@ -257,6 +260,29 @@ public class ResultAggregator {
                 eventKind,
                 interrupted.get(),
                 consumptionCompletionFuture);
+    }
+
+    private @Nullable Task reconcileTaskStore(boolean blocking) throws A2AError {
+        Task task = taskManager.getTask();
+        if (task != null || !blocking) {
+            return task;
+        }
+
+        long deadline = System.nanoTime() + TASK_STORE_RECONCILIATION_TIMEOUT_NANOS;
+        while (System.nanoTime() < deadline) {
+            try {
+                Thread.sleep(TASK_STORE_RECONCILIATION_POLL_MILLIS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new InternalError("Interrupted while reconciling TaskStore for " + taskManager.getTaskId());
+            }
+
+            task = taskManager.getTask();
+            if (task != null) {
+                return task;
+            }
+        }
+        return null;
     }
 
     private String taskIdForLogging() {

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/ResultAggregator.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/ResultAggregator.java
@@ -29,19 +29,21 @@ import org.slf4j.LoggerFactory;
 
 public class ResultAggregator {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResultAggregator.class);
-    private static final long TASK_STORE_RECONCILIATION_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(1);
     private static final long TASK_STORE_RECONCILIATION_POLL_MILLIS = 10;
 
     private final TaskManager taskManager;
     private final Executor executor;
     private final Executor eventConsumerExecutor;
+    private final long reconciliationTimeoutNanos;
     private volatile @Nullable Message message;
 
-    public ResultAggregator(TaskManager taskManager, @Nullable Message message, Executor executor, Executor eventConsumerExecutor) {
+    public ResultAggregator(TaskManager taskManager, @Nullable Message message, Executor executor,
+            Executor eventConsumerExecutor, long reconciliationTimeoutNanos) {
         this.taskManager = taskManager;
         this.message = message;
         this.executor = executor;
         this.eventConsumerExecutor = eventConsumerExecutor;
+        this.reconciliationTimeoutNanos = reconciliationTimeoutNanos;
     }
 
     public @Nullable EventKind getCurrentResult() {
@@ -238,7 +240,8 @@ public class ResultAggregator {
             Utils.rethrow(error);
         }
 
-        // Return Message if captured, otherwise Task if captured, otherwise reconcile with TaskStore.
+        // Return Message if captured, otherwise Task if captured,
+        // otherwise poll TaskStore with bounded timeout (blocking) or single read (non-blocking).
         EventKind eventKind = message.get();
         if (eventKind == null) {
             eventKind = capturedTask.get();
@@ -268,7 +271,10 @@ public class ResultAggregator {
             return task;
         }
 
-        long deadline = System.nanoTime() + TASK_STORE_RECONCILIATION_TIMEOUT_NANOS;
+        LOGGER.debug("TaskStore reconciliation: task not found on first read, polling for up to {}ms",
+                TimeUnit.NANOSECONDS.toMillis(reconciliationTimeoutNanos));
+
+        long deadline = System.nanoTime() + reconciliationTimeoutNanos;
         while (System.nanoTime() < deadline) {
             try {
                 Thread.sleep(TASK_STORE_RECONCILIATION_POLL_MILLIS);
@@ -279,6 +285,7 @@ public class ResultAggregator {
 
             task = taskManager.getTask();
             if (task != null) {
+                LOGGER.debug("TaskStore reconciliation: task {} found after polling", task.id());
                 return task;
             }
         }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/ResultAggregator.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/ResultAggregator.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 public class ResultAggregator {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResultAggregator.class);
+    private static final long DEFAULT_TASK_STORE_RECONCILIATION_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(1);
     private static final long TASK_STORE_RECONCILIATION_POLL_MILLIS = 10;
 
     private final TaskManager taskManager;
@@ -36,6 +37,12 @@ public class ResultAggregator {
     private final Executor eventConsumerExecutor;
     private final long reconciliationTimeoutNanos;
     private volatile @Nullable Message message;
+
+    public ResultAggregator(TaskManager taskManager, @Nullable Message message, Executor executor,
+            Executor eventConsumerExecutor) {
+        this(taskManager, message, executor, eventConsumerExecutor,
+                DEFAULT_TASK_STORE_RECONCILIATION_TIMEOUT_NANOS);
+    }
 
     public ResultAggregator(TaskManager taskManager, @Nullable Message message, Executor executor,
             Executor eventConsumerExecutor, long reconciliationTimeoutNanos) {

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/ResultAggregator.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/ResultAggregator.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 
 public class ResultAggregator {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResultAggregator.class);
-    private static final long DEFAULT_TASK_STORE_RECONCILIATION_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(1);
     private static final long TASK_STORE_RECONCILIATION_POLL_MILLIS = 10;
 
     private final TaskManager taskManager;
@@ -37,12 +36,6 @@ public class ResultAggregator {
     private final Executor eventConsumerExecutor;
     private final long reconciliationTimeoutNanos;
     private volatile @Nullable Message message;
-
-    public ResultAggregator(TaskManager taskManager, @Nullable Message message, Executor executor,
-            Executor eventConsumerExecutor) {
-        this(taskManager, message, executor, eventConsumerExecutor,
-                DEFAULT_TASK_STORE_RECONCILIATION_TIMEOUT_NANOS);
-    }
 
     public ResultAggregator(TaskManager taskManager, @Nullable Message message, Executor executor,
             Executor eventConsumerExecutor, long reconciliationTimeoutNanos) {

--- a/server-common/src/main/resources/META-INF/a2a-defaults.properties
+++ b/server-common/src/main/resources/META-INF/a2a-defaults.properties
@@ -10,6 +10,10 @@ a2a.blocking.agent.timeout.seconds=30
 # Ensures TaskStore is fully updated before returning to client
 a2a.blocking.consumption.timeout.seconds=5
 
+# Timeout for TaskStore reconciliation polling in blocking calls (seconds)
+# When in-memory event capture is empty, polls TaskStore with this bounded timeout
+a2a.blocking.reconciliation.timeout.seconds=1
+
 # AsyncExecutorProducer - Thread pool configuration
 # Core pool size for async agent execution
 a2a.executor.core-pool-size=5

--- a/server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandlerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandlerTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
@@ -20,6 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.a2aproject.sdk.server.ServerCallContext;
 import org.a2aproject.sdk.server.agentexecution.AgentExecutor;
 import org.a2aproject.sdk.server.agentexecution.RequestContext;
+import org.a2aproject.sdk.server.config.A2AConfigProvider;
 import org.a2aproject.sdk.server.events.EventQueue;
 import org.a2aproject.sdk.server.events.EventQueueItem;
 import org.a2aproject.sdk.server.events.EventQueueUtil;
@@ -144,6 +147,22 @@ public class DefaultRequestHandlerTest {
      */
     protected interface AgentExecutorMethod {
         void invoke(RequestContext context, AgentEmitter agentEmitter) throws A2AError;
+    }
+
+    @Test
+    void testInitConfigReadsBlockingTimeouts() {
+        A2AConfigProvider configProvider = mock(A2AConfigProvider.class);
+        when(configProvider.getValue("a2a.blocking.agent.timeout.seconds")).thenReturn("30");
+        when(configProvider.getValue("a2a.blocking.consumption.timeout.seconds")).thenReturn("5");
+        when(configProvider.getValue("a2a.blocking.reconciliation.timeout.seconds")).thenReturn("7");
+
+        DefaultRequestHandler handler = new DefaultRequestHandler();
+        handler.configProvider = configProvider;
+        handler.initConfig();
+
+        assertEquals(30, handler.agentCompletionTimeoutSeconds);
+        assertEquals(5, handler.consumptionCompletionTimeoutSeconds);
+        assertEquals(7, handler.reconciliationTimeoutSeconds);
     }
 
     /**

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/ResultAggregatorTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/ResultAggregatorTest.java
@@ -62,7 +62,7 @@ public class ResultAggregatorTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        aggregator = new ResultAggregator(mockTaskManager, null, testExecutor, testExecutor, TimeUnit.SECONDS.toNanos(1));
+        aggregator = new ResultAggregator(mockTaskManager, null, testExecutor, testExecutor);
     }
 
     // Helper methods for creating sample data

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/ResultAggregatorTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/ResultAggregatorTest.java
@@ -62,7 +62,7 @@ public class ResultAggregatorTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        aggregator = new ResultAggregator(mockTaskManager, null, testExecutor, testExecutor);
+        aggregator = new ResultAggregator(mockTaskManager, null, testExecutor, testExecutor, TimeUnit.SECONDS.toNanos(1));
     }
 
     // Helper methods for creating sample data
@@ -120,7 +120,7 @@ public class ResultAggregatorTest {
     @Test
     void testConstructorWithMessage() {
         Message initialMessage = createSampleMessage("initial", "msg1", Message.Role.ROLE_USER);
-        ResultAggregator aggregatorWithMessage = new ResultAggregator(mockTaskManager, initialMessage, testExecutor, testExecutor);
+        ResultAggregator aggregatorWithMessage = new ResultAggregator(mockTaskManager, initialMessage, testExecutor, testExecutor, TimeUnit.SECONDS.toNanos(1));
 
         // Test that the message is properly stored by checking getCurrentResult
         assertEquals(initialMessage, aggregatorWithMessage.getCurrentResult());
@@ -131,7 +131,7 @@ public class ResultAggregatorTest {
     @Test
     void testGetCurrentResultWithMessageSet() {
         Message sampleMessage = createSampleMessage("hola", "msg1", Message.Role.ROLE_USER);
-        ResultAggregator aggregatorWithMessage = new ResultAggregator(mockTaskManager, sampleMessage, testExecutor, testExecutor);
+        ResultAggregator aggregatorWithMessage = new ResultAggregator(mockTaskManager, sampleMessage, testExecutor, testExecutor, TimeUnit.SECONDS.toNanos(1));
 
         EventKind result = aggregatorWithMessage.getCurrentResult();
 
@@ -166,7 +166,7 @@ public class ResultAggregatorTest {
 
     @Test
     void testConstructorWithNullMessage() {
-        ResultAggregator aggregatorWithNullMessage = new ResultAggregator(mockTaskManager, null, testExecutor, testExecutor);
+        ResultAggregator aggregatorWithNullMessage = new ResultAggregator(mockTaskManager, null, testExecutor, testExecutor, TimeUnit.SECONDS.toNanos(1));
         Task expectedTask = createSampleTask("null_msg_task", TaskState.TASK_STATE_WORKING, "ctx1");
         when(mockTaskManager.getTask()).thenReturn(expectedTask);
 
@@ -226,7 +226,7 @@ public class ResultAggregatorTest {
     void testGetCurrentResultWithMessageTakesPrecedence() {
         // Test that when both message and task are available, message takes precedence
         Message message = createSampleMessage("priority message", "pri1", Message.Role.ROLE_USER);
-        ResultAggregator messageAggregator = new ResultAggregator(mockTaskManager, message, testExecutor, testExecutor);
+        ResultAggregator messageAggregator = new ResultAggregator(mockTaskManager, message, testExecutor, testExecutor, TimeUnit.SECONDS.toNanos(1));
 
         // Even if we set up the task manager to return something, message should take precedence
         Task task = createSampleTask("should_not_be_returned", TaskState.TASK_STATE_WORKING, "ctx1");
@@ -297,7 +297,7 @@ public class ResultAggregatorTest {
 
         TaskManager taskManager = new TaskManager(taskId, "ctx1", taskStore, null);
         ResultAggregator blockingAggregator =
-                new ResultAggregator(taskManager, null, testExecutor, testExecutor);
+                new ResultAggregator(taskManager, null, testExecutor, testExecutor, TimeUnit.SECONDS.toNanos(1));
 
         MainEventBus mainEventBus = new MainEventBus();
         InMemoryQueueManager queueManager =
@@ -325,7 +325,7 @@ public class ResultAggregatorTest {
         TaskStore taskStore = mock(TaskStore.class);
         TaskManager taskManager = new TaskManager(taskId, "ctx1", taskStore, null);
         ResultAggregator blockingAggregator =
-                new ResultAggregator(taskManager, null, testExecutor, testExecutor);
+                new ResultAggregator(taskManager, null, testExecutor, testExecutor, TimeUnit.MILLISECONDS.toNanos(100));
 
         InternalError error = assertThrows(InternalError.class, () ->
                 blockingAggregator.consumeAndBreakOnInterrupt(createClosedEventConsumer(taskId), true));
@@ -339,7 +339,7 @@ public class ResultAggregatorTest {
         TaskStore taskStore = mock(TaskStore.class);
         TaskManager taskManager = new TaskManager(taskId, "ctx1", taskStore, null);
         ResultAggregator nonBlockingAggregator =
-                new ResultAggregator(taskManager, null, testExecutor, testExecutor);
+                new ResultAggregator(taskManager, null, testExecutor, testExecutor, TimeUnit.SECONDS.toNanos(1));
 
         assertThrows(InternalError.class, () ->
                 nonBlockingAggregator.consumeAndBreakOnInterrupt(createClosedEventConsumer(taskId), false));

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/ResultAggregatorTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/ResultAggregatorTest.java
@@ -3,8 +3,10 @@ package org.a2aproject.sdk.server.tasks;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -15,7 +17,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.a2aproject.sdk.server.events.EnhancedRunnable;
 import org.a2aproject.sdk.server.events.EventConsumer;
 import org.a2aproject.sdk.server.events.EventQueue;
 import org.a2aproject.sdk.server.events.EventQueueUtil;
@@ -24,6 +28,7 @@ import org.a2aproject.sdk.server.events.MainEventBus;
 import org.a2aproject.sdk.server.events.MainEventBusProcessor;
 import org.a2aproject.sdk.spec.Event;
 import org.a2aproject.sdk.spec.EventKind;
+import org.a2aproject.sdk.spec.InternalError;
 import org.a2aproject.sdk.spec.Message;
 import org.a2aproject.sdk.spec.Task;
 import org.a2aproject.sdk.spec.TaskState;
@@ -279,6 +284,76 @@ public class ResultAggregatorTest {
 
         // Cleanup: stop the processor
         EventQueueUtil.stop(processor);
+    }
+
+    @Test
+    void testBlockingReturnsTaskWhenStoreBecomesVisibleAfterEmptyCapture() throws Exception {
+        String taskId = "task-store-reconciliation";
+        Task completedTask = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED, "ctx1");
+        AtomicBoolean taskVisible = new AtomicBoolean(false);
+        TaskStore taskStore = mock(TaskStore.class);
+        when(taskStore.get(taskId)).thenAnswer(invocation ->
+                taskVisible.compareAndSet(false, true) ? null : completedTask);
+
+        TaskManager taskManager = new TaskManager(taskId, "ctx1", taskStore, null);
+        ResultAggregator blockingAggregator =
+                new ResultAggregator(taskManager, null, testExecutor, testExecutor);
+
+        MainEventBus mainEventBus = new MainEventBus();
+        InMemoryQueueManager queueManager =
+                new InMemoryQueueManager(new MockTaskStateProvider(), mainEventBus);
+        EventQueue queue = queueManager.getEventQueueBuilder(taskId).build().tap();
+        EventConsumer eventConsumer = new EventConsumer(queue, testExecutor);
+
+        EnhancedRunnable completedAgent = new EnhancedRunnable() {
+            @Override
+            public void run() {
+            }
+        };
+        eventConsumer.createAgentRunnableDoneCallback().done(completedAgent);
+
+        ResultAggregator.EventTypeAndInterrupt result =
+                blockingAggregator.consumeAndBreakOnInterrupt(eventConsumer, true);
+
+        assertEquals(completedTask, result.eventType());
+        assertFalse(result.interrupted());
+    }
+
+    @Test
+    void testBlockingStillRaisesMissingTaskErrorWhenStoreRemainsEmpty() {
+        String taskId = "missing-task";
+        TaskStore taskStore = mock(TaskStore.class);
+        TaskManager taskManager = new TaskManager(taskId, "ctx1", taskStore, null);
+        ResultAggregator blockingAggregator =
+                new ResultAggregator(taskManager, null, testExecutor, testExecutor);
+
+        InternalError error = assertThrows(InternalError.class, () ->
+                blockingAggregator.consumeAndBreakOnInterrupt(createClosedEventConsumer(taskId), true));
+
+        assertEquals("Could not find a Task/Message for " + taskId, error.getMessage());
+    }
+
+    @Test
+    void testNonBlockingDoesNotPollTaskStoreWhenCaptureIsEmpty() {
+        String taskId = "non-blocking-missing-task";
+        TaskStore taskStore = mock(TaskStore.class);
+        TaskManager taskManager = new TaskManager(taskId, "ctx1", taskStore, null);
+        ResultAggregator nonBlockingAggregator =
+                new ResultAggregator(taskManager, null, testExecutor, testExecutor);
+
+        assertThrows(InternalError.class, () ->
+                nonBlockingAggregator.consumeAndBreakOnInterrupt(createClosedEventConsumer(taskId), false));
+
+        verify(taskStore, times(1)).get(taskId);
+    }
+
+    private EventConsumer createClosedEventConsumer(String taskId) {
+        MainEventBus mainEventBus = new MainEventBus();
+        InMemoryQueueManager queueManager =
+                new InMemoryQueueManager(new MockTaskStateProvider(), mainEventBus);
+        EventQueue queue = queueManager.getEventQueueBuilder(taskId).build().tap();
+        queue.close();
+        return new EventConsumer(queue, testExecutor);
     }
 
     // AUTH_REQUIRED Tests

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/ResultAggregatorTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/ResultAggregatorTest.java
@@ -62,7 +62,8 @@ public class ResultAggregatorTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        aggregator = new ResultAggregator(mockTaskManager, null, testExecutor, testExecutor);
+        aggregator = new ResultAggregator(mockTaskManager, null, testExecutor, testExecutor,
+                TimeUnit.SECONDS.toNanos(1));
     }
 
     // Helper methods for creating sample data


### PR DESCRIPTION
## Summary

Fixes a race in the blocking Java server response path tracked by [a2aproject/A2A#2049](https://github.com/a2aproject/A2A/issues/2049). `onMessageSend` can currently return an internal error when the agent is complete but TaskStore persistence is still becoming visible to the response aggregator.

## Root Cause / Context

When the event consumer completes without delivering a Message or full Task event, `ResultAggregator` performs one TaskStore lookup and immediately raises `Could not find a Task/Message` if the row is not visible yet. That prevents the later response-handler TaskStore reconciliation from running.

## Changes

- Poll TaskStore with a bounded timeout when a blocking call has no in-memory result, while preserving the single-read behavior for non-blocking calls.
- Make the reconciliation timeout configurable through `a2a.blocking.reconciliation.timeout.seconds`, retaining the existing one-second behavior by default.
- Add debug logging for reconciliation attempts and successful delayed lookups.
- Document the new setting and add regression coverage for delayed visibility, permanent absence, non-blocking behavior, configuration wiring, and the default property value.

## Scope / Risk

Only the blocking empty-capture path polls TaskStore, and the default timeout remains one second. EventConsumer lifecycle, TaskStore APIs, cancellation, streaming emission, and the public A2A protocol are unchanged.

## Verification

```bash
mvn -pl server-common test
mvn -pl integrations/microprofile-config test
mvn -pl server-common,integrations/microprofile-config -am -Dtest=ResultAggregatorTest,DefaultRequestHandlerTest,MicroProfileConfigProviderTest -Dsurefire.failIfNoSpecifiedTests=false test
git diff --check
```

The module suites pass 416 `server-common` tests and 10 MicroProfile config tests. The focused cross-module run passes 46 tests.

Fixes a2aproject/A2A#2049
