### PR TITLE
fix(opentelemetry): correct inaccurate docs, Javadoc, and dead config

### DIFF
--- a/docs/content/dev/client.md
+++ b/docs/content/dev/client.md
@@ -185,6 +185,10 @@ Client client = Client
         .build();
 ```
 
+## Observability (Optional)
+
+Add distributed tracing and W3C Trace Context propagation to client calls with the [OpenTelemetry extras modules](extra/opentelemetry#client).
+
 ## Communicating with v0.3 Agents
 
 See [Backward Compatibility](compatibility#client-communicating-with-v03-agents) for using `Client_v0_3` with older protocol agents.

--- a/docs/content/dev/extra/opentelemetry.md
+++ b/docs/content/dev/extra/opentelemetry.md
@@ -1,12 +1,12 @@
 ---
 title: OpenTelemetry
-description: OpenTelemetry observability integration for the A2A Java SDK with distributed tracing, context propagation, and metrics for servers and clients.
+description: OpenTelemetry observability integration for the A2A Java SDK with distributed tracing and context propagation for servers and clients.
 layout: page
 ---
 
 # OpenTelemetry
 
-Adds distributed tracing, metrics, and context propagation to A2A servers and clients using [OpenTelemetry](https://opentelemetry.io/).
+Adds distributed tracing and context propagation to A2A servers and clients using [OpenTelemetry](https://opentelemetry.io/).
 
 ## Features
 
@@ -28,7 +28,7 @@ Adds distributed tracing, metrics, and context propagation to A2A servers and cl
 
 The `OpenTelemetryRequestHandlerDecorator` wraps the default request handler to create spans for every A2A protocol method, with automatic error tracking.
 
-### 1. Add Dependency
+### Add Dependency
 
 ```xml
 <dependency>
@@ -90,12 +90,20 @@ For other runtimes, consult your MicroProfile Context Propagation implementation
 
 ### Span Attributes
 
-The following attributes are automatically added to spans:
+The following attributes are automatically added to spans (defined in `A2AObservabilityNames`):
 
 | Attribute | Description |
 |-----------|-------------|
-| `gen_ai.agent.a2a.request` | Request parameters (if extraction enabled) |
-| `gen_ai.agent.a2a.response` | Response data (if extraction enabled) |
+| `gen_ai.agent.a2a.operation.name` | The A2A method name (e.g., `message/send`, `tasks/get`) |
+| `gen_ai.agent.a2a.task_id` | Task identifier (when available) |
+| `gen_ai.agent.a2a.context_id` | Context/conversation identifier (when available) |
+| `gen_ai.agent.a2a.message_id` | Message identifier (when available) |
+| `gen_ai.agent.a2a.role` | Message role (when available) |
+| `gen_ai.agent.a2a.extensions` | Comma-separated extension names (when present) |
+| `gen_ai.agent.a2a.parts.number` | Number of message parts |
+| `gen_ai.agent.a2a.config_id` | Push notification config identifier (when available) |
+| `gen_ai.agent.a2a.request` | Full request parameters (only if extraction enabled) |
+| `gen_ai.agent.a2a.response` | Full response data (only if extraction enabled) |
 | `error.type` | Error message (on failures) |
 
 ### Request/Response Extraction

