### PR TITLE
fix(security): enforce authorization for listTasks

### DIFF
--- a/server-common/src/main/java/org/a2aproject/sdk/server/auth/TaskAuthorizationProvider.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/auth/TaskAuthorizationProvider.java
@@ -61,8 +61,10 @@ import org.jspecify.annotations.Nullable;
  *   <li>{@code onMessageSend}, {@code onMessageSendStream} — call {@link #checkWrite} if an
  *       existing task ID is provided, otherwise call {@link #checkCreate}; after the delegate
  *       returns, call {@link #recordOwnership} if a new task was created</li>
- *   <li>{@code onListTasks} — filtering is pushed down to the {@code TaskStore}, which calls
- *       {@link #checkRead} per task to exclude unauthorized entries</li>
+ *   <li>{@code onListTasks} — a list-scoped read check is performed before delegation
+ *       (see {@link #checkRead}); after the delegate returns, per-task filtering is also
+ *       pushed down to the {@code TaskStore}, which calls {@link #checkRead} for each task
+ *       to exclude unauthorized entries</li>
  * </ul>
  * Denied operations throw {@code TaskNotFoundError} — the caller cannot distinguish
  * "does not exist" from "not authorized", preventing information leakage.
@@ -105,8 +107,15 @@ public interface TaskAuthorizationProvider {
     /**
      * Check whether the current user is allowed to read the given task.
      *
+     * <p>For {@link TaskOperation#LIST_TASKS}, {@code taskId} is an empty-string sentinel
+     * representing the whole list scope: the decorator calls this method once before
+     * delegation (deny rejects the entire list), and the {@code TaskStore} subsequently
+     * calls it per task during {@code list()} filtering. Providers should treat {@code ""}
+     * with {@code LIST_TASKS} as "may this user list tasks at all" — returning {@code false}
+     * hides all tasks.</p>
+     *
      * @param context the server call context containing the authenticated user
-     * @param taskId the task being accessed
+     * @param taskId the task being accessed, or {@code ""} for the list scope of {@code LIST_TASKS}
      * @param operation which RequestHandler method triggered the check
      * @return {@code true} to allow, {@code false} to deny
      * @throws A2AError if the authorization check itself fails

--- a/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/AuthorizationRequestHandlerDecorator.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/AuthorizationRequestHandlerDecorator.java
@@ -173,6 +173,25 @@ public class AuthorizationRequestHandlerDecorator implements RequestHandler {
         }
     }
 
+    /**
+     * List-scoped read check for {@code onListTasks}.
+     * <p>
+     * {@code LIST_TASKS} has no single task ID, so the provider is invoked with an
+     * empty-string sentinel representing the whole list scope (a {@code null} task ID
+     * would break providers that key lookups on the task ID, e.g.
+     * {@code ConcurrentHashMap}-backed stores). Denying the check rejects the call
+     * outright; otherwise per-task {@code checkRead} filtering is applied by the
+     * {@code TaskStore} during {@code list()}.
+     */
+    private static final String LIST_TASKS_SCOPE_ID = "";
+
+    private void enforceListRead(ServerCallContext context) throws A2AError {
+        if (authorizationProvider != null
+                && !authorizationProvider.checkRead(context, LIST_TASKS_SCOPE_ID, TaskOperation.LIST_TASKS)) {
+            throw new TaskNotFoundError();
+        }
+    }
+
     @Override
     public Task onGetTask(TaskQueryParams params, ServerCallContext context) throws A2AError {
         enforceRead(context, params.id(), TaskOperation.GET_TASK);
@@ -181,6 +200,8 @@ public class AuthorizationRequestHandlerDecorator implements RequestHandler {
 
     @Override
     public ListTasksResult onListTasks(ListTasksParams params, ServerCallContext context) throws A2AError {
+        // List-scoped read check; per-task filtering is additionally applied by the TaskStore.
+        enforceListRead(context);
         return delegate.onListTasks(params, context);
     }
 

--- a/server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/AuthorizationRequestHandlerDecoratorTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/AuthorizationRequestHandlerDecoratorTest.java
@@ -187,6 +187,29 @@ class AuthorizationRequestHandlerDecoratorTest {
         }
 
         @Test
+        void onListTasks_denied() throws A2AError {
+            ListTasksParams params = new ListTasksParams();
+            when(authorizationProvider.checkRead(context, "", TaskOperation.LIST_TASKS)).thenReturn(false);
+
+            assertThrows(TaskNotFoundError.class, () -> decorator.onListTasks(params, context));
+            verifyNoInteractions(delegate);
+        }
+
+        @Test
+        void onListTasks_allowed() throws A2AError {
+            ListTasksParams params = new ListTasksParams();
+            ListTasksResult expected = new ListTasksResult(Collections.emptyList(), 0, 0, null);
+            when(authorizationProvider.checkRead(context, "", TaskOperation.LIST_TASKS)).thenReturn(true);
+            when(delegate.onListTasks(params, context)).thenReturn(expected);
+
+            ListTasksResult result = decorator.onListTasks(params, context);
+
+            assertEquals(expected, result);
+            verify(authorizationProvider).checkRead(context, "", TaskOperation.LIST_TASKS);
+            verify(delegate).onListTasks(params, context);
+        }
+
+        @Test
         void authorizeTaskAccess_allowed() throws A2AError {
             when(authorizationProvider.checkRead(context, "task-1", TaskOperation.SUBSCRIBE_TO_TASK)).thenReturn(true);
 


### PR DESCRIPTION
## What changed

### 1. Enforce authorization for `onListTasks` (CWE-862)

**Problem:** `onListTasks` in `AuthorizationRequestHandlerDecorator` delegated directly to the wrapped handler without any authorization check, unlike every other handler method which calls an `enforce*` check first. With a `TaskAuthorizationProvider` configured, a caller could invoke `listTasks` and bypass the authorization model entirely — only per-task filtering in the `TaskStore` (which custom store implementations may skip) stood between the caller and other users' tasks.

**Fix (server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/AuthorizationRequestHandlerDecorator.java):**
- Added a list-scoped read check (`enforceListRead`) invoked from `onListTasks` before delegation. Since `LIST_TASKS` has no single task ID, the provider is invoked with an empty-string sentinel (`LIST_TASKS_SCOPE_ID`) representing the whole list scope; a denial throws `TaskNotFoundError` (the same fail-closed error used by all other checks, avoiding information leakage). A `null` task ID was deliberately avoided because it breaks providers that key lookups on the task ID (e.g. `ConcurrentHashMap`-backed stores throw on `get(null)`).
- Per-task `checkRead` filtering in the `TaskStore.list()` implementation remains in place and is unchanged.

**Fix (server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/AuthorizationRequestHandlerDecoratorTest.java):**
- Added `onListTasks_denied` — when `checkRead(context, "", LIST_TASKS)` returns `false`, the call throws `TaskNotFoundError` and the delegate is never invoked.
- Added `onListTasks_allowed` — when the check returns `true`, the call is delegated and the result returned.

Behavior change: with a `TaskAuthorizationProvider` configured, `listTasks` now goes through a list-scoped authorization gate; a provider that denies `LIST_TASKS` will reject list requests outright. Providers that allow unknown tasks (e.g. `TestTaskAuthorizationProvider`, whose lookup for the sentinel ID yields no owner and therefore allows) see no behavior change.

## Testing

- `mvn -pl server-common test -Dtest=AuthorizationRequestHandlerDecoratorTest` — **29 tests run, 0 failures, 0 errors** (includes the 2 new regression tests).
- `mvn -pl reference/jsonrpc test -Dtest=QuarkusA2AJSONRPCWithTaskAuthorizationVertxTest` — **7 tests run, 0 failures, 0 errors** (this suite previously failed in CI with `Cannot invoke "Object.hashCode()" because "key" is null`; the list-scoped authorization test now passes with the sentinel-based check).
- CI re-run after the fix: build matrix green.
