### PR TITLE
feat: add TaskStreamLifecycleHook for stream lifecycle management

### DIFF
--- a/docs/content/dev/examples.md
+++ b/docs/content/dev/examples.md
@@ -144,6 +144,45 @@ The client expects an OpenTelemetry collector on port 5317. The easiest way is t
 
 For more information, see the [OpenTelemetry extras module](extras/opentelemetry).
 
+## Stream Lifecycle Hook
+
+This example demonstrates the `TaskStreamLifecycleHook` — a CDI-discoverable hook that observes stream lifecycle events and can close all active streams on demand.
+
+The server implements a hook that closes all subscriber streams when 3 clients connect to the same task. The client creates 3 subscribers sequentially, sending messages while the first two are active. When the third subscriber connects, the hook fires and all streams close gracefully.
+
+### Start the Server
+
+```bash
+cd examples/stream-lifecycle/server
+mvn quarkus:dev
+```
+
+### Run the Client
+
+```bash
+cd examples/stream-lifecycle/client
+mvn exec:java
+```
+
+The client logs each event received by each subscriber, showing events flowing to subscribers 1 and 2 before the hook triggers.
+
+#### Transport Protocol Selection
+
+```bash
+# JSON-RPC (default)
+mvn exec:java
+
+# gRPC
+mvn exec:java -Dquarkus.agentcard.protocol=GRPC
+
+# HTTP+JSON/REST
+mvn exec:java -Dquarkus.agentcard.protocol=HTTP+JSON
+```
+
+Select the same protocol on both server and client.
+
+For implementation details, see the [Stream Lifecycle Hook section](server#6-stream-lifecycle-hook-optional) in the Server Guide.
+
 ## More Examples
 
 - [a2a-samples repository](https://github.com/a2aproject/a2a-samples/tree/main/samples/java/agents) — Additional agent examples in Java and other languages

--- a/docs/content/dev/server.md
+++ b/docs/content/dev/server.md
@@ -158,6 +158,71 @@ See [Configuration](configuration) for all config properties and tuning.
 
 See [Task Authorization](authorization) for per-user access control.
 
+## 6. Stream Lifecycle Hook (Optional)
+
+The `TaskStreamLifecycleHook` lets you observe and control streaming connections for a task. You are notified when clients subscribe, unsubscribe, or when events are distributed, and you can close all active streams on demand via the `StreamCloseHandle`.
+
+### Implementing a Hook
+
+Create a CDI bean that implements `TaskStreamLifecycleHook` and overrides the default no-op:
+
+```java
+@ApplicationScoped
+@Alternative
+@Priority(1)
+public class MyStreamHook implements TaskStreamLifecycleHook {
+
+    @Override
+    public void onSubscribe(String taskId, StreamCloseHandle handle) {
+        // Called when a client subscribes to a task's event stream
+    }
+
+    @Override
+    public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
+        // Called when a client disconnects
+    }
+
+    @Override
+    public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
+        // Called after an event is persisted and distributed to all subscribers
+    }
+}
+```
+
+### StreamCloseHandle
+
+Each callback receives a `StreamCloseHandle` with two methods:
+
+- **`closeStreams()`** — Gracefully closes all active subscriber streams for the task. The agent executor continues running and the MainQueue stays alive (for non-finalized tasks), so new clients can resubscribe.
+- **`getActiveSubscriberCount()`** — Returns the number of currently connected subscribers.
+
+### Example: Close Streams at a Subscriber Threshold
+
+```java
+@ApplicationScoped
+@Alternative
+@Priority(1)
+public class CloseStreamsHook implements TaskStreamLifecycleHook {
+
+    private static final int MAX_SUBSCRIBERS = 3;
+
+    @Override
+    public void onSubscribe(String taskId, StreamCloseHandle handle) {
+        if (handle.getActiveSubscriberCount() >= MAX_SUBSCRIBERS) {
+            handle.closeStreams();
+        }
+    }
+
+    @Override
+    public void onUnsubscribe(String taskId, StreamCloseHandle handle) { }
+
+    @Override
+    public void onEvent(String taskId, Event event, StreamCloseHandle handle) { }
+}
+```
+
+See the [`examples/stream-lifecycle`](https://github.com/a2aproject/a2a-java/tree/main/examples/stream-lifecycle) directory for a complete working example with server, client, and integration tests for all three transports.
+
 ## Backward Compatibility with v0.3
 
 See [Backward Compatibility](compatibility) for multi-version modules, version routing, and v0.3 client support.

--- a/examples/stream-lifecycle/README.md
+++ b/examples/stream-lifecycle/README.md
@@ -1,0 +1,135 @@
+# Stream Lifecycle Hook Example
+
+This example demonstrates `TaskStreamLifecycleHook`, a CDI-discoverable hook that lets you observe and control streaming connections for a task. The server closes all active streams when 3 subscribers connect to the same task.
+
+For example, in order to save resources associated with streaming connections, you might want to close streams:
+
+* If no events are received for a Task in a given timeframe. This can help if you have a lot of Tasks taking a very long time to complete
+* Stopping rogue client opening too many subscriptions to the same Task
+
+## Prerequisites
+
+- Java 17 or higher
+- Maven
+
+## What It Does
+
+**Server** — An agent sends 20 progress messages (one every 500ms). A `CloseStreamsHook` monitors subscriber count and calls `StreamCloseHandle.closeStreams()` when 3 subscribers are connected, gracefully closing all streams.
+
+**Client** — Connects 3 subscribers sequentially:
+1. Subscriber 1 sends a message (creates the task, starts streaming)
+2. Subscriber 2 subscribes to the same task after 1.5 seconds
+3. Both subscribers receive progress messages for 2 seconds
+4. Subscriber 3 subscribes — the hook fires and closes all streams
+5. All 3 subscribers see their streams end gracefully
+
+## Run the Example
+
+### 1. Build the SDK
+
+From the repository root:
+
+```bash
+mvn clean install -DskipTests
+```
+
+### 2. Start the Server
+
+```bash
+cd examples/stream-lifecycle/server
+mvn quarkus:dev
+```
+
+### 3. Run the Client
+
+In a separate terminal:
+
+```bash
+cd examples/stream-lifecycle/client
+mvn exec:java
+```
+
+### Expected Output (Client)
+
+The exact event interleaving depends on timing, but you should see something like:
+
+```
+Resolved agent card: Stream Lifecycle Demo Agent
+[Sub-1] Sending message to create task...
+[Sub-1] StatusUpdate — TASK_STATE_WORKING
+
+=== Task created: <task-id> ===
+
+[Sub-1] ArtifactEvent — Progress update 1/20
+[Sub-1] ArtifactEvent — Progress update 2/20
+[Sub-1] ArtifactEvent — Progress update 3/20
+[Sub-2] Subscribing to task <task-id>...
+
+=== Subscribers 1 and 2 are active — receiving events... ===
+
+[Sub-2] TaskEvent — state: TASK_STATE_WORKING, id: <task-id>
+[Sub-1] ArtifactEvent — Progress update 4/20
+[Sub-2] ArtifactEvent — Progress update 4/20
+[Sub-1] ArtifactEvent — Progress update 5/20
+[Sub-2] ArtifactEvent — Progress update 5/20
+...
+[Sub-3] Subscribing to task <task-id> (will trigger stream close)...
+[Sub-1] Stream closed.
+[Sub-2] Stream closed.
+[Sub-3] Stream closed.
+
+=== All streams closed. ===
+```
+
+### Expected Output (Server)
+
+```
+[HOOK] Subscriber added for task <id>. Active subscribers: 1
+[AGENT] Starting execution for task <id>
+[AGENT] Sending: Progress update 1/20
+[HOOK] Event distributed for task <id>: Message (subscribers: 1)
+...
+[HOOK] Subscriber added for task <id>. Active subscribers: 2
+...
+[HOOK] Subscriber added for task <id>. Active subscribers: 3
+[HOOK] Subscriber count reached 3 for task <id> — closing all streams
+[HOOK] Subscriber removed for task <id>. Active subscribers: 2
+[HOOK] Subscriber removed for task <id>. Active subscribers: 1
+[HOOK] Subscriber removed for task <id>. Active subscribers: 0
+```
+
+## Transport Protocol Selection
+
+Set `quarkus.agentcard.protocol` on both server and client (must match). Available values:
+
+| Value | Transport |
+|-------|-----------|
+| `JSONRPC` | JSON-RPC 2.0 (default) |
+| `GRPC` | gRPC |
+| `HTTP+JSON` | HTTP+JSON/REST |
+
+```bash
+# Server — gRPC example
+mvn quarkus:dev -Dquarkus.agentcard.protocol=GRPC
+
+# Client — must use the same value
+mvn exec:java -Dquarkus.agentcard.protocol=GRPC
+```
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `server/.../CloseStreamsHook.java` | `TaskStreamLifecycleHook` implementation — closes streams at 3 subscribers |
+| `server/.../AgentExecutorProducer.java` | Agent that sends 20 progress messages over 10 seconds |
+| `server/.../AgentCardProducer.java` | Agent card with streaming enabled |
+| `client/.../StreamLifecycleClient.java` | Client that creates 3 subscribers and logs events |
+
+## Integration Tests
+
+The server module includes `@QuarkusTest` integration tests that verify the hook behavior across all three transports:
+
+```bash
+cd examples/stream-lifecycle/server
+mvn test
+```

--- a/examples/stream-lifecycle/client/pom.xml
+++ b/examples/stream-lifecycle/client/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.a2aproject.sdk</groupId>
+        <artifactId>a2a-java-sdk-examples-stream-lifecycle-parent</artifactId>
+        <version>1.1.1.Final-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>a2a-java-sdk-examples-stream-lifecycle-client</artifactId>
+
+    <name>Java SDK A2A Examples - Stream Lifecycle Client</name>
+    <description>Client demonstrating TaskStreamLifecycleHook with multiple subscribers</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-jsonrpc-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-client-transport-grpc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-client-transport-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.6.3</version>
+                <configuration>
+                    <mainClass>org.a2aproject.sdk.examples.streamlifecycle.client.StreamLifecycleClient</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/stream-lifecycle/client/src/main/java/org/a2aproject/sdk/examples/streamlifecycle/client/StreamLifecycleClient.java
+++ b/examples/stream-lifecycle/client/src/main/java/org/a2aproject/sdk/examples/streamlifecycle/client/StreamLifecycleClient.java
@@ -1,0 +1,278 @@
+package org.a2aproject.sdk.examples.streamlifecycle.client;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import org.a2aproject.sdk.A2A;
+import org.a2aproject.sdk.client.Client;
+import org.a2aproject.sdk.client.ClientBuilder;
+import org.a2aproject.sdk.client.ClientEvent;
+import org.a2aproject.sdk.client.MessageEvent;
+import org.a2aproject.sdk.client.TaskEvent;
+import org.a2aproject.sdk.client.TaskUpdateEvent;
+import org.a2aproject.sdk.client.config.ClientConfig;
+import org.a2aproject.sdk.client.http.A2ACardResolver;
+import org.a2aproject.sdk.client.transport.grpc.GrpcTransport;
+import org.a2aproject.sdk.client.transport.grpc.GrpcTransportConfigBuilder;
+import org.a2aproject.sdk.client.transport.jsonrpc.JSONRPCTransport;
+import org.a2aproject.sdk.client.transport.jsonrpc.JSONRPCTransportConfig;
+import org.a2aproject.sdk.client.transport.rest.RestTransport;
+import org.a2aproject.sdk.client.transport.rest.RestTransportConfig;
+import org.a2aproject.sdk.client.transport.spi.ClientTransportConfig;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.Message;
+import org.a2aproject.sdk.spec.Part;
+import org.a2aproject.sdk.spec.Task;
+import org.a2aproject.sdk.spec.TaskArtifactUpdateEvent;
+import org.a2aproject.sdk.spec.TaskIdParams;
+import org.a2aproject.sdk.spec.TextPart;
+
+import io.grpc.Channel;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+
+/**
+ * Demonstrates the TaskStreamLifecycleHook by connecting 3 subscribers to a task.
+ * <p>
+ * Flow:
+ * <ol>
+ *   <li>Subscriber 1: sends a message (creates the task, starts streaming)</li>
+ *   <li>Subscriber 2: subscribes to the same task</li>
+ *   <li>Both subscribers receive progress messages from the agent</li>
+ *   <li>Subscriber 3: subscribes — the server hook detects 3 subscribers and closes all streams</li>
+ *   <li>All subscribers see their streams end gracefully</li>
+ * </ol>
+ * <p>
+ * Start the server first ({@code mvn quarkus:dev} in the server module), then run this client.
+ * <p>
+ * This class also serves as the integration test body — {@code runAndVerify(AgentCard, String)}
+ * is called by the server module's {@code @QuarkusTest} for each transport protocol.
+ */
+public class StreamLifecycleClient {
+
+    private static final String SERVER_URL = "http://localhost:9999";
+
+    private static final List<ManagedChannel> grpcChannels = new CopyOnWriteArrayList<>();
+
+    public static void main(String[] args) throws Exception {
+        try {
+            AgentCard agentCard = A2ACardResolver.builder().baseUrl(SERVER_URL).build().getAgentCard();
+            System.out.println("Resolved agent card: " + agentCard.name());
+            String protocol = System.getProperty("quarkus.agentcard.protocol", "JSONRPC");
+            runAndVerify(agentCard, protocol);
+        } finally {
+            shutdownGrpcChannels();
+        }
+    }
+
+    /**
+     * Runs the 3-subscriber scenario and asserts correctness.
+     * Called by {@code main()} for manual runs and by the server's {@code @QuarkusTest} for each protocol.
+     */
+    public static void runAndVerify(AgentCard agentCard, String protocol) throws Exception {
+        AtomicReference<String> taskIdRef = new AtomicReference<>();
+        CountDownLatch taskIdReady = new CountDownLatch(1);
+
+        CountDownLatch sub1StreamDone = new CountDownLatch(1);
+        CountDownLatch sub2StreamDone = new CountDownLatch(1);
+        CountDownLatch sub3StreamDone = new CountDownLatch(1);
+
+        CopyOnWriteArrayList<ClientEvent> sub1Events = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<ClientEvent> sub2Events = new CopyOnWriteArrayList<>();
+
+        // --- Subscriber 1: Send a message (creates the task) ---
+        Thread sub1Thread = new Thread(() -> {
+            try {
+                Client client = createStreamingClient(agentCard, "Sub-1", (event, card) -> {
+                    sub1Events.add(event);
+                    logEvent("Sub-1", event);
+                    if (taskIdRef.get() == null) {
+                        String id = extractTaskId(event);
+                        if (id != null) {
+                            taskIdRef.set(id);
+                            taskIdReady.countDown();
+                        }
+                    }
+                }, sub1StreamDone, protocol);
+
+                System.out.println("[Sub-1] Sending message to create task...");
+                client.sendMessage(A2A.toUserMessage("Start streaming demo"));
+            } catch (Exception e) {
+                System.out.println("[Sub-1] Error: " + e.getMessage());
+            } finally {
+                sub1StreamDone.countDown();
+            }
+        }, "subscriber-1");
+        sub1Thread.start();
+
+        assertTrue(taskIdReady.await(10, TimeUnit.SECONDS), "Task should be created");
+        String taskId = taskIdRef.get();
+        assertNotNull(taskId);
+        System.out.println("\n=== Task created: " + taskId + " ===\n");
+
+        // Give some time for messages to flow to subscriber 1
+        Thread.sleep(1500);
+
+        // --- Subscriber 2: Subscribe to the existing task ---
+        Thread sub2Thread = new Thread(() -> {
+            try {
+                Client client = createStreamingClient(agentCard, "Sub-2", (event, card) -> {
+                    sub2Events.add(event);
+                    logEvent("Sub-2", event);
+                }, sub2StreamDone, protocol);
+
+                System.out.println("[Sub-2] Subscribing to task " + taskId + "...");
+                client.subscribeToTask(new TaskIdParams(taskId));
+            } catch (Exception e) {
+                System.out.println("[Sub-2] Error: " + e.getMessage());
+            } finally {
+                sub2StreamDone.countDown();
+            }
+        }, "subscriber-2");
+        sub2Thread.start();
+
+        System.out.println("\n=== Subscribers 1 and 2 are active — receiving events... ===\n");
+        Thread.sleep(2000);
+
+        // --- Subscriber 3: Triggers the hook (closes all streams) ---
+        Thread sub3Thread = new Thread(() -> {
+            try {
+                Client client = createStreamingClient(agentCard, "Sub-3", (event, card) -> {
+                    logEvent("Sub-3", event);
+                }, sub3StreamDone, protocol);
+
+                System.out.println("[Sub-3] Subscribing to task " + taskId + " (will trigger stream close)...");
+                client.subscribeToTask(new TaskIdParams(taskId));
+            } catch (Exception e) {
+                System.out.println("[Sub-3] Error: " + e.getMessage());
+            } finally {
+                sub3StreamDone.countDown();
+            }
+        }, "subscriber-3");
+        sub3Thread.start();
+
+        // Wait for all streams to close
+        assertTrue(sub1StreamDone.await(30, TimeUnit.SECONDS), "Subscriber 1 stream should close");
+        assertTrue(sub2StreamDone.await(30, TimeUnit.SECONDS), "Subscriber 2 stream should close");
+        assertTrue(sub3StreamDone.await(30, TimeUnit.SECONDS), "Subscriber 3 stream should close");
+
+        System.out.println("\n=== All streams closed. ===");
+
+        // Verify events were received
+        assertTrue(sub1Events.size() >= 2,
+                "Subscriber 1 should have received at least a status update and one artifact, got: " + sub1Events.size());
+        assertTrue(sub2Events.size() >= 1,
+                "Subscriber 2 should have received at least a task snapshot, got: " + sub2Events.size());
+    }
+
+    public static void shutdownGrpcChannels() {
+        for (ManagedChannel ch : grpcChannels) {
+            ch.shutdownNow();
+            try {
+                ch.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        grpcChannels.clear();
+    }
+
+    private static Client createStreamingClient(AgentCard agentCard, String name,
+                                                BiConsumer<ClientEvent, AgentCard> consumer,
+                                                CountDownLatch streamDone,
+                                                String protocol) throws Exception {
+        ClientBuilder builder = Client.builder(agentCard)
+                .addConsumer(consumer)
+                .streamingErrorHandler(e -> {
+                    System.out.println("[" + name + "] Stream closed.");
+                    streamDone.countDown();
+                })
+                .clientConfig(ClientConfig.builder().setStreaming(true).build());
+        configureTransport(builder, protocol);
+        return builder.build();
+    }
+
+    private static void configureTransport(ClientBuilder clientBuilder, String protocol) {
+        ClientTransportConfig transportConfig;
+        switch (protocol) {
+            case "GRPC":
+                Function<String, Channel> channelFactory = url -> {
+                    String target = url.replaceAll("^https?://", "");
+                    ManagedChannel channel = ManagedChannelBuilder.forTarget(target).usePlaintext().build();
+                    grpcChannels.add(channel);
+                    return channel;
+                };
+                transportConfig = new GrpcTransportConfigBuilder().channelFactory(channelFactory).build();
+                clientBuilder.withTransport(GrpcTransport.class, transportConfig);
+                break;
+            case "HTTP+JSON":
+                transportConfig = new RestTransportConfig();
+                clientBuilder.withTransport(RestTransport.class, transportConfig);
+                break;
+            case "JSONRPC":
+            default:
+                transportConfig = new JSONRPCTransportConfig();
+                clientBuilder.withTransport(JSONRPCTransport.class, transportConfig);
+                break;
+        }
+    }
+
+    public static void logEvent(String subscriber, ClientEvent event) {
+        if (event instanceof TaskEvent te) {
+            System.out.printf("[%s] TaskEvent — state: %s, id: %s%n",
+                    subscriber, te.getTask().status().state(), te.getTask().id());
+        } else if (event instanceof TaskUpdateEvent tue) {
+            if (tue.getUpdateEvent() instanceof TaskArtifactUpdateEvent artifact) {
+                String text = extractText(artifact);
+                System.out.printf("[%s] ArtifactEvent — %s%n", subscriber, text);
+            } else {
+                System.out.printf("[%s] StatusUpdate — %s%n", subscriber, tue.getTask().status().state());
+            }
+        } else if (event instanceof MessageEvent me) {
+            String text = extractText(me.getMessage());
+            System.out.printf("[%s] MessageEvent — %s%n", subscriber, text);
+        }
+    }
+
+    static String extractTaskId(ClientEvent event) {
+        if (event instanceof TaskEvent te) {
+            return te.getTask().id();
+        } else if (event instanceof TaskUpdateEvent tue) {
+            Task task = tue.getTask();
+            return task != null ? task.id() : null;
+        }
+        return null;
+    }
+
+    private static String extractText(TaskArtifactUpdateEvent artifact) {
+        if (artifact.artifact() == null) {
+            return "(no parts)";
+        }
+        return extractTextFromParts(artifact.artifact().parts());
+    }
+
+    private static String extractText(Message message) {
+        return extractTextFromParts(message.parts());
+    }
+
+    private static String extractTextFromParts(List<Part<?>> parts) {
+        if (parts == null) {
+            return "(no parts)";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (Part<?> part : parts) {
+            if (part instanceof TextPart tp) {
+                sb.append(tp.text());
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/examples/stream-lifecycle/pom.xml
+++ b/examples/stream-lifecycle/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.a2aproject.sdk</groupId>
+        <artifactId>a2a-java-sdk-parent</artifactId>
+        <version>1.1.1.Final-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>a2a-java-sdk-examples-stream-lifecycle-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Java SDK A2A Examples: Stream Lifecycle</name>
+    <description>Example demonstrating TaskStreamLifecycleHook for managing streaming connections</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.a2aproject.sdk</groupId>
+                <artifactId>a2a-java-sdk-client</artifactId>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <modules>
+        <module>client</module>
+        <module>server</module>
+    </modules>
+</project>

--- a/examples/stream-lifecycle/server/pom.xml
+++ b/examples/stream-lifecycle/server/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.a2aproject.sdk</groupId>
+        <artifactId>a2a-java-sdk-examples-stream-lifecycle-parent</artifactId>
+        <version>1.1.1.Final-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>a2a-java-sdk-examples-stream-lifecycle-server</artifactId>
+
+    <name>Java SDK A2A Examples - Stream Lifecycle Server</name>
+    <description>Server demonstrating TaskStreamLifecycleHook for closing streams on demand</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-reference-grpc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-reference-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+
+        <!-- Test dependencies for integration tests -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-examples-stream-lifecycle-client</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jvmArgs>--add-opens=java.base/java.lang=ALL-UNNAMED</jvmArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/stream-lifecycle/server/src/main/java/org/a2aproject/sdk/examples/streamlifecycle/server/AgentCardProducer.java
+++ b/examples/stream-lifecycle/server/src/main/java/org/a2aproject/sdk/examples/streamlifecycle/server/AgentCardProducer.java
@@ -1,0 +1,53 @@
+package org.a2aproject.sdk.examples.streamlifecycle.server;
+
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import org.a2aproject.sdk.server.PublicAgentCard;
+import org.a2aproject.sdk.spec.AgentCapabilities;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.AgentInterface;
+import org.a2aproject.sdk.spec.AgentSkill;
+import org.a2aproject.sdk.spec.TransportProtocol;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class AgentCardProducer {
+
+    @ConfigProperty(name = "quarkus.agentcard.protocol", defaultValue = "JSONRPC")
+    String protocolStr;
+
+    @Produces
+    @PublicAgentCard
+    public AgentCard agentCard() {
+        return AgentCard.builder()
+                .name("Stream Lifecycle Demo Agent")
+                .description("Demonstrates TaskStreamLifecycleHook — closes all streams when 3 subscribers connect")
+                .supportedInterfaces(Collections.singletonList(getAgentInterface()))
+                .version("1.0.0")
+                .capabilities(AgentCapabilities.builder()
+                        .streaming(true)
+                        .build())
+                .defaultInputModes(Collections.singletonList("text"))
+                .defaultOutputModes(Collections.singletonList("text"))
+                .skills(Collections.singletonList(AgentSkill.builder()
+                        .id("stream_lifecycle")
+                        .name("Stream lifecycle demo")
+                        .description("Sends progress messages while subscribers connect and disconnect")
+                        .tags(List.of("streaming", "lifecycle"))
+                        .build()))
+                .build();
+    }
+
+    private AgentInterface getAgentInterface() {
+        TransportProtocol protocol = TransportProtocol.fromString(protocolStr);
+        String url = switch (protocol) {
+            case GRPC -> "localhost:9000";
+            case JSONRPC, HTTP_JSON -> "http://localhost:9999";
+        };
+        return new AgentInterface(protocol.asString(), url);
+    }
+}

--- a/examples/stream-lifecycle/server/src/main/java/org/a2aproject/sdk/examples/streamlifecycle/server/AgentExecutorProducer.java
+++ b/examples/stream-lifecycle/server/src/main/java/org/a2aproject/sdk/examples/streamlifecycle/server/AgentExecutorProducer.java
@@ -1,0 +1,59 @@
+package org.a2aproject.sdk.examples.streamlifecycle.server;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import org.a2aproject.sdk.server.agentexecution.AgentExecutor;
+import org.a2aproject.sdk.server.agentexecution.RequestContext;
+import org.a2aproject.sdk.server.tasks.AgentEmitter;
+import org.a2aproject.sdk.spec.A2AError;
+import org.a2aproject.sdk.spec.TextPart;
+import org.a2aproject.sdk.spec.UnsupportedOperationError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Agent executor that sends a series of messages over time, giving clients time to subscribe.
+ * <p>
+ * The agent sends 20 progress messages, one every 500ms. This gives the demo client enough
+ * time to establish multiple subscriptions and observe events flowing to each subscriber
+ * before the {@link CloseStreamsHook} closes all streams.
+ * </p>
+ */
+@ApplicationScoped
+public class AgentExecutorProducer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AgentExecutorProducer.class);
+
+    @Produces
+    public AgentExecutor agentExecutor() {
+        return new AgentExecutor() {
+            @Override
+            public void execute(RequestContext context, AgentEmitter emitter) throws A2AError {
+                LOG.info("[AGENT] Starting execution for task {}", context.getTaskId());
+                emitter.startWork();
+
+                for (int i = 1; i <= 20; i++) {
+                    try {
+                        Thread.sleep(500);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        LOG.info("[AGENT] Interrupted at message {}", i);
+                        break;
+                    }
+                    String text = "Progress update " + i + "/20";
+                    LOG.info("[AGENT] Sending: {}", text);
+                    emitter.addArtifact(java.util.List.of(new TextPart(text)));
+                }
+
+                LOG.info("[AGENT] Completing task {}", context.getTaskId());
+                emitter.complete();
+            }
+
+            @Override
+            public void cancel(RequestContext context, AgentEmitter emitter) throws A2AError {
+                throw new UnsupportedOperationError();
+            }
+        };
+    }
+}

--- a/examples/stream-lifecycle/server/src/main/java/org/a2aproject/sdk/examples/streamlifecycle/server/CloseStreamsHook.java
+++ b/examples/stream-lifecycle/server/src/main/java/org/a2aproject/sdk/examples/streamlifecycle/server/CloseStreamsHook.java
@@ -1,0 +1,52 @@
+package org.a2aproject.sdk.examples.streamlifecycle.server;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+import org.a2aproject.sdk.server.events.StreamCloseHandle;
+import org.a2aproject.sdk.server.events.TaskStreamLifecycleHook;
+import org.a2aproject.sdk.spec.Event;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Demonstrates closing all streams for a task when the subscriber count reaches a threshold.
+ * <p>
+ * When 3 subscribers are connected to the same task, this hook calls
+ * {@link StreamCloseHandle#closeStreams()} to gracefully close all active streams.
+ * The agent executor continues running, but disconnected clients can resubscribe later.
+ * </p>
+ */
+@ApplicationScoped
+@Alternative
+@Priority(1)
+public class CloseStreamsHook implements TaskStreamLifecycleHook {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CloseStreamsHook.class);
+    private static final int MAX_SUBSCRIBERS = 3;
+
+    @Override
+    public void onSubscribe(String taskId, StreamCloseHandle handle) {
+        int count = handle.getActiveSubscriberCount();
+        LOG.info("[HOOK] Subscriber added for task {}. Active subscribers: {}", taskId, count);
+
+        if (count >= MAX_SUBSCRIBERS) {
+            LOG.info("[HOOK] Subscriber count reached {} for task {} — closing all streams",
+                    MAX_SUBSCRIBERS, taskId);
+            handle.closeStreams();
+        }
+    }
+
+    @Override
+    public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
+        LOG.info("[HOOK] Subscriber removed for task {}. Active subscribers: {}",
+                taskId, handle.getActiveSubscriberCount());
+    }
+
+    @Override
+    public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
+        LOG.info("[HOOK] Event distributed for task {}: {} (subscribers: {})",
+                taskId, event.getClass().getSimpleName(), handle.getActiveSubscriberCount());
+    }
+}

--- a/examples/stream-lifecycle/server/src/main/resources/application.properties
+++ b/examples/stream-lifecycle/server/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+%dev.quarkus.http.port=9999
+
+# Protocol can be JSONRPC, GRPC, or HTTP+JSON
+quarkus.agentcard.protocol=JSONRPC

--- a/examples/stream-lifecycle/server/src/test/java/org/a2aproject/sdk/examples/streamlifecycle/server/StreamLifecycleTest.java
+++ b/examples/stream-lifecycle/server/src/test/java/org/a2aproject/sdk/examples/streamlifecycle/server/StreamLifecycleTest.java
@@ -1,0 +1,59 @@
+package org.a2aproject.sdk.examples.streamlifecycle.server;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.a2aproject.sdk.examples.streamlifecycle.client.StreamLifecycleClient;
+import org.a2aproject.sdk.spec.AgentCapabilities;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.AgentInterface;
+import org.a2aproject.sdk.spec.TransportProtocol;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+@QuarkusTest
+class StreamLifecycleTest {
+
+    private static final String HTTP_URL = "http://localhost:8081";
+    private static final String GRPC_URL = "localhost:8081";
+
+    @AfterEach
+    void cleanupGrpcChannels() {
+        StreamLifecycleClient.shutdownGrpcChannels();
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void testStreamLifecycleWithJsonRpc() throws Exception {
+        StreamLifecycleClient.runAndVerify(buildCard(TransportProtocol.JSONRPC, HTTP_URL), "JSONRPC");
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void testStreamLifecycleWithRest() throws Exception {
+        StreamLifecycleClient.runAndVerify(buildCard(TransportProtocol.HTTP_JSON, HTTP_URL), "HTTP+JSON");
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void testStreamLifecycleWithGrpc() throws Exception {
+        StreamLifecycleClient.runAndVerify(buildCard(TransportProtocol.GRPC, GRPC_URL), "GRPC");
+    }
+
+    private AgentCard buildCard(TransportProtocol protocol, String url) {
+        return AgentCard.builder()
+                .name("test")
+                .description("test")
+                .version("1.0.0")
+                .defaultInputModes(List.of("text"))
+                .defaultOutputModes(List.of("text"))
+                .skills(List.of())
+                .supportedInterfaces(List.of(
+                        new AgentInterface(protocol.asString(), url)))
+                .capabilities(AgentCapabilities.builder().streaming(true).build())
+                .build();
+    }
+}

--- a/examples/stream-lifecycle/server/src/test/resources/application.properties
+++ b/examples/stream-lifecycle/server/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+quarkus.http.port=8081
+quarkus.grpc.server.use-separate-server=false
+quarkus.agentcard.protocol=JSONRPC

--- a/extras/queue-manager-replicated/core/src/main/java/org/a2aproject/sdk/extras/queuemanager/replicated/core/ReplicatedQueueManager.java
+++ b/extras/queue-manager-replicated/core/src/main/java/org/a2aproject/sdk/extras/queuemanager/replicated/core/ReplicatedQueueManager.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
 import org.a2aproject.sdk.extras.common.events.TaskFinalizedEvent;
+import org.a2aproject.sdk.server.events.DefaultTaskStreamLifecycleHook;
 import org.a2aproject.sdk.server.events.EventEnqueueHook;
 import org.a2aproject.sdk.server.events.EventQueue;
 import org.a2aproject.sdk.server.events.EventQueueFactory;
@@ -15,6 +16,7 @@ import org.a2aproject.sdk.server.events.EventQueueItem;
 import org.a2aproject.sdk.server.events.InMemoryQueueManager;
 import org.a2aproject.sdk.server.events.MainEventBus;
 import org.a2aproject.sdk.server.events.QueueManager;
+import org.a2aproject.sdk.server.events.TaskStreamLifecycleHook;
 import org.a2aproject.sdk.server.tasks.TaskStateProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +33,7 @@ public class ReplicatedQueueManager implements QueueManager {
     private InMemoryQueueManager delegate;
     private ReplicationStrategy replicationStrategy;
     private TaskStateProvider taskStateProvider;
+    private TaskStreamLifecycleHook streamLifecycleHook;
 
     /**
      * No-args constructor for CDI proxy creation.
@@ -43,15 +46,25 @@ public class ReplicatedQueueManager implements QueueManager {
         this.delegate = null;
         this.replicationStrategy = null;
         this.taskStateProvider = null;
+        this.streamLifecycleHook = null;
+    }
+
+    public ReplicatedQueueManager(ReplicationStrategy replicationStrategy,
+                                    TaskStateProvider taskStateProvider,
+                                    MainEventBus mainEventBus) {
+        this(replicationStrategy, taskStateProvider, mainEventBus, new DefaultTaskStreamLifecycleHook());
     }
 
     @Inject
     public ReplicatedQueueManager(ReplicationStrategy replicationStrategy,
                                     TaskStateProvider taskStateProvider,
-                                    MainEventBus mainEventBus) {
+                                    MainEventBus mainEventBus,
+                                    TaskStreamLifecycleHook streamLifecycleHook) {
         this.replicationStrategy = replicationStrategy;
         this.taskStateProvider = taskStateProvider;
-        this.delegate = new InMemoryQueueManager(new ReplicatingEventQueueFactory(), taskStateProvider, mainEventBus);
+        this.streamLifecycleHook = streamLifecycleHook;
+        this.delegate = new InMemoryQueueManager(
+                new ReplicatingEventQueueFactory(), taskStateProvider, mainEventBus, streamLifecycleHook);
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -575,6 +575,7 @@
         <module>client/transport/spi</module>
         <module>common</module>
         <module>examples/helloworld</module>
+        <module>examples/stream-lifecycle</module>
         <module>examples/cloud-deployment/server</module>
         <module>extras/common</module>
         <module>extras/opentelemetry</module>

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/DefaultTaskStreamLifecycleHook.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/DefaultTaskStreamLifecycleHook.java
@@ -1,0 +1,25 @@
+package org.a2aproject.sdk.server.events;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.a2aproject.sdk.spec.Event;
+
+/**
+ * Default no-op implementation of {@link TaskStreamLifecycleHook}.
+ * Override with a CDI {@code @Alternative @Priority} bean to provide custom stream lifecycle behavior.
+ */
+@ApplicationScoped
+public class DefaultTaskStreamLifecycleHook implements TaskStreamLifecycleHook {
+
+    @Override
+    public void onSubscribe(String taskId, StreamCloseHandle handle) {
+    }
+
+    @Override
+    public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
+    }
+
+    @Override
+    public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
+    }
+}

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/EventQueue.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/EventQueue.java
@@ -400,6 +400,19 @@ public abstract class EventQueue implements AutoCloseable {
         private final List<Runnable> onCloseCallbacks;
         private final @Nullable TaskStateProvider taskStateProvider;
         private final MainEventBus mainEventBus;
+        private volatile @Nullable TaskStreamLifecycleHook streamLifecycleHook;
+
+        private final StreamCloseHandle streamCloseHandle = new StreamCloseHandle() {
+            @Override
+            public void closeStreams() {
+                closeChildren();
+            }
+
+            @Override
+            public int getActiveSubscriberCount() {
+                return getActiveChildCount();
+            }
+        };
 
         MainQueue(int queueSize,
                   @Nullable EventEnqueueHook hook,
@@ -422,6 +435,13 @@ public abstract class EventQueue implements AutoCloseable {
         public EventQueue tap() {
             ChildQueue child = new ChildQueue(this);
             children.add(child);
+            if (streamLifecycleHook != null) {
+                try {
+                    streamLifecycleHook.onSubscribe(taskId, getStreamCloseHandle());
+                } catch (Exception e) {
+                    LOGGER.error("Error in TaskStreamLifecycleHook.onSubscribe for task {}", taskId, e);
+                }
+            }
             return child;
         }
 
@@ -564,7 +584,18 @@ public abstract class EventQueue implements AutoCloseable {
           }
 
         void childClosing(ChildQueue child, boolean immediate) {
-            children.remove(child);  // Remove the closing child
+            if (!children.remove(child)) {
+                return;  // Already removed by a concurrent close
+            }
+
+            // Notify stream lifecycle hook of unsubscription
+            if (streamLifecycleHook != null) {
+                try {
+                    streamLifecycleHook.onUnsubscribe(taskId, getStreamCloseHandle());
+                } catch (Exception e) {
+                    LOGGER.error("Error in TaskStreamLifecycleHook.onUnsubscribe for task {}", taskId, e);
+                }
+            }
 
             // If there are still children, keep queue open
             if (!children.isEmpty()) {
@@ -627,6 +658,36 @@ public abstract class EventQueue implements AutoCloseable {
          */
         public int getActiveChildCount() {
             return children.size();
+        }
+
+        void setTaskStreamLifecycleHook(@Nullable TaskStreamLifecycleHook hook) {
+            this.streamLifecycleHook = hook;
+        }
+
+        @Nullable
+        TaskStreamLifecycleHook getTaskStreamLifecycleHook() {
+            return streamLifecycleHook;
+        }
+
+        /**
+         * Gracefully closes all current ChildQueues without closing this MainQueue.
+         * Events already in ChildQueue deques will be drained before the stream terminates.
+         * New subscriptions via {@link #tap()} remain possible after this call.
+         * <p>
+         * Note: if the task is finalized, the last {@code childClosing()} call will close the
+         * MainQueue itself (existing behavior). For non-finalized tasks, the MainQueue stays open.
+         * </p>
+         */
+        void closeChildren() {
+            List<ChildQueue> snapshot = List.copyOf(children);
+            LOGGER.debug("MainQueue[{}]: Closing {} children gracefully", taskId, snapshot.size());
+            for (ChildQueue child : snapshot) {
+                child.close(false);
+            }
+        }
+
+        StreamCloseHandle getStreamCloseHandle() {
+            return streamCloseHandle;
         }
 
         @Override

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/EventQueue.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/EventQueue.java
@@ -414,6 +414,8 @@ public abstract class EventQueue implements AutoCloseable {
         private final MainEventBus mainEventBus;
         private final @Nullable TaskStreamLifecycleHook streamLifecycleHook;
 
+        private final ThreadLocal<Boolean> closingChildren = ThreadLocal.withInitial(() -> false);
+
         private final StreamCloseHandle streamCloseHandle = new StreamCloseHandle() {
             @Override
             public void closeStreams() {
@@ -446,6 +448,15 @@ public abstract class EventQueue implements AutoCloseable {
         }
 
 
+        /**
+         * Creates a new ChildQueue subscribed to this MainQueue's event stream.
+         *
+         * <p><strong>Hook interaction:</strong> If a {@link TaskStreamLifecycleHook} is configured,
+         * {@code onSubscribe} is called after the child is added to the children list. If the hook
+         * calls {@link StreamCloseHandle#closeStreams()} during that callback, the returned
+         * ChildQueue will already be closed. Callers must handle this — a closed ChildQueue's
+         * {@link #dequeueEventItem(int)} will throw {@link EventQueueClosedException} immediately.
+         */
         public EventQueue tap() {
             ChildQueue child = new ChildQueue(this);
             children.add(child);
@@ -689,10 +700,21 @@ public abstract class EventQueue implements AutoCloseable {
          * </p>
          */
         void closeChildren() {
-            List<ChildQueue> snapshot = List.copyOf(children);
-            LOGGER.debug("MainQueue[{}]: Closing {} children gracefully", taskId, snapshot.size());
-            for (ChildQueue child : snapshot) {
-                child.close(false);
+            // Guard against reentrancy: onUnsubscribe callbacks (triggered by child.close below)
+            // receive a StreamCloseHandle and could call closeStreams() again on the same thread.
+            if (closingChildren.get()) {
+                LOGGER.debug("MainQueue[{}]: Reentrant closeChildren() call ignored", taskId);
+                return;
+            }
+            closingChildren.set(true);
+            try {
+                List<ChildQueue> snapshot = List.copyOf(children);
+                LOGGER.debug("MainQueue[{}]: Closing {} children gracefully", taskId, snapshot.size());
+                for (ChildQueue child : snapshot) {
+                    child.close(false);
+                }
+            } finally {
+                closingChildren.set(false);
             }
         }
 

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/EventQueue.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/EventQueue.java
@@ -91,6 +91,7 @@ public abstract class EventQueue implements AutoCloseable {
         private List<Runnable> onCloseCallbacks = new java.util.ArrayList<>();
         private @Nullable TaskStateProvider taskStateProvider;
         private @Nullable MainEventBus mainEventBus;
+        private @Nullable TaskStreamLifecycleHook streamLifecycleHook;
 
         /**
          * Sets the maximum queue size.
@@ -161,6 +162,17 @@ public abstract class EventQueue implements AutoCloseable {
         }
 
         /**
+         * Sets the stream lifecycle hook for subscribe/unsubscribe/event notifications.
+         *
+         * @param streamLifecycleHook the hook to be notified of stream lifecycle events
+         * @return this builder
+         */
+        public EventQueueBuilder streamLifecycleHook(@Nullable TaskStreamLifecycleHook streamLifecycleHook) {
+            this.streamLifecycleHook = streamLifecycleHook;
+            return this;
+        }
+
+        /**
          * Builds and returns the configured EventQueue.
          *
          * @return a new MainQueue instance
@@ -173,7 +185,7 @@ public abstract class EventQueue implements AutoCloseable {
             if (taskId == null) {
                 throw new IllegalStateException("taskId is required for EventQueue creation");
             }
-            return new MainQueue(queueSize, hook, taskId, onCloseCallbacks, taskStateProvider, mainEventBus);
+            return new MainQueue(queueSize, hook, taskId, onCloseCallbacks, taskStateProvider, mainEventBus, streamLifecycleHook);
         }
     }
 
@@ -400,7 +412,7 @@ public abstract class EventQueue implements AutoCloseable {
         private final List<Runnable> onCloseCallbacks;
         private final @Nullable TaskStateProvider taskStateProvider;
         private final MainEventBus mainEventBus;
-        private volatile @Nullable TaskStreamLifecycleHook streamLifecycleHook;
+        private final @Nullable TaskStreamLifecycleHook streamLifecycleHook;
 
         private final StreamCloseHandle streamCloseHandle = new StreamCloseHandle() {
             @Override
@@ -419,7 +431,8 @@ public abstract class EventQueue implements AutoCloseable {
                   String taskId,
                   List<Runnable> onCloseCallbacks,
                   @Nullable TaskStateProvider taskStateProvider,
-                  @Nullable MainEventBus mainEventBus) {
+                  @Nullable MainEventBus mainEventBus,
+                  @Nullable TaskStreamLifecycleHook streamLifecycleHook) {
             super(queueSize);
             this.semaphore = new Semaphore(queueSize, true);
             this.enqueueHook = hook;
@@ -427,6 +440,7 @@ public abstract class EventQueue implements AutoCloseable {
             this.onCloseCallbacks = List.copyOf(onCloseCallbacks);  // Defensive copy
             this.taskStateProvider = taskStateProvider;
             this.mainEventBus = Objects.requireNonNull(mainEventBus, "MainEventBus is required");
+            this.streamLifecycleHook = streamLifecycleHook;
             LOGGER.debug("Created MainQueue for task {} with {} onClose callbacks, TaskStateProvider: {}, MainEventBus configured",
                     taskId, onCloseCallbacks.size(), taskStateProvider != null);
         }
@@ -658,10 +672,6 @@ public abstract class EventQueue implements AutoCloseable {
          */
         public int getActiveChildCount() {
             return children.size();
-        }
-
-        void setTaskStreamLifecycleHook(@Nullable TaskStreamLifecycleHook hook) {
-            this.streamLifecycleHook = hook;
         }
 
         @Nullable

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/InMemoryQueueManager.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/InMemoryQueueManager.java
@@ -118,15 +118,7 @@ public class InMemoryQueueManager implements QueueManager {
 
         EventQueue newQueue = null;
         if (existing == null) {
-            // Use builder pattern for cleaner queue creation
             newQueue = factory.builder(taskId).build();
-            // Set the stream lifecycle hook on newly created queues only.
-            // If a queue already exists (putIfAbsent returns non-null), the existing
-            // hook is retained — the hook is bound for the lifetime of the MainQueue.
-            if (newQueue instanceof EventQueue.MainQueue mainQueue) {
-                mainQueue.setTaskStreamLifecycleHook(streamLifecycleHook);
-            }
-            // Make sure an existing queue has not been added in the meantime
             existing = queues.putIfAbsent(taskId, newQueue);
         }
 
@@ -176,7 +168,8 @@ public class InMemoryQueueManager implements QueueManager {
         return EventQueue.builder(mainEventBus)
                 .taskId(taskId)
                 .addOnCloseCallback(getCleanupCallback(taskId))
-                .taskStateProvider(taskStateProvider);
+                .taskStateProvider(taskStateProvider)
+                .streamLifecycleHook(streamLifecycleHook);
     }
 
     /**

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/InMemoryQueueManager.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/InMemoryQueueManager.java
@@ -21,6 +21,7 @@ public class InMemoryQueueManager implements QueueManager {
     // final, is not proxyable in all runtimes
     private EventQueueFactory factory;
     private TaskStateProvider taskStateProvider;
+    private TaskStreamLifecycleHook streamLifecycleHook;
 
     /**
      * No-args constructor for CDI proxy creation.
@@ -32,22 +33,35 @@ public class InMemoryQueueManager implements QueueManager {
         // For CDI proxy creation
         this.factory = null;
         this.taskStateProvider = null;
+        this.streamLifecycleHook = null;
     }
 
     MainEventBus mainEventBus;
 
-    @Inject
     public InMemoryQueueManager(TaskStateProvider taskStateProvider, MainEventBus mainEventBus) {
+        this(taskStateProvider, mainEventBus, new DefaultTaskStreamLifecycleHook());
+    }
+
+    @Inject
+    public InMemoryQueueManager(TaskStateProvider taskStateProvider, MainEventBus mainEventBus,
+                                TaskStreamLifecycleHook streamLifecycleHook) {
         this.mainEventBus = mainEventBus;
         this.factory = new DefaultEventQueueFactory();
         this.taskStateProvider = taskStateProvider;
+        this.streamLifecycleHook = streamLifecycleHook;
     }
 
     // For testing/extensions with custom factory and MainEventBus
     public InMemoryQueueManager(EventQueueFactory factory, TaskStateProvider taskStateProvider, MainEventBus mainEventBus) {
+        this(factory, taskStateProvider, mainEventBus, new DefaultTaskStreamLifecycleHook());
+    }
+
+    public InMemoryQueueManager(EventQueueFactory factory, TaskStateProvider taskStateProvider,
+                                MainEventBus mainEventBus, TaskStreamLifecycleHook streamLifecycleHook) {
         this.factory = factory;
         this.taskStateProvider = taskStateProvider;
         this.mainEventBus = mainEventBus;
+        this.streamLifecycleHook = streamLifecycleHook;
     }
 
     @Override
@@ -106,6 +120,12 @@ public class InMemoryQueueManager implements QueueManager {
         if (existing == null) {
             // Use builder pattern for cleaner queue creation
             newQueue = factory.builder(taskId).build();
+            // Set the stream lifecycle hook on newly created queues only.
+            // If a queue already exists (putIfAbsent returns non-null), the existing
+            // hook is retained — the hook is bound for the lifetime of the MainQueue.
+            if (newQueue instanceof EventQueue.MainQueue mainQueue) {
+                mainQueue.setTaskStreamLifecycleHook(streamLifecycleHook);
+            }
             // Make sure an existing queue has not been added in the meantime
             existing = queues.putIfAbsent(taskId, newQueue);
         }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/MainEventBusProcessor.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/MainEventBusProcessor.java
@@ -257,6 +257,16 @@ public class MainEventBusProcessor implements Runnable {
             LOGGER.debug("MainEventBusProcessor: Distributed {} to {} children for task {}",
                         eventToDistribute.getClass().getSimpleName(), childCount, taskId);
 
+            // Step 3b: Notify stream lifecycle hook after distribution (only if there were active subscribers)
+            TaskStreamLifecycleHook streamHook = mainQueue.getTaskStreamLifecycleHook();
+            if (streamHook != null && childCount > 0) {
+                try {
+                    streamHook.onEvent(taskId, eventToDistribute, mainQueue.getStreamCloseHandle());
+                } catch (Exception e) {
+                    LOGGER.error("Error in TaskStreamLifecycleHook.onEvent for task {}", taskId, e);
+                }
+            }
+
             LOGGER.debug("MainEventBusProcessor: Completed processing event for task {}", taskId);
 
         } finally {

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/StreamCloseHandle.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/StreamCloseHandle.java
@@ -1,0 +1,25 @@
+package org.a2aproject.sdk.server.events;
+
+/**
+ * Handle for closing all active streams (ChildQueues) for a task.
+ * Passed to {@link TaskStreamLifecycleHook} callbacks to allow
+ * user-controlled stream lifecycle management.
+ */
+public interface StreamCloseHandle {
+
+    /**
+     * Gracefully closes all active ChildQueues for this task.
+     * Events already in ChildQueue deques will be drained before the stream terminates.
+     * The MainQueue stays alive for non-finalized tasks — new clients can resubscribe,
+     * and the agent can keep emitting events. If the task is already finalized, the
+     * MainQueue will also close after the last child is removed (existing lifecycle behavior).
+     */
+    void closeStreams();
+
+    /**
+     * Returns the number of active ChildQueues (subscribers) for this task.
+     *
+     * @return the active subscriber count
+     */
+    int getActiveSubscriberCount();
+}

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/TaskStreamLifecycleHook.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/TaskStreamLifecycleHook.java
@@ -55,6 +55,11 @@ public interface TaskStreamLifecycleHook {
     /**
      * Called when a new ChildQueue is created for a task (a client subscribes to the stream).
      *
+     * <p>If this method calls {@link StreamCloseHandle#closeStreams()}, the ChildQueue being
+     * created will be closed before {@code tap()} returns it to the caller. The caller will
+     * receive a closed queue whose {@code dequeueEventItem()} throws
+     * {@code EventQueueClosedException} immediately.</p>
+     *
      * @param taskId the task identifier
      * @param handle handle to close streams and query subscriber count
      */
@@ -62,6 +67,11 @@ public interface TaskStreamLifecycleHook {
 
     /**
      * Called when a ChildQueue closes for a task (a client disconnects or streams are closed).
+     *
+     * <p>Calling {@link StreamCloseHandle#closeStreams()} from within this callback is safe
+     * but has no effect — a reentrancy guard prevents recursive iteration over the children
+     * list. To close remaining streams in response to an unsubscription, schedule the call
+     * asynchronously or handle it in {@link #onEvent}.</p>
      *
      * @param taskId the task identifier
      * @param handle handle to close streams and query subscriber count

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/TaskStreamLifecycleHook.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/TaskStreamLifecycleHook.java
@@ -1,0 +1,79 @@
+package org.a2aproject.sdk.server.events;
+
+import org.a2aproject.sdk.spec.Event;
+
+/**
+ * Hook for observing task stream lifecycle events and controlling stream resources.
+ * <p>
+ * Implementations are notified when clients subscribe/unsubscribe to a task's event stream
+ * and when events are processed for a task. The {@link StreamCloseHandle} passed to each
+ * callback can be used to gracefully close all active streams for the task.
+ * </p>
+ *
+ * <h2>Ordering guarantees</h2>
+ * <ul>
+ *   <li>{@code onSubscribe} is called synchronously during {@code MainQueue.tap()}, after
+ *       the ChildQueue has been added to the children list but before the ChildQueue is
+ *       returned to the caller. The subscriber count visible via
+ *       {@link StreamCloseHandle#getActiveSubscriberCount()} includes the new subscriber.</li>
+ *   <li>{@code onEvent} is called on the {@code MainEventBusProcessor} thread <em>after</em>
+ *       the event has been persisted and distributed to all ChildQueues.
+ *       Implementations must return promptly to avoid stalling event distribution
+ *       for other tasks.</li>
+ *   <li>Because {@code onSubscribe} and {@code onEvent} run on different threads, a fast
+ *       event emission may cause {@code onEvent} to fire concurrently with or even before
+ *       {@code onSubscribe} returns. Stateful hook implementations must be thread-safe.</li>
+ *   <li>{@code onUnsubscribe} is called synchronously inside {@code ChildQueue.close()},
+ *       on whichever thread closes the child (EventConsumer, hook via
+ *       {@link StreamCloseHandle#closeStreams()}, or the client's transport layer).</li>
+ * </ul>
+ *
+ * <h2>Hook binding lifetime</h2>
+ * <p>
+ * The hook is set on a MainQueue when it is first created (in
+ * {@code InMemoryQueueManager.createOrTap()}). If the MainQueue already exists (e.g., a
+ * second client subscribes to the same task), the existing hook reference is retained.
+ * The hook instance is effectively bound for the lifetime of the MainQueue.
+ * </p>
+ * <p>
+ * The default implementation is a no-op. To provide custom behavior (e.g., closing streams
+ * after a timeout), implement this interface and register it as a CDI alternative:
+ * </p>
+ * <pre>{@code
+ * @ApplicationScoped
+ * @Alternative
+ * @Priority(1)
+ * public class MyStreamHook implements TaskStreamLifecycleHook {
+ *     // ...
+ * }
+ * }</pre>
+ *
+ * @see StreamCloseHandle
+ */
+public interface TaskStreamLifecycleHook {
+
+    /**
+     * Called when a new ChildQueue is created for a task (a client subscribes to the stream).
+     *
+     * @param taskId the task identifier
+     * @param handle handle to close streams and query subscriber count
+     */
+    void onSubscribe(String taskId, StreamCloseHandle handle);
+
+    /**
+     * Called when a ChildQueue closes for a task (a client disconnects or streams are closed).
+     *
+     * @param taskId the task identifier
+     * @param handle handle to close streams and query subscriber count
+     */
+    void onUnsubscribe(String taskId, StreamCloseHandle handle);
+
+    /**
+     * Called after an event has been persisted and distributed to all ChildQueues.
+     *
+     * @param taskId the task identifier
+     * @param event the event that was processed
+     * @param handle handle to close streams and query subscriber count
+     */
+    void onEvent(String taskId, Event event, StreamCloseHandle handle);
+}

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/EventQueueTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/EventQueueTest.java
@@ -31,6 +31,7 @@ import org.a2aproject.sdk.spec.TaskState;
 import org.a2aproject.sdk.spec.TaskStatus;
 import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
 import org.a2aproject.sdk.spec.TextPart;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -88,8 +89,13 @@ public class EventQueueTest {
      * Helper to create a queue with MainEventBus configured (for tests that need event distribution).
      */
     private EventQueue createQueueWithEventBus(String taskId) {
+        return createQueueWithEventBus(taskId, null);
+    }
+
+    private EventQueue createQueueWithEventBus(String taskId, @Nullable TaskStreamLifecycleHook hook) {
         return EventQueueUtil.getEventQueueBuilder(mainEventBus)
                 .taskId(taskId)
+                .streamLifecycleHook(hook)
                 .build();
     }
 
@@ -578,8 +584,7 @@ public class EventQueueTest {
             }
         };
 
-        EventQueue mainQueue = createQueueWithEventBus("hook-event-test");
-        ((EventQueue.MainQueue) mainQueue).setTaskStreamLifecycleHook(hook);
+        EventQueue mainQueue = createQueueWithEventBus("hook-event-test", hook);
         EventQueue child = mainQueue.tap();
 
         TaskStatusUpdateEvent statusEvent = TaskStatusUpdateEvent.builder()
@@ -622,8 +627,7 @@ public class EventQueueTest {
             }
         };
 
-        EventQueue mainQueue = createQueueWithEventBus("close-in-hook-test");
-        ((EventQueue.MainQueue) mainQueue).setTaskStreamLifecycleHook(hook);
+        EventQueue mainQueue = createQueueWithEventBus("close-in-hook-test", hook);
         mainQueue.tap();
         mainQueue.tap();
 
@@ -659,8 +663,7 @@ public class EventQueueTest {
             }
         };
 
-        EventQueue mainQueue = createQueueWithEventBus("no-subscribers-test");
-        ((EventQueue.MainQueue) mainQueue).setTaskStreamLifecycleHook(hook);
+        EventQueue mainQueue = createQueueWithEventBus("no-subscribers-test", hook);
 
         TaskStatusUpdateEvent statusEvent = TaskStatusUpdateEvent.builder()
                 .taskId("no-subscribers-test")

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/EventQueueTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/EventQueueTest.java
@@ -10,11 +10,15 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.a2aproject.sdk.server.tasks.InMemoryTaskStore;
+import org.a2aproject.sdk.server.tasks.MockTaskStateProvider;
 import org.a2aproject.sdk.server.tasks.PushNotificationSender;
 import org.a2aproject.sdk.spec.A2AError;
 import org.a2aproject.sdk.spec.Artifact;
@@ -493,5 +497,198 @@ public class EventQueueTest {
         // Now MainQueue should auto-close (no children left)
         assertTrue(mainQueue.isClosed());
         assertTrue(child2.isClosed());
+    }
+
+    /**
+     * Helper to create a queue with a TaskStateProvider that keeps MainQueue open
+     * when all children close (task is never finalized).
+     */
+    private EventQueue createNonFinalizedQueueWithEventBus(String taskId) {
+        return EventQueueUtil.getEventQueueBuilder(mainEventBus)
+                .taskId(taskId)
+                .taskStateProvider(new MockTaskStateProvider())
+                .build();
+    }
+
+    @Test
+    public void testCloseChildrenGracefullyClosesAllChildren() throws InterruptedException {
+        EventQueue mainQueue = createNonFinalizedQueueWithEventBus("close-children-test");
+
+        EventQueue child1 = mainQueue.tap();
+        EventQueue child2 = mainQueue.tap();
+        assertFalse(child1.isClosed());
+        assertFalse(child2.isClosed());
+
+        ((EventQueue.MainQueue) mainQueue).closeChildren();
+
+        assertTrue(child1.isClosed());
+        assertTrue(child2.isClosed());
+
+        assertFalse(mainQueue.isClosed());
+    }
+
+    @Test
+    public void testCloseChildrenAllowsNewSubscriptions() throws InterruptedException {
+        EventQueue mainQueue = createNonFinalizedQueueWithEventBus("close-children-resubscribe-test");
+
+        EventQueue child1 = mainQueue.tap();
+        ((EventQueue.MainQueue) mainQueue).closeChildren();
+        assertTrue(child1.isClosed());
+
+        EventQueue child2 = mainQueue.tap();
+        assertFalse(child2.isClosed());
+        assertFalse(mainQueue.isClosed());
+    }
+
+    @Test
+    public void testStreamCloseHandleCloseStreams() throws InterruptedException {
+        EventQueue mainQueue = createNonFinalizedQueueWithEventBus("handle-close-test");
+
+        EventQueue child1 = mainQueue.tap();
+        EventQueue child2 = mainQueue.tap();
+
+        StreamCloseHandle handle = ((EventQueue.MainQueue) mainQueue).getStreamCloseHandle();
+        assertEquals(2, handle.getActiveSubscriberCount());
+
+        handle.closeStreams();
+
+        assertTrue(child1.isClosed());
+        assertTrue(child2.isClosed());
+        assertFalse(mainQueue.isClosed());
+        assertEquals(0, handle.getActiveSubscriberCount());
+    }
+
+    @Test
+    public void testStreamLifecycleHookOnEventCalledAfterDistribution() throws InterruptedException {
+        List<Event> receivedEvents = new ArrayList<>();
+        CountDownLatch hookLatch = new CountDownLatch(1);
+        TaskStreamLifecycleHook hook = new TaskStreamLifecycleHook() {
+            @Override
+            public void onSubscribe(String taskId, StreamCloseHandle handle) {
+            }
+
+            @Override
+            public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
+            }
+
+            @Override
+            public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
+                receivedEvents.add(event);
+                hookLatch.countDown();
+            }
+        };
+
+        EventQueue mainQueue = createQueueWithEventBus("hook-event-test");
+        ((EventQueue.MainQueue) mainQueue).setTaskStreamLifecycleHook(hook);
+        EventQueue child = mainQueue.tap();
+
+        TaskStatusUpdateEvent statusEvent = TaskStatusUpdateEvent.builder()
+                .taskId("hook-event-test")
+                .contextId("ctx-1")
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING, null, null))
+                .build();
+
+        mainQueue.enqueueEvent(statusEvent);
+
+        assertTrue(hookLatch.await(5, TimeUnit.SECONDS),
+                "TaskStreamLifecycleHook.onEvent should have been called");
+
+        assertEquals(1, receivedEvents.size());
+        assertSame(statusEvent, receivedEvents.get(0));
+    }
+
+    @Test
+    public void testCloseStreamsFromWithinOnEventDoesNotCauseConcurrentModification() throws InterruptedException {
+        CountDownLatch hookLatch = new CountDownLatch(1);
+        AtomicReference<Throwable> caughtException = new AtomicReference<>();
+        TaskStreamLifecycleHook hook = new TaskStreamLifecycleHook() {
+            @Override
+            public void onSubscribe(String taskId, StreamCloseHandle handle) {
+            }
+
+            @Override
+            public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
+            }
+
+            @Override
+            public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
+                try {
+                    handle.closeStreams();
+                } catch (Throwable t) {
+                    caughtException.set(t);
+                } finally {
+                    hookLatch.countDown();
+                }
+            }
+        };
+
+        EventQueue mainQueue = createQueueWithEventBus("close-in-hook-test");
+        ((EventQueue.MainQueue) mainQueue).setTaskStreamLifecycleHook(hook);
+        mainQueue.tap();
+        mainQueue.tap();
+
+        TaskStatusUpdateEvent statusEvent = TaskStatusUpdateEvent.builder()
+                .taskId("close-in-hook-test")
+                .contextId("ctx-1")
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING, null, null))
+                .build();
+
+        mainQueue.enqueueEvent(statusEvent);
+
+        assertTrue(hookLatch.await(5, TimeUnit.SECONDS),
+                "onEvent should have been called");
+        assertNull(caughtException.get(),
+                "closeStreams() from within onEvent should not throw");
+    }
+
+    @Test
+    public void testOnEventNotCalledWithZeroSubscribers() throws InterruptedException {
+        AtomicBoolean onEventCalled = new AtomicBoolean(false);
+        TaskStreamLifecycleHook hook = new TaskStreamLifecycleHook() {
+            @Override
+            public void onSubscribe(String taskId, StreamCloseHandle handle) {
+            }
+
+            @Override
+            public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
+            }
+
+            @Override
+            public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
+                onEventCalled.set(true);
+            }
+        };
+
+        EventQueue mainQueue = createQueueWithEventBus("no-subscribers-test");
+        ((EventQueue.MainQueue) mainQueue).setTaskStreamLifecycleHook(hook);
+
+        TaskStatusUpdateEvent statusEvent = TaskStatusUpdateEvent.builder()
+                .taskId("no-subscribers-test")
+                .contextId("ctx-1")
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING, null, null))
+                .build();
+
+        CountDownLatch processingLatch = new CountDownLatch(1);
+        mainEventBusProcessor.setCallback(new MainEventBusProcessorCallback() {
+            @Override
+            public void onEventProcessed(String taskId, Event event) {
+                processingLatch.countDown();
+            }
+
+            @Override
+            public void onTaskFinalized(String taskId) {
+            }
+        });
+
+        try {
+            mainQueue.enqueueEvent(statusEvent);
+            assertTrue(processingLatch.await(5, TimeUnit.SECONDS),
+                    "Event should have been processed");
+        } finally {
+            mainEventBusProcessor.setCallback(null);
+        }
+
+        assertFalse(onEventCalled.get(),
+                "onEvent should not be called when there are zero subscribers");
     }
 }

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/EventQueueTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/EventQueueTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.a2aproject.sdk.server.tasks.InMemoryTaskStore;
@@ -568,21 +569,10 @@ public class EventQueueTest {
     public void testStreamLifecycleHookOnEventCalledAfterDistribution() throws InterruptedException {
         List<Event> receivedEvents = new ArrayList<>();
         CountDownLatch hookLatch = new CountDownLatch(1);
-        TaskStreamLifecycleHook hook = new TaskStreamLifecycleHook() {
-            @Override
-            public void onSubscribe(String taskId, StreamCloseHandle handle) {
-            }
-
-            @Override
-            public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
-            }
-
-            @Override
-            public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
-                receivedEvents.add(event);
-                hookLatch.countDown();
-            }
-        };
+        TaskStreamLifecycleHook hook = TestStreamLifecycleHook.onEvent((taskId, event, handle) -> {
+            receivedEvents.add(event);
+            hookLatch.countDown();
+        });
 
         EventQueue mainQueue = createQueueWithEventBus("hook-event-test", hook);
         EventQueue child = mainQueue.tap();
@@ -606,26 +596,15 @@ public class EventQueueTest {
     public void testCloseStreamsFromWithinOnEventDoesNotCauseConcurrentModification() throws InterruptedException {
         CountDownLatch hookLatch = new CountDownLatch(1);
         AtomicReference<Throwable> caughtException = new AtomicReference<>();
-        TaskStreamLifecycleHook hook = new TaskStreamLifecycleHook() {
-            @Override
-            public void onSubscribe(String taskId, StreamCloseHandle handle) {
+        TaskStreamLifecycleHook hook = TestStreamLifecycleHook.onEvent((taskId, event, handle) -> {
+            try {
+                handle.closeStreams();
+            } catch (Throwable t) {
+                caughtException.set(t);
+            } finally {
+                hookLatch.countDown();
             }
-
-            @Override
-            public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
-            }
-
-            @Override
-            public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
-                try {
-                    handle.closeStreams();
-                } catch (Throwable t) {
-                    caughtException.set(t);
-                } finally {
-                    hookLatch.countDown();
-                }
-            }
-        };
+        });
 
         EventQueue mainQueue = createQueueWithEventBus("close-in-hook-test", hook);
         mainQueue.tap();
@@ -646,22 +625,51 @@ public class EventQueueTest {
     }
 
     @Test
+    public void testCloseStreamsFromOnUnsubscribeIsNoOp() {
+        AtomicInteger unsubscribeCount = new AtomicInteger(0);
+        AtomicReference<Throwable> caughtException = new AtomicReference<>();
+        TaskStreamLifecycleHook hook = TestStreamLifecycleHook.onUnsubscribe((taskId, handle) -> {
+            unsubscribeCount.incrementAndGet();
+            try {
+                handle.closeStreams();
+            } catch (Throwable t) {
+                caughtException.set(t);
+            }
+        });
+
+        EventQueue mainQueue = createQueueWithEventBus("reentrant-close-test", hook);
+        mainQueue.tap();
+        mainQueue.tap();
+        mainQueue.tap();
+
+        ((EventQueue.MainQueue) mainQueue).closeChildren();
+
+        assertNull(caughtException.get(),
+                "Reentrant closeStreams() from onUnsubscribe should not throw");
+        assertEquals(3, unsubscribeCount.get(),
+                "All three children should have triggered onUnsubscribe exactly once");
+        assertEquals(0, ((EventQueue.MainQueue) mainQueue).getActiveChildCount(),
+                "All children should be closed");
+    }
+
+    @Test
+    public void testTapReturnsClosedQueueWhenHookCallsCloseStreams() {
+        TaskStreamLifecycleHook hook = TestStreamLifecycleHook.onSubscribe((taskId, handle) -> handle.closeStreams());
+
+        EventQueue mainQueue = createQueueWithEventBus("tap-close-test", hook);
+        EventQueue child = mainQueue.tap();
+
+        assertTrue(child.isClosed(),
+                "ChildQueue returned by tap() should be closed when hook calls closeStreams() during onSubscribe");
+        assertThrows(EventQueueClosedException.class,
+                () -> child.dequeueEventItem(0),
+                "Dequeuing from a closed ChildQueue should throw EventQueueClosedException");
+    }
+
+    @Test
     public void testOnEventNotCalledWithZeroSubscribers() throws InterruptedException {
         AtomicBoolean onEventCalled = new AtomicBoolean(false);
-        TaskStreamLifecycleHook hook = new TaskStreamLifecycleHook() {
-            @Override
-            public void onSubscribe(String taskId, StreamCloseHandle handle) {
-            }
-
-            @Override
-            public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
-            }
-
-            @Override
-            public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
-                onEventCalled.set(true);
-            }
-        };
+        TaskStreamLifecycleHook hook = TestStreamLifecycleHook.onEvent((taskId, event, handle) -> onEventCalled.set(true));
 
         EventQueue mainQueue = createQueueWithEventBus("no-subscribers-test", hook);
 

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/InMemoryQueueManagerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/InMemoryQueueManagerTest.java
@@ -1,6 +1,7 @@
 package org.a2aproject.sdk.server.events;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -12,7 +13,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
+
+import org.a2aproject.sdk.spec.Event;
 
 import org.a2aproject.sdk.server.tasks.InMemoryTaskStore;
 import org.a2aproject.sdk.server.tasks.MockTaskStateProvider;
@@ -238,5 +242,98 @@ public class InMemoryQueueManagerTest {
         // All ChildQueues should be distinct instances
         long distinctCount = results.stream().distinct().count();
         assertEquals(results.size(), distinctCount, "All ChildQueues should be distinct instances");
+    }
+
+    @Test
+    public void testHookOnSubscribeCalledOnCreateOrTap() {
+        List<String> subscribeEvents = new ArrayList<>();
+        TaskStreamLifecycleHook hook = new TaskStreamLifecycleHook() {
+            @Override
+            public void onSubscribe(String taskId, StreamCloseHandle handle) {
+                subscribeEvents.add(taskId);
+            }
+
+            @Override
+            public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
+            }
+
+            @Override
+            public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
+            }
+        };
+
+        InMemoryQueueManager hookedQueueManager = new InMemoryQueueManager(taskStateProvider, mainEventBus, hook);
+
+        hookedQueueManager.createOrTap("task-1");
+        assertEquals(1, subscribeEvents.size());
+        assertEquals("task-1", subscribeEvents.get(0));
+
+        hookedQueueManager.tap("task-1");
+        assertEquals(2, subscribeEvents.size());
+    }
+
+    @Test
+    public void testHookOnUnsubscribeCalledOnChildClose() {
+        List<String> unsubscribeEvents = new ArrayList<>();
+        TaskStreamLifecycleHook hook = new TaskStreamLifecycleHook() {
+            @Override
+            public void onSubscribe(String taskId, StreamCloseHandle handle) {
+            }
+
+            @Override
+            public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
+                unsubscribeEvents.add(taskId);
+            }
+
+            @Override
+            public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
+            }
+        };
+
+        InMemoryQueueManager hookedQueueManager = new InMemoryQueueManager(taskStateProvider, mainEventBus, hook);
+
+        EventQueue child = hookedQueueManager.createOrTap("task-1");
+        child.close();
+
+        assertEquals(1, unsubscribeEvents.size());
+        assertEquals("task-1", unsubscribeEvents.get(0));
+    }
+
+    @Test
+    public void testStreamCloseHandleClosesAllChildrenViaQueueManager() {
+        AtomicReference<StreamCloseHandle> capturedHandle = new AtomicReference<>();
+        TaskStreamLifecycleHook hook = new TaskStreamLifecycleHook() {
+            @Override
+            public void onSubscribe(String taskId, StreamCloseHandle handle) {
+                capturedHandle.set(handle);
+            }
+
+            @Override
+            public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
+            }
+
+            @Override
+            public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
+            }
+        };
+
+        InMemoryQueueManager hookedQueueManager = new InMemoryQueueManager(taskStateProvider, mainEventBus, hook);
+
+        EventQueue child1 = hookedQueueManager.createOrTap("task-1");
+        EventQueue child2 = hookedQueueManager.tap("task-1");
+
+        assertNotNull(capturedHandle.get());
+        assertEquals(2, capturedHandle.get().getActiveSubscriberCount());
+
+        capturedHandle.get().closeStreams();
+
+        assertTrue(child1.isClosed());
+        assertTrue(child2.isClosed());
+        assertEquals(0, capturedHandle.get().getActiveSubscriberCount());
+
+        // MainQueue should still exist and accept new subscriptions
+        EventQueue child3 = hookedQueueManager.tap("task-1");
+        assertNotNull(child3);
+        assertFalse(child3.isClosed());
     }
 }

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/InMemoryQueueManagerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/InMemoryQueueManagerTest.java
@@ -13,13 +13,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
 import org.a2aproject.sdk.server.tasks.InMemoryTaskStore;
 import org.a2aproject.sdk.server.tasks.MockTaskStateProvider;
 import org.a2aproject.sdk.server.tasks.PushNotificationSender;
-import org.a2aproject.sdk.spec.Event;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -245,90 +243,46 @@ public class InMemoryQueueManagerTest {
 
     @Test
     public void testHookOnSubscribeCalledOnCreateOrTap() {
-        List<String> subscribeEvents = new ArrayList<>();
-        TaskStreamLifecycleHook hook = new TaskStreamLifecycleHook() {
-            @Override
-            public void onSubscribe(String taskId, StreamCloseHandle handle) {
-                subscribeEvents.add(taskId);
-            }
-
-            @Override
-            public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
-            }
-
-            @Override
-            public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
-            }
-        };
-
+        TestStreamLifecycleHook.CaptureHook hook = TestStreamLifecycleHook.capturing();
         InMemoryQueueManager hookedQueueManager = new InMemoryQueueManager(taskStateProvider, mainEventBus, hook);
 
         hookedQueueManager.createOrTap("task-1");
-        assertEquals(1, subscribeEvents.size());
-        assertEquals("task-1", subscribeEvents.get(0));
+        assertEquals(1, hook.subscribedTaskIds().size());
+        assertEquals("task-1", hook.subscribedTaskIds().get(0));
 
         hookedQueueManager.tap("task-1");
-        assertEquals(2, subscribeEvents.size());
+        assertEquals(2, hook.subscribedTaskIds().size());
     }
 
     @Test
     public void testHookOnUnsubscribeCalledOnChildClose() {
-        List<String> unsubscribeEvents = new ArrayList<>();
-        TaskStreamLifecycleHook hook = new TaskStreamLifecycleHook() {
-            @Override
-            public void onSubscribe(String taskId, StreamCloseHandle handle) {
-            }
-
-            @Override
-            public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
-                unsubscribeEvents.add(taskId);
-            }
-
-            @Override
-            public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
-            }
-        };
-
+        TestStreamLifecycleHook.CaptureHook hook = TestStreamLifecycleHook.capturing();
         InMemoryQueueManager hookedQueueManager = new InMemoryQueueManager(taskStateProvider, mainEventBus, hook);
 
         EventQueue child = hookedQueueManager.createOrTap("task-1");
         child.close();
 