--- a/docs/content/dev/server.md
+++ b/docs/content/dev/server.md
@@ -223,6 +223,10 @@ public class CloseStreamsHook implements TaskStreamLifecycleHook {
 
 See the [`examples/stream-lifecycle`](https://github.com/a2aproject/a2a-java/tree/main/examples/stream-lifecycle) directory for a complete working example with server, client, and integration tests for all three transports.
 
+## Observability (Optional)
+
+Add distributed tracing to your server with the [OpenTelemetry extras module](extra/opentelemetry). It decorates the request handler to create spans for every A2A protocol method, with automatic error tracking and optional request/response extraction.
+
 ## Backward Compatibility with v0.3
 
 See [Backward Compatibility](compatibility) for multi-version modules, version routing, and v0.3 client support.

--- a/extras/opentelemetry/README.md
+++ b/extras/opentelemetry/README.md
@@ -1,36 +1,34 @@
 # OpenTelemetry Integration for A2A
 
-This module provides OpenTelemetry observability integration for A2A servers, including distributed tracing, metrics, and context propagation across asynchronous boundaries.
+This module provides OpenTelemetry observability integration for A2A servers and clients, including distributed tracing and context propagation.
 
 ## Features
 
-- **Distributed Tracing**: Automatic span creation for all A2A protocol methods
-- **Context Propagation**: OpenTelemetry trace context propagation across async operations
-- **Request/Response Logging**: Optional extraction of request and response data into spans
+- **Distributed Tracing**: Automatic span creation for all A2A protocol methods (both client and server)
+- **Context Propagation**: W3C Trace Context injection into outbound client requests
+- **Request/Response Logging**: Optional extraction of request and response data into span attributes
 - **Error Tracking**: Automatic error status and error type attributes on failures
 
 ## Modules
 
 ### `opentelemetry-common`
-Common utilities and constants shared across OpenTelemetry modules.
+Constants and span attribute names shared across client and server modules. See `A2AObservabilityNames` for the full list of attribute keys.
 
 ### `opentelemetry-client`
-OpenTelemetry integration for A2A clients.
+Client-side distributed tracing. Wraps `ClientTransport` to create spans for every A2A operation. Discovered automatically via `ServiceLoader` when a `Tracer` is present in the transport configuration parameters.
 
 ### `opentelemetry-client-propagation`
-Context propagation support for A2A clients.
+Injects W3C Trace Context headers into outbound client requests using `OpenTelemetry.getPropagators().getTextMapPropagator()`. Discovered automatically via `ServiceLoader` when an `OpenTelemetry` instance is present in the transport configuration parameters.
 
 ### `opentelemetry-server`
-OpenTelemetry integration for A2A servers, including the context-aware executor.
+CDI decorator (`OpenTelemetryRequestHandlerDecorator`) that wraps `RequestHandler` to create server-side spans. Automatically activated when the module JAR is on the classpath (via the bundled `beans.xml`).
 
 ### `opentelemetry-integration-tests`
-Integration tests for OpenTelemetry functionality.
+Quarkus-based integration tests for OpenTelemetry functionality.
 
-## Usage
+## Server Usage
 
-### Basic Setup
-
-Add the OpenTelemetry server module to your dependencies:
+### Add Dependency
 
 ```xml
 <dependency>
@@ -40,120 +38,131 @@ Add the OpenTelemetry server module to your dependencies:
 </dependency>
 ```
 
-### Context-Aware Async Executor
+The `OpenTelemetryRequestHandlerDecorator` is registered automatically via the `beans.xml` bundled in the module JAR. No additional configuration is required.
 
-The `AsyncManagedExecutorProducer` provides a `ManagedExecutor` that automatically propagates OpenTelemetry trace context across asynchronous boundaries. This ensures that spans created in async tasks are properly linked to their parent spans.
-
-#### How It Works
-
-When the OpenTelemetry server module is included, the `AsyncManagedExecutorProducer` automatically replaces the default `AsyncExecutorProducer` using CDI alternatives:
-
-- **Priority 20**: Takes precedence over the default executor producer (priority 10)
-- **Automatic Activation**: No configuration needed - just include the module
-- **Context Propagation**: Uses MicroProfile Context Propagation to maintain trace context
-
-#### Configuration
-
-The `ManagedExecutor` is container-managed and configured through your runtime environment:
-
-**Quarkus:**
-```properties
-# Configure the managed executor pool
-quarkus.thread-pool.core-threads=10
-quarkus.thread-pool.max-threads=50
-quarkus.thread-pool.queue-size=100
-```
-
-**Other Runtimes:**
-Consult your MicroProfile Context Propagation implementation documentation for configuration options.
-
-> **Note**: Unlike the default `AsyncExecutorProducer`, the `AsyncManagedExecutorProducer` does not use the `a2a.executor.*` configuration properties. Pool sizing is controlled by the container's ManagedExecutor configuration.
-
-#### Example
-
-```java
-@ApplicationScoped
-public class MyAgent implements Agent {
-    
-    @Inject
-    @Internal
-    Executor executor;  // Automatically uses ManagedExecutor with context propagation
-    
-    @Override
-    public void execute(RequestContext context, AgentEmitter emitter) {
-        // Current span context is automatically propagated
-        executor.execute(() -> {
-            // This code runs in a different thread but maintains the trace context
-            Span currentSpan = Span.current();
-            currentSpan.addEvent("Processing in async task");
-            
-            // Do async work...
-        });
-    }
-}
-```
+> **Note**: The decorator relies on the runtime (e.g., Quarkus OpenTelemetry extension) to extract trace context from incoming HTTP requests. It does not perform context extraction itself — it creates a new span within the already-established trace context.
 
 ### Request/Response Extraction
 
-Enable request and response data extraction in spans:
+Optionally include full request/response data as span attributes. These are controlled by **JVM system properties** (not application config), read via `Boolean.getBoolean()`:
 
-```properties
-# Extract request parameters into span attributes
-a2a.opentelemetry.extract-request=true
-
-# Extract response data into span attributes
-a2a.opentelemetry.extract-response=true
+```bash
+# Pass as JVM system properties (-D flags)
+-Dorg.a2aproject.sdk.server.extract.request=true
+-Dorg.a2aproject.sdk.server.extract.response=true
 ```
 
 > **Warning**: Extracting request/response data may expose sensitive information in traces. Use with caution in production environments.
 
 ### Span Attributes
 
-The following attributes are automatically added to spans:
+The following attributes are automatically added to spans (defined in `A2AObservabilityNames`):
 
-- `genai.request`: Request parameters (if extraction enabled)
-- `genai.response`: Response data (if extraction enabled)
-- `error.type`: Error message (on failures)
+| Attribute | Description |
+|-----------|-------------|
+| `gen_ai.agent.a2a.operation.name` | The A2A method name (e.g., `message/send`, `tasks/get`) |
+| `gen_ai.agent.a2a.task_id` | Task identifier (when available) |
+| `gen_ai.agent.a2a.context_id` | Context/conversation identifier (when available) |
+| `gen_ai.agent.a2a.message_id` | Message identifier (when available) |
+| `gen_ai.agent.a2a.role` | Message role (when available) |
+| `gen_ai.agent.a2a.extensions` | Comma-separated extension names (when present) |
+| `gen_ai.agent.a2a.parts.number` | Number of message parts |
+| `gen_ai.agent.a2a.config_id` | Push notification config identifier (when available) |
+| `gen_ai.agent.a2a.request` | Full request parameters (only if extraction enabled) |
+| `gen_ai.agent.a2a.response` | Full response data (only if extraction enabled) |
+| `error.type` | Error message (on failures) |
+
+### Streaming Methods
+
+For streaming methods (`onMessageSendStream`, `onSubscribeToTask`), the server-side span covers only the creation of the `Flow.Publisher`, not the actual streaming of events. The span is started and ended synchronously before events are emitted, and the response attribute is set to `"Stream publisher created"`. This means the span duration does not reflect the actual duration of the streaming operation.
+
+On the client side, streaming is handled differently: the `OpenTelemetryClientTransport` creates child spans linked to the parent for each streaming event and error callback, providing per-event tracing.
+
+## Client Usage
+
+### Instrumentation (Tracing Spans)
+
+Add the client tracing module:
+
+```xml
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-extras-opentelemetry-client</artifactId>
+    <version>${a2a.version}</version>
+</dependency>
+```
+
+Enable tracing by adding a `Tracer` instance to the transport configuration parameters:
+
+```java
+import static org.a2aproject.sdk.extras.opentelemetry.client.OpenTelemetryClientTransportWrapper.OTEL_TRACER_KEY;
+
+config.setParameters(Map.of(
+    OTEL_TRACER_KEY, openTelemetry.getTracer("my-service")
+));
+```
+
+### Context Propagation (W3C Trace Headers)
+
+Add the propagation module:
+
+```xml
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-extras-opentelemetry-client-propagation</artifactId>
+    <version>${a2a.version}</version>
+</dependency>
+```
+
+Enable propagation by adding an `OpenTelemetry` instance to the transport configuration parameters:
+
+```java
+import static org.a2aproject.sdk.extras.opentelemetry.client.propagation.OpenTelemetryClientPropagatorTransportWrapper.OTEL_OPEN_TELEMETRY_KEY;
+
+config.setParameters(Map.of(
+    OTEL_TRACER_KEY, openTelemetry.getTracer("my-service"),
+    OTEL_OPEN_TELEMETRY_KEY, openTelemetry
+));
+```
+
+Both wrappers are discovered automatically via `ServiceLoader` and activate only when their respective keys are present in the configuration parameters. The client wrapper (priority 600) runs after the propagation wrapper (priority 500), so trace context headers are injected before the tracing span is created.
 
 ## Architecture
 
-### Request Handler Decoration
-
-The `OpenTelemetryRequestHandlerDecorator` wraps the default request handler and creates spans for each A2A protocol method:
+### Server Request Handler Decoration
 
 ```
 Client Request
     ↓
-OpenTelemetryRequestHandlerDecorator
-    ↓ (creates span)
+Runtime (e.g., Quarkus OTel) extracts trace context from HTTP headers
+    ↓
+OpenTelemetryRequestHandlerDecorator creates span within trace context
+    ↓
 Default RequestHandler
     ↓
-Agent Execution (with context propagation)
+Agent Execution
     ↓
 Response
 ```
 
-### Context Propagation Flow
+### Client Transport Wrapping
 
 ```
-HTTP Request (with trace headers)
+Application calls ClientTransport method
     ↓
-OpenTelemetry extracts context
+OpenTelemetryClientPropagatorTransport injects W3C trace context headers (priority 500)
     ↓
-Span created for A2A method
+OpenTelemetryClientTransport creates tracing span (priority 600)
     ↓
-ManagedExecutor propagates context
+Underlying transport (JSON-RPC, gRPC, REST)
     ↓
-Async agent execution (maintains trace context)
-    ↓
-Response (with trace headers)
+Response
 ```
 
 ## Testing
 
-The module includes comprehensive unit tests:
+The module includes:
 
-- `AsyncManagedExecutorProducerTest`: Tests for the context-aware executor producer
 - `OpenTelemetryRequestHandlerDecoratorTest`: Tests for span creation and error handling
 
 Run tests:
@@ -167,28 +176,13 @@ mvn test -pl extras/opentelemetry/server
 
 **Symptom**: Spans in async tasks are not linked to parent spans.
 
-**Solution**: Ensure the OpenTelemetry server module is included and the `ManagedExecutor` is being injected correctly. Check logs for:
-```
-Initializing OpenTelemetry-aware ManagedExecutor for async operations
-```
-
-### ManagedExecutor Not Available
-
-**Symptom**: `IllegalStateException: ManagedExecutor not injected - ensure MicroProfile Context Propagation is available`
-
-**Solution**: Ensure your runtime provides MicroProfile Context Propagation support. For Quarkus, add:
-```xml
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-smallrye-context-propagation</artifactId>
-</dependency>
-```
+**Solution**: Ensure your runtime provides trace context propagation for async boundaries. For Quarkus, this is handled automatically by MicroProfile Context Propagation. The context-aware `ManagedExecutor` that propagates trace context across async boundaries is provided by the reference server module (`reference/common`), not this OpenTelemetry module.
 
 ### Performance Impact
 
 **Symptom**: Increased latency with OpenTelemetry enabled.
 
-**Solution**: 
+**Solution**:
 - Disable request/response extraction in production
 - Configure sampling rate to reduce trace volume
 - Ensure your OpenTelemetry collector is properly sized
@@ -203,13 +197,12 @@ Initializing OpenTelemetry-aware ManagedExecutor for async operations
 
 ## Dependencies
 
-- MicroProfile Telemetry 2.0.1+
-- MicroProfile Context Propagation 1.3+
 - OpenTelemetry API
-- A2A Server Common
+- A2A Server Common (for server module)
+- A2A Client Transport SPI (for client modules)
 
 ## See Also
 
 - [OpenTelemetry Documentation](https://opentelemetry.io/docs/)
 - [MicroProfile Telemetry Specification](https://github.com/eclipse/microprofile-telemetry)
-- [MicroProfile Context Propagation](https://github.com/eclipse/microprofile-context-propagation)
+- [Helloworld Example with OpenTelemetry](../../examples/helloworld/)

--- a/extras/opentelemetry/client-propagation/src/main/java/org/a2aproject/sdk/extras/opentelemetry/client/propagation/OpenTelemetryClientPropagatorTransportWrapper.java
+++ b/extras/opentelemetry/client-propagation/src/main/java/org/a2aproject/sdk/extras/opentelemetry/client/propagation/OpenTelemetryClientPropagatorTransportWrapper.java
@@ -4,19 +4,16 @@ import org.a2aproject.sdk.client.transport.spi.ClientTransport;
 import org.a2aproject.sdk.client.transport.spi.ClientTransportConfig;
 import org.a2aproject.sdk.client.transport.spi.ClientTransportWrapper;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.trace.Tracer;
 
 /**
- * OpenTelemetry client transport wrapper that adds opentelemetry propagation to A2A client calls.
+ * OpenTelemetry client transport wrapper that injects W3C Trace Context headers into outbound A2A client requests.
  *
  * <p>This wrapper is automatically discovered via Java's ServiceLoader mechanism.
- * To enable tracing, add a {@link Tracer} instance to the transport configuration:
+ * To enable context propagation, add an {@link OpenTelemetry} instance to the transport configuration:
  * <pre>{@code
  * ClientTransportConfig config = new JSONRPCTransportConfig();
  * config.setParameters(Map.of(
- *     OpenTelemetryClientTransportFactory.OTEL_TRACER_KEY,
- *     openTelemetry.getTracer("my-service"),
- *     OpenTelemetryClientTransportFactory.OTEL_OPEN_TELEMETRY_KEY,
+ *     OpenTelemetryClientPropagatorTransportWrapper.OTEL_OPEN_TELEMETRY_KEY,
  *     openTelemetry
  * ));
  * }</pre>
@@ -24,10 +21,8 @@ import io.opentelemetry.api.trace.Tracer;
 public class OpenTelemetryClientPropagatorTransportWrapper implements ClientTransportWrapper {
 
     /**
-     * Configuration key for the OpenTelemetry Tracer instance.
-     * Value must be of type {@link Tracer}.
+     * Configuration key for the {@link OpenTelemetry} instance used for context propagation.
      */
-    public static final String OTEL_TRACER_KEY = "org.a2aproject.sdk.extras.opentelemetry.Tracer";
     public static final String OTEL_OPEN_TELEMETRY_KEY = "org.a2aproject.sdk.extras.opentelemetry.OpenTelemetry";
 
     @Override
@@ -36,7 +31,7 @@ public class OpenTelemetryClientPropagatorTransportWrapper implements ClientTran
         if (openTelemetryObj != null && openTelemetryObj instanceof OpenTelemetry openTelemetry) {
             return new OpenTelemetryClientPropagatorTransport(transport, openTelemetry);
         }
-        // No tracer configured, return unwrapped transport
+        // No OpenTelemetry configured, return unwrapped transport
         return transport;
     }
 

--- a/extras/opentelemetry/client/src/main/java/org/a2aproject/sdk/extras/opentelemetry/client/OpenTelemetryClientTransportWrapper.java
+++ b/extras/opentelemetry/client/src/main/java/org/a2aproject/sdk/extras/opentelemetry/client/OpenTelemetryClientTransportWrapper.java
@@ -13,10 +13,8 @@ import io.opentelemetry.api.trace.Tracer;
  * <pre>{@code
  * ClientTransportConfig config = new JSONRPCTransportConfig();
  * config.setParameters(Map.of(
- *     OpenTelemetryClientTransportFactory.OTEL_TRACER_KEY,
- *     openTelemetry.getTracer("my-service"),
- *     OpenTelemetryClientTransportFactory.OTEL_OPEN_TELEMETRY_KEY,
- *     openTelemetry
+ *     OpenTelemetryClientTransportWrapper.OTEL_TRACER_KEY,
+ *     openTelemetry.getTracer("my-service")
  * ));
  * }</pre>
  */

--- a/extras/opentelemetry/integration-tests/README.md
+++ b/extras/opentelemetry/integration-tests/README.md
@@ -2,75 +2,42 @@
 
 ## Overview
 
-This module provides **Quarkus-based integration tests** for OpenTelemetry tracing in the A2A Java SDK, similar to the approach used in the [Quarkus OpenTelemetry quickstart](https://github.com/quarkusio/quarkus/tree/main/integration-tests/opentelemetry-quickstart).
+This module provides **Quarkus-based integration tests** for OpenTelemetry tracing in the A2A Java SDK.
 
-Unlike the previous mock-based tests, these are **real integration tests** that:
-- Start an actual Quarkus application
-- Expose a REST API with A2A agent endpoints
-- Make real HTTP requests
-- Validate that OpenTelemetry spans are created correctly
+The tests start a real Quarkus application, make HTTP requests via the A2A client SDK, and validate that the `OpenTelemetryRequestHandlerDecorator` (from the `opentelemetry-server` module) creates spans with the expected attributes.
 
 ## Architecture
 
-### Components
+### Application Components
 
-1. **SimpleAgent** - A basic A2A agent implementation for testing
-   - Implements all RequestHandler methods
-   - Stores tasks in memory
-   - Provides simple echo responses for messages
+- **SimpleAgentExecutor** — A basic `AgentExecutor` that echoes back the user's message and completes the task immediately.
+- **TestAgentCardProducer** — CDI producer for the test agent's `AgentCard` (JSON-RPC interface on port 8081, streaming enabled).
+- **A2ATestRoutes** — Vert.x routes exposing test utility endpoints for task/queue manipulation (`/test/task/*`, `/test/queue/*`) and span inspection (`/export`, `/reset`, `/hello`). Also contains the `InMemorySpanExporterProducer` that captures spans in memory for assertion.
+- **TestUtilsBean** — CDI bean wrapping `TaskStore` and `QueueManager` for direct test manipulation (save/get/delete tasks, create queues, enqueue events).
 
-2. **AgentResource** - JAX-RS REST resource
-   - Exposes HTTP endpoints (`/a2a/tasks`, `/a2a/messages`, etc.)
-   - Delegates to the RequestHandler
-   - Creates ServerCallContext for each request
+### Test Classes
 
-3. **InstrumentedRequestHandler** - CDI Alternative
-   - Wraps SimpleAgent with OpenTelemetry decorator
-   - Delegates to the OpenTelemetry decorator for span creation
-   - Ensures spans are created for each operation
+- **OpenTelemetryTest** (`@QuarkusTest`) — Smoke test: hits the `/hello` endpoint and verifies a span is created.
+- **OpenTelemetryA2ATest** (`@QuarkusTest`) — JVM-mode tests for A2A protocol operations (getTask, listTasks, cancelTask) verifying server-side spans, span attributes (`gen_ai.agent.a2a.operation.name`, `gen_ai.agent.a2a.task_id`), and span metadata (kind, status, parent).
+- **OpenTelemetryA2AIT** (`@QuarkusIntegrationTest`) — Same tests running in native/integration mode.
+- **OpenTelemetryA2ABaseTest** — Abstract base class containing the shared test logic. Uses the A2A `Client` SDK to make JSON-RPC calls and `java.net.HttpClient` to interact with the test utility endpoints.
+- **BaseTest** — Provides a `getSpans()` helper that fetches captured spans from the `/export` endpoint via REST Assured.
 
-4. **OpenTelemetryProducer** - CDI bean producer
-   - Creates the Tracer from Quarkus OpenTelemetry
-   - Produces the OpenTelemetryRequestHandlerDecorator (CDI decorator)
-   - Integrates with Quarkus OpenTelemetry extension
+### Span Capture Flow
 
-## Test Strategy
-
-### Functional Tests (`OpenTelemetryIntegrationTest`)
-- Use `@QuarkusTest` annotation
-- Make real HTTP requests using REST Assured
-- Verify HTTP responses are correct
-- Ensure the application behaves correctly end-to-end
-
-### Tracing Tests (`OpenTelemetryTracingTest`)
-- Use `InMemorySpanExporter` to capture spans
-- Verify that HTTP requests create OpenTelemetry spans
-- Validate span names, kinds (CLIENT/SERVER), and status codes
-- Check that spans are properly ended
-
-## Current Status
-
-### ✅ Completed
-- Project structure and POM configuration
-- Quarkus dependencies and plugins (including opentelemetry-sdk-testing)
-- SimpleAgentExecutor following reference module pattern
-- TestAgentCardProducer with proper JSONRPC interface
-- InMemorySpanExporter producer for span validation
-- OpenTelemetryIntegrationTest using Client API
-- Tests compile and run (service loader issues resolved)
-
-### 🔨 In Progress / Known Issues
-
-1. **Test Execution Timeouts**
-   - Tests are timing out during message send operations
-   - Error: "Timeout waiting for consumption to complete for task test-task-1"
-   - Likely a configuration issue between client (non-streaming) and server (streaming capable)
-   - Need to investigate JSONRPC transport configuration
-
-2. **Span Validation**
-   - InMemorySpanExporter is configured but needs verification
-   - Some tests are not finding expected spans
-   - May need to configure span processor to route to InMemorySpanExporter
+```
+A2A Client SDK call (e.g., getTask)
+    ↓
+Quarkus HTTP server
+    ↓
+OpenTelemetryRequestHandlerDecorator creates SERVER span
+    ↓
+RequestHandler processes request
+    ↓
+InMemorySpanExporter captures completed span
+    ↓
+Test calls GET /export → asserts on span attributes
+```
 
 ## Running the Tests
 
@@ -82,79 +49,44 @@ mvn clean install -DskipTests
 
 ### Run Integration Tests
 ```bash
-# From the integration-tests directory
-mvn clean verify
-
-# Or from the root
+# From the root
 mvn verify -pl extras/opentelemetry/integration-tests -am
+
+# Or from the integration-tests directory
+mvn clean verify
 ```
 
-### Run Specific Test
+### Run a Specific Test
 ```bash
-mvn test -Dtest=OpenTelemetryIntegrationTest
+mvn test -pl extras/opentelemetry/integration-tests -Dtest=OpenTelemetryA2ATest
+mvn test -pl extras/opentelemetry/integration-tests -Dtest=OpenTelemetryTest
 ```
 
 ## Configuration
 
-### Application Properties
-- `src/main/resources/application.properties` - Runtime configuration
-- `src/test/resources/application.properties` - Test-specific configuration
-
-Key settings:
+### `src/main/resources/application.properties`
 ```properties
-# OpenTelemetry
+quarkus.http.port=8081
+
 quarkus.otel.sdk.disabled=false
 quarkus.otel.traces.enabled=true
-quarkus.otel.service.name=a2a-opentelemetry-integration-test
+quarkus.otel.metrics.enabled=false
+quarkus.otel.logs.enabled=false
+quarkus.otel.instrument.vertx-http=false
 
-# Test mode: use in-memory exporter
-quarkus.otel.traces.exporter=none
+quarkus.otel.bsp.schedule.delay=0
+quarkus.otel.bsp.export.timeout=5s
+
+quarkus.otel.service.name=a2a-opentelemetry-integration-test
+quarkus.otel.propagators=tracecontext
 ```
 
-### beans.xml
-Located at `src/main/resources/META-INF/beans.xml`:
-- Enables CDI bean discovery
-- Configures alternatives (InstrumentedRequestHandler)
-
-## Next Steps
-
-To complete this integration test module:
-
-1. **Resolve CDI ambiguity**
-   - Add `@Named` or custom qualifier to SimpleAgent
-   - Or exclude DefaultRequestHandler from test classpath
-   - Or use `@Alternative` more effectively
-
-2. **Configure span exporter**
-   - Properly wire InMemorySpanExporter into Quarkus OpenTelemetry
-   - May need custom OTel SDK configuration
-
-3. **Add more test scenarios**
-   - Test error handling and error spans
-   - Test streaming operations
-   - Test context propagation across services
-   - Test span attributes and metadata
-
-4. **Performance testing** (optional)
-   - Measure overhead of OpenTelemetry instrumentation
-   - Verify spans don't impact performance significantly
-
-## Comparison with Quarkus Quickstart
-
-This implementation follows the same patterns as the Quarkus OpenTelemetry quickstart:
-- ✅ Uses `@QuarkusTest` for integration tests
-- ✅ Uses REST Assured for HTTP testing
-- ✅ Integrates with Quarkus OpenTelemetry extension
-- ✅ Uses in-memory span exporter for validation
-- ✅ Tests actual HTTP requests, not mocks
-
-Unlike the quickstart which is a standalone app, this module:
-- Tests A2A SDK-specific functionality
-- Validates OpenTelemetry CDI decorator integration
-- Focuses on A2A protocol operations (tasks, messages, etc.)
+Key choices:
+- **Vert.x HTTP instrumentation disabled** (`instrument.vertx-http=false`) to avoid Quarkus HTTP spans polluting assertions — only the A2A decorator spans are captured.
+- **Batch span processor delay set to 0** (`bsp.schedule.delay=0`) so spans are exported immediately for test assertions.
+- **Metrics and logs disabled** to keep the test focused on tracing.
 
 ## References
 
 - [Quarkus OpenTelemetry Guide](https://quarkus.io/guides/opentelemetry)
-- [Quarkus OpenTelemetry Quickstart](https://github.com/quarkusio/quarkus/tree/main/integration-tests/opentelemetry-quickstart)
 - [OpenTelemetry Java Documentation](https://opentelemetry.io/docs/languages/java/)

--- a/extras/opentelemetry/integration-tests/src/main/resources/META-INF/beans.xml
+++ b/extras/opentelemetry/integration-tests/src/main/resources/META-INF/beans.xml
@@ -3,7 +3,4 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
        version="4.0" bean-discovery-mode="all">
-    <alternatives>
-        <class>org.a2aproject.sdk.extras.opentelemetry.it.InstrumentedRequestHandler</class>
-    </alternatives>
 </beans>


### PR DESCRIPTION
- README: fix wrong property names, attribute names, remove misplaced AsyncManagedExecutorProducer section, add client usage and streaming limitation docs
- Javadoc: fix references to non-existent OpenTelemetryClientTransportFactory
- beans.xml: remove reference to non-existent InstrumentedRequestHandler
- Docs site: remove false "metrics" claim, expand span attributes table, add cross-references from server/client guides


Supersedes https://github.com/a2aproject/a2a-java/pull/1016 that didn't cover docs part