### PR TITLE
build(grpc): upgrade protobuf-maven-plugin to 5.1.7

### DIFF
--- a/.github/workflows/verify-grpc-generation.yml
+++ b/.github/workflows/verify-grpc-generation.yml
@@ -1,0 +1,29 @@
+name: Verify gRPC Generation
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+# Only run the latest job
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  verify-grpc-generation:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Verify gRPC code generation
+      # -pl: build only spec-grpc and compat-0.3/spec-grpc modules
+      # -am: also build their dependencies
+      # -Dskip.protobuf.generate=false: enable protoc generation in spec-grpc (skipped by default)
+      # -Pproto-compile: activate the proto-compile profile in compat-0.3/spec-grpc
+      run: mvn install -B -DskipTests -pl spec-grpc,compat-0.3/spec-grpc -am -Dskip.protobuf.generate=false -Pproto-compile

--- a/compat-0.3/spec-grpc/pom.xml
+++ b/compat-0.3/spec-grpc/pom.xml
@@ -95,7 +95,6 @@
         <profile>
             <id>proto-compile</id>
                 <build>
-
                     <plugins>
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
@@ -125,21 +124,29 @@
                         </plugin>
                         <!-- Protocol Buffers Compiler Plugin -->
                         <plugin>
-                            <groupId>org.xolstice.maven.plugins</groupId>
+                            <groupId>io.github.ascopes</groupId>
                             <artifactId>protobuf-maven-plugin</artifactId>
                             <version>${protobuf-maven-plugin.version}</version>
                             <configuration>
-                                <protocArtifact>com.google.protobuf:protoc:${protobuf-java.version}:exe:${os.detected.classifier}</protocArtifact>
-                                <pluginId>grpc-java</pluginId>
-                                <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
-                                <outputDirectory>src/main/java</outputDirectory>
-                                <clearOutputDirectory>false</clearOutputDirectory>
+                                <skip>${skip.protobuf.generate}</skip>
+                                <cleanOutputDirectories>true</cleanOutputDirectories>
+                                <protoc kind="binary-maven">
+                                    <version>${protobuf-java.version}</version>
+                                </protoc>
+                                <outputDirectory>${project.basedir}/src/main/java/</outputDirectory>
+                                <plugins>
+                                    <plugin kind="binary-maven">
+                                        <groupId>io.grpc</groupId>
+                                        <artifactId>protoc-gen-grpc-java</artifactId>
+                                        <version>${grpc.version}</version>
+                                    </plugin>
+                                </plugins>
                             </configuration>
                             <executions>
                                 <execution>
+                                    <phase>generate-sources</phase>
                                     <goals>
-                                        <goal>compile</goal>
-                                        <goal>compile-custom</goal>
+                                        <goal>generate</goal>
                                     </goals>
                                 </execution>
                             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <mutiny-zero.version>1.1.1</mutiny-zero.version>
         <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
         <protobuf-java.version>4.33.2</protobuf-java.version>
-        <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
+        <protobuf-maven-plugin.version>5.1.7</protobuf-maven-plugin.version>
         <quarkus.platform.version>3.36.3</quarkus.platform.version>
         <rest-assured.version>6.0.0</rest-assured.version>
         <slf4j.version>2.0.18</slf4j.version>

--- a/spec-grpc/pom.xml
+++ b/spec-grpc/pom.xml
@@ -96,19 +96,21 @@
             <plugin>
                 <groupId>io.github.ascopes</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>4.1.2</version>
+                <version>${protobuf-maven-plugin.version}</version>
                 <configuration>
                     <skip>${skip.protobuf.generate}</skip>
                     <cleanOutputDirectories>true</cleanOutputDirectories>
-                    <protoc>${protobuf-java.version}</protoc>
+                    <protoc kind="binary-maven">
+                        <version>${protobuf-java.version}</version>
+                    </protoc>
                     <outputDirectory>${project.basedir}/src/main/java/</outputDirectory>
-                    <binaryMavenPlugins>
-                        <binaryMavenPlugin>
+                    <plugins>
+                        <plugin kind="binary-maven">
                             <groupId>io.grpc</groupId>
                             <artifactId>protoc-gen-grpc-java</artifactId>
                             <version>${grpc.version}</version>
-                        </binaryMavenPlugin>
-                    </binaryMavenPlugins>
+                        </plugin>
+                    </plugins>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Migrate all protobuf compilation to io.github.ascopes:protobuf-maven-plugin 5.1.7, replacing both the hardcoded 4.1.2 in spec-grpc and the legacy org.xolstice.maven.plugins plugin in compat-0.3/spec-grpc:

- Centralize version in parent POM property
- Update plugin configuration to v5.x API (protoc, plugins, goals)
- Add GitHub Actions workflow to verify gRPC code generation in CI