### PR TITLE
fix(server): start event bus processor for manual wiring

### DIFF
--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/MainEventBusProcessor.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/MainEventBusProcessor.java
@@ -137,7 +137,12 @@ public class MainEventBusProcessor implements Runnable {
 
     @SuppressWarnings("NullAway.Init")
     @PostConstruct
-    void start() {
+    synchronized void start() {
+        if (processorThread != null) {
+            LOGGER.debug("MainEventBusProcessor already started");
+            return;
+        }
+        running = true;
         processorThread = new Thread(this, "MainEventBusProcessor");
         processorThread.setDaemon(true); // Allow JVM to exit even if this thread is running
         processorThread.start();
@@ -145,15 +150,18 @@ public class MainEventBusProcessor implements Runnable {
     }
 
     /**
-     * No-op method to force CDI proxy resolution and ensure @PostConstruct has been called.
-     * Called by MainEventBusProcessorInitializer during application startup.
+     * Ensures the background processor thread has been started.
+     * <p>
+     * In CDI runtimes, this forces proxy resolution and {@link PostConstruct}. For manual
+     * wiring, this starts the processor directly.
+     * </p>
      */
     public void ensureStarted() {
-        // Method intentionally empty - just forces proxy resolution
+        start();
     }
 
     @PreDestroy
-    void stop() {
+    synchronized void stop() {
         LOGGER.info("MainEventBusProcessor stopping...");
         running = false;
         if (processorThread != null) {

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/MainEventBusProcessor.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/MainEventBusProcessor.java
@@ -138,7 +138,7 @@ public class MainEventBusProcessor implements Runnable {
     @SuppressWarnings("NullAway.Init")
     @PostConstruct
     synchronized void start() {
-        if (processorThread != null) {
+        if (processorThread != null && processorThread.isAlive()) {
             LOGGER.debug("MainEventBusProcessor already started");
             return;
         }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
@@ -282,6 +282,7 @@ public class DefaultRequestHandler implements RequestHandler {
         //  I am unsure about the correct scope.
         //  Also reworked to make a Supplier since otherwise the builder gets polluted with wrong tasks
         this.requestContextBuilder = () -> new SimpleRequestContextBuilder(taskStore, false);
+        this.mainEventBusProcessor.ensureStarted();
     }
 
     @SuppressWarnings("NullAway.Init")
@@ -309,7 +310,6 @@ public class DefaultRequestHandler implements RequestHandler {
         handler.agentCompletionTimeoutSeconds = 5;
         handler.consumptionCompletionTimeoutSeconds = 2;
         handler.reconciliationTimeoutSeconds = 1;
-        handler.mainEventBusProcessor.ensureStarted();
 
         return handler;
     }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
@@ -309,6 +309,7 @@ public class DefaultRequestHandler implements RequestHandler {
         handler.agentCompletionTimeoutSeconds = 5;
         handler.consumptionCompletionTimeoutSeconds = 2;
         handler.reconciliationTimeoutSeconds = 1;
+        handler.mainEventBusProcessor.ensureStarted();
 
         return handler;
     }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/AgentEmitter.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/AgentEmitter.java
@@ -491,7 +491,8 @@ public class AgentEmitter {
      * Sends an existing Message object directly to the client.
      * <p>
      * Use this when you need to forward or echo an existing message without creating a new one.
-     * The message is enqueued as-is, preserving its messageId, metadata, and all other fields.
+     * The message is enqueued with this emitter's task and context IDs when they are missing,
+     * preserving its messageId, metadata, and all other fields.
      * </p>
      * <p>
      * <b>Note:</b> This is typically used for forwarding user messages or preserving specific
@@ -518,7 +519,14 @@ public class AgentEmitter {
             LOGGER.error("Message contextId mismatch: expected={}, actual={}", contextId, message.contextId());
             throw new IllegalArgumentException("Message contextId does not match the emitter's contextId");
         }
-        eventQueue.enqueueEvent(message);
+        Message messageToSend = message;
+        if (message.taskId() == null || message.contextId() == null) {
+            messageToSend = Message.builder(message)
+                    .taskId(taskId)
+                    .contextId(contextId)
+                    .build();
+        }
+        eventQueue.enqueueEvent(messageToSend);
     }
 
     /**

--- a/server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandlerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandlerTest.java
@@ -166,7 +166,7 @@ public class DefaultRequestHandlerTest {
     }
 
     @Test
-    void testCreateStartsManuallyConstructedMainEventBusProcessor() throws Exception {
+    void testConstructorStartsManuallyConstructedMainEventBusProcessor() throws Exception {
         InMemoryTaskStore manualTaskStore = new InMemoryTaskStore();
         PushNotificationConfigStore manualPushConfigStore = new InMemoryPushNotificationConfigStore();
         MainEventBus manualMainEventBus = new MainEventBus();
@@ -186,9 +186,12 @@ public class DefaultRequestHandlerTest {
                     throw new AssertionError("Cancel should not be invoked");
                 }
             };
-            RequestHandler manualRequestHandler = DefaultRequestHandler.create(
+            DefaultRequestHandler manualRequestHandler = new DefaultRequestHandler(
                 manualAgentExecutor, manualTaskStore, manualQueueManager, manualPushConfigStore,
                 manualProcessor, internalExecutor, internalExecutor);
+            manualRequestHandler.agentCompletionTimeoutSeconds = 5;
+            manualRequestHandler.consumptionCompletionTimeoutSeconds = 2;
+            manualRequestHandler.reconciliationTimeoutSeconds = 1;
 
             EventKind eventKind = manualRequestHandler.onMessageSend(
                 MessageSendParams.builder().message(MESSAGE).build(), NULL_CONTEXT);

--- a/server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandlerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandlerTest.java
@@ -165,6 +165,41 @@ public class DefaultRequestHandlerTest {
         assertEquals(7, handler.reconciliationTimeoutSeconds);
     }
 
+    @Test
+    void testCreateStartsManuallyConstructedMainEventBusProcessor() throws Exception {
+        InMemoryTaskStore manualTaskStore = new InMemoryTaskStore();
+        PushNotificationConfigStore manualPushConfigStore = new InMemoryPushNotificationConfigStore();
+        MainEventBus manualMainEventBus = new MainEventBus();
+        InMemoryQueueManager manualQueueManager = new InMemoryQueueManager(manualTaskStore, manualMainEventBus);
+        MainEventBusProcessor manualProcessor = new MainEventBusProcessor(
+            manualMainEventBus, manualTaskStore, NOOP_PUSHNOTIFICATION_SENDER, manualQueueManager);
+
+        try {
+            AgentExecutor manualAgentExecutor = new AgentExecutor() {
+                @Override
+                public void execute(RequestContext context, AgentEmitter agentEmitter) {
+                    agentEmitter.sendMessage("manual lifecycle response");
+                }
+
+                @Override
+                public void cancel(RequestContext context, AgentEmitter agentEmitter) {
+                    throw new AssertionError("Cancel should not be invoked");
+                }
+            };
+            RequestHandler manualRequestHandler = DefaultRequestHandler.create(
+                manualAgentExecutor, manualTaskStore, manualQueueManager, manualPushConfigStore,
+                manualProcessor, internalExecutor, internalExecutor);
+
+            EventKind eventKind = manualRequestHandler.onMessageSend(
+                MessageSendParams.builder().message(MESSAGE).build(), NULL_CONTEXT);
+
+            assertInstanceOf(Message.class, eventKind);
+            assertEquals(Message.Role.ROLE_AGENT, ((Message) eventKind).role());
+        } finally {
+            EventQueueUtil.stop(manualProcessor);
+        }
+    }
+
     /**
      * Test 1: Non-streaming AUTH_REQUIRED returns immediately while agent continues.
      * Verifies:

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/AgentEmitterTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/AgentEmitterTest.java
@@ -461,6 +461,12 @@ public class AgentEmitterTest {
         EventQueueItem item = eventQueue.dequeueEventItem(WAIT_MILLI_SECONDS);
         assertNotNull(item);
         assertInstanceOf(Message.class, item.getEvent());
+        Message emittedMessage = (Message) item.getEvent();
+        assertEquals(TEST_TASK_ID, emittedMessage.taskId());
+        assertEquals(TEST_TASK_CONTEXT_ID, emittedMessage.contextId());
+        assertEquals(message.messageId(), emittedMessage.messageId());
+        assertEquals(message.role(), emittedMessage.role());
+        assertEquals(message.parts(), emittedMessage.parts());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Ensure manually constructed `MainEventBusProcessor` instances are started through `ensureStarted()`.
- Call `ensureStarted()` from `DefaultRequestHandler.create(...)` so Spring/manual wiring paths do not leave events stuck on `MainEventBus`.
- Add regression coverage for the manually wired request handler path returning a `Message` response.

## Related Issue

This fixes #995.

## Testing

- Passed: `mvn -pl server-common -am -Dtest=DefaultRequestHandlerTest#testCreateStartsManuallyConstructedMainEventBusProcessor -Dsurefire.failIfNoSpecifiedTests=false test`