-        assertEquals(1, unsubscribeEvents.size());
-        assertEquals("task-1", unsubscribeEvents.get(0));
+        assertEquals(1, hook.unsubscribedTaskIds().size());
+        assertEquals("task-1", hook.unsubscribedTaskIds().get(0));
     }
 
     @Test
     public void testStreamCloseHandleClosesAllChildrenViaQueueManager() {
-        AtomicReference<StreamCloseHandle> capturedHandle = new AtomicReference<>();
-        TaskStreamLifecycleHook hook = new TaskStreamLifecycleHook() {
-            @Override
-            public void onSubscribe(String taskId, StreamCloseHandle handle) {
-                capturedHandle.set(handle);
-            }
-
-            @Override
-            public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
-            }
-
-            @Override
-            public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
-            }
-        };
-
+        TestStreamLifecycleHook.CaptureHook hook = TestStreamLifecycleHook.capturing();
         InMemoryQueueManager hookedQueueManager = new InMemoryQueueManager(taskStateProvider, mainEventBus, hook);
 
         EventQueue child1 = hookedQueueManager.createOrTap("task-1");
         EventQueue child2 = hookedQueueManager.tap("task-1");
 
-        assertNotNull(capturedHandle.get());
-        assertEquals(2, capturedHandle.get().getActiveSubscriberCount());
+        StreamCloseHandle handle = hook.lastHandle();
+        assertNotNull(handle);
+        assertEquals(2, handle.getActiveSubscriberCount());
 
