### PR TITLE
fix(itk): exclude Go v0.3 from HTTP JSON scenarios

### DIFF
--- a/itk/scenarios_full.json
+++ b/itk/scenarios_full.json
@@ -70,16 +70,16 @@
     },
     {
       "name": "Nightly - HTTP_JSON - Send Message",
-      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
-      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "sdks": ["current", "java_v10", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
       "protocols": ["http_json"],
       "behavior": "send_message",
       "build_subtests": true
     },
     {
       "name": "Nightly - HTTP_JSON - Send Message (Streaming)",
-      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
-      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "sdks": ["current", "java_v10", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
       "protocols": ["http_json"],
       "streaming": true,
       "behavior": "send_message",
@@ -87,16 +87,16 @@
     },
     {
       "name": "Nightly - HTTP_JSON - Push Notification",
-      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
-      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "sdks": ["current", "java_v10", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
       "protocols": ["http_json"],
       "behavior": "push_notification",
       "build_subtests": true
     },
     {
       "name": "Nightly - HTTP_JSON - Resubscribe",
-      "sdks": ["current", "java_v10", "python_v10", "go_v10", "go_v03"],
-      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "sdks": ["current", "java_v10", "python_v10", "go_v10"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
       "protocols": ["http_json"],
       "streaming": true,
       "behavior": "resubscribe",


### PR DESCRIPTION
# Description

## Summary

- Remove `go_v03` from all four nightly `HTTP_JSON` interoperability scenarios because A2A Go v0.3 does not expose REST/HTTP+JSON endpoints.
- Remove the corresponding `0->4` and `4->0` edges so each scenario's topology remains valid after the SDK list is shortened.
- Keep Go v0.3 coverage unchanged for the supported JSON-RPC and gRPC scenarios.

## Validation

- Baseline scenario assertion failed on all four nightly HTTP_JSON scenarios before the change.
- Post-change JSON and topology assertions passed: four HTTP_JSON scenarios exclude `go_v03`, supported protocols retain it, and every edge index is valid.
- `.\docs\mvnw.cmd -q -pl itk -am -DskipTests package` passed for the 42-module ITK dependency chain (run through an ASCII drive mapping to avoid the known Windows `protoc` issue with non-ASCII workspace paths).
- `git diff --check` passed.

- [x] Follow the [`CONTRIBUTING` Guide](../CONTRIBUTING.md).
- [x] Make the Pull Request title follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
- [x] Ensure the tests pass.
- [x] Appropriate READMEs were updated (not necessary for this scenario-only correction).

AI assistance: OpenAI Codex was used for repository analysis, the focused edit, and validation.

Fixes #979