-        capturedHandle.get().closeStreams();
+        handle.closeStreams();
 
         assertTrue(child1.isClosed());
         assertTrue(child2.isClosed());
-        assertEquals(0, capturedHandle.get().getActiveSubscriberCount());
+        assertEquals(0, handle.getActiveSubscriberCount());
 
         // MainQueue should still exist and accept new subscriptions
         EventQueue child3 = hookedQueueManager.tap("task-1");

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/InMemoryQueueManagerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/InMemoryQueueManagerTest.java
@@ -16,11 +16,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
-import org.a2aproject.sdk.spec.Event;
-
 import org.a2aproject.sdk.server.tasks.InMemoryTaskStore;
 import org.a2aproject.sdk.server.tasks.MockTaskStateProvider;
 import org.a2aproject.sdk.server.tasks.PushNotificationSender;
+import org.a2aproject.sdk.spec.Event;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/TestStreamLifecycleHook.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/TestStreamLifecycleHook.java
@@ -1,0 +1,108 @@
+package org.a2aproject.sdk.server.events;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import org.a2aproject.sdk.spec.Event;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Test utility for creating {@link TaskStreamLifecycleHook} instances without
+ * boilerplate. Unspecified callbacks default to no-ops.
+ */
+final class TestStreamLifecycleHook implements TaskStreamLifecycleHook {
+
+    @FunctionalInterface
+    interface EventCallback {
+        void accept(String taskId, Event event, StreamCloseHandle handle);
+    }
+
+    private final BiConsumer<String, StreamCloseHandle> subscribeCallback;
+    private final BiConsumer<String, StreamCloseHandle> unsubscribeCallback;
+    private final EventCallback eventCallback;
+
+    private TestStreamLifecycleHook(
+            BiConsumer<String, StreamCloseHandle> subscribeCallback,
+            BiConsumer<String, StreamCloseHandle> unsubscribeCallback,
+            EventCallback eventCallback) {
+        this.subscribeCallback = subscribeCallback;
+        this.unsubscribeCallback = unsubscribeCallback;
+        this.eventCallback = eventCallback;
+    }
+
+    static TestStreamLifecycleHook onSubscribe(BiConsumer<String, StreamCloseHandle> callback) {
+        return new TestStreamLifecycleHook(callback, (t, h) -> {}, (t, e, h) -> {});
+    }
+
+    static TestStreamLifecycleHook onUnsubscribe(BiConsumer<String, StreamCloseHandle> callback) {
+        return new TestStreamLifecycleHook((t, h) -> {}, callback, (t, e, h) -> {});
+    }
+
+    static TestStreamLifecycleHook onEvent(EventCallback callback) {
+        return new TestStreamLifecycleHook((t, h) -> {}, (t, h) -> {}, callback);
+    }
+
+    static CaptureHook capturing() {
+        return new CaptureHook();
+    }
+
+    @Override
+    public void onSubscribe(String taskId, StreamCloseHandle handle) {
+        subscribeCallback.accept(taskId, handle);
+    }
+
+    @Override
+    public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
+        unsubscribeCallback.accept(taskId, handle);
+    }
+
+    @Override
+    public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
+        eventCallback.accept(taskId, event, handle);
+    }
+
+    /**
+     * A hook that records all callback invocations for later assertion.
+     */
+    static final class CaptureHook implements TaskStreamLifecycleHook {
+        private final List<String> subscribedTaskIds = new ArrayList<>();
+        private final List<String> unsubscribedTaskIds = new ArrayList<>();
+        private final List<Event> receivedEvents = new ArrayList<>();
+        private volatile @Nullable StreamCloseHandle lastHandle;
+
+        List<String> subscribedTaskIds() {
+            return subscribedTaskIds;
+        }
+
+        List<String> unsubscribedTaskIds() {
+            return unsubscribedTaskIds;
+        }
+
+        List<Event> receivedEvents() {
+            return receivedEvents;
+        }
+
+        @Nullable StreamCloseHandle lastHandle() {
+            return lastHandle;
+        }
+
+        @Override
+        public void onSubscribe(String taskId, StreamCloseHandle handle) {
+            subscribedTaskIds.add(taskId);
+            lastHandle = handle;
+        }
+
+        @Override
+        public void onUnsubscribe(String taskId, StreamCloseHandle handle) {
+            unsubscribedTaskIds.add(taskId);
+            lastHandle = handle;
+        }
+
+        @Override
+        public void onEvent(String taskId, Event event, StreamCloseHandle handle) {
+            receivedEvents.add(event);
+            lastHandle = handle;
+        }
+    }
+}


### PR DESCRIPTION
Add a CDI-discoverable hook that lets users observe task stream lifecycle events (subscribe, unsubscribe, event) and close all ChildQueues for a task on demand via StreamCloseHandle. Wired through InMemoryQueueManager, MainEventBusProcessor, and ReplicatedQueueManager.

Includes a stream-lifecycle example with integration tests for all three transports (JSONRPC, gRPC, REST) and documentation.

This fixes #990
