### PR TITLE
fix: guard limitTaskHistory against negative historyLength

### DIFF
--- a/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java
@@ -420,7 +420,12 @@ public class DefaultRequestHandler implements RequestHandler {
      * @return the task with limited history, or the original task if no limiting needed
      */
     private static Task limitTaskHistory(Task task, @Nullable Integer historyLength) {
-        if (task.history() == null || historyLength == null || historyLength >= task.history().size()) {
+        // A negative historyLength is invalid (TaskQueryParams rejects it at construction, but
+        // guard defensively here to avoid IndexOutOfBoundsException in subList below). Consistent
+        // with the Python/JS SDKs, a negative value leaves the history untouched; 0 means an
+        // empty history, and N >= history size means no limiting is needed.
+        if (task.history() == null || historyLength == null || historyLength < 0
+                || historyLength >= task.history().size()) {
             return task;
         }
         // Keep only the most recent historyLength messages

--- a/server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandlerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandlerTest.java
@@ -4,11 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,6 +52,7 @@ import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
 import org.a2aproject.sdk.spec.TaskState;
 import org.a2aproject.sdk.spec.TaskStatus;
 import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
+import org.a2aproject.sdk.spec.TaskQueryParams;
 import org.a2aproject.sdk.spec.TextPart;
 import org.a2aproject.sdk.spec.UnsupportedOperationError;
 
@@ -1145,5 +1148,59 @@ public class DefaultRequestHandlerTest {
         // Assert
         assertEquals("1.0", pushConfigStore.getProtocolVersion(taskId, taskId),
             "Protocol version should be stored when push config is provided via onMessageSendStream");
+    }
+
+    @Test
+    void testOnGetTaskHistoryLengthLimitsHistory() throws Exception {
+        Task task = taskWithHistory("task-hl-limit");
+        taskStore.save(task, false);
+
+        Task result = requestHandler.onGetTask(new TaskQueryParams("task-hl-limit", 2), NULL_CONTEXT);
+
+        assertEquals(2, result.history().size());
+        assertEquals("msg-2", result.history().get(0).messageId());
+        assertEquals("msg-3", result.history().get(1).messageId());
+    }
+
+    @Test
+    void testOnGetTaskHistoryLengthZeroReturnsEmptyHistory() throws Exception {
+        Task task = taskWithHistory("task-hl-zero");
+        taskStore.save(task, false);
+
+        Task result = requestHandler.onGetTask(new TaskQueryParams("task-hl-zero", 0), NULL_CONTEXT);
+
+        assertNotNull(result.history());
+        assertTrue(result.history().isEmpty());
+    }
+
+    @Test
+    void testLimitTaskHistoryNegativeHistoryLengthReturnsTaskUnchanged() throws Exception {
+        Task task = taskWithHistory("task-hl-negative");
+
+        Method method = DefaultRequestHandler.class.getDeclaredMethod(
+                "limitTaskHistory", Task.class, Integer.class);
+        method.setAccessible(true);
+        Task result = (Task) method.invoke(null, task, -1);
+
+        // A negative historyLength must not throw IndexOutOfBoundsException and must leave
+        // the history untouched (aligned with the Python/JS SDK semantics).
+        assertSame(task, result);
+        assertEquals(task.history(), result.history());
+    }
+
+    private Task taskWithHistory(String id) {
+        return Task.builder()
+                .id(id)
+                .contextId("ctx-history")
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
+                .history(List.of(
+                        Message.builder().messageId("msg-1").role(Message.Role.ROLE_USER)
+                                .parts(new TextPart("one")).build(),
+                        Message.builder().messageId("msg-2").role(Message.Role.ROLE_AGENT)
+                                .parts(new TextPart("two")).build(),
+                        Message.builder().messageId("msg-3").role(Message.Role.ROLE_AGENT)
+                                .parts(new TextPart("three")).build()))
+                .artifacts(List.of())
+                .build();
     }
 }


### PR DESCRIPTION
## What changed

### 1. Guard `limitTaskHistory` against negative `historyLength` 

**Problem:** The guard in `limitTaskHistory` only checked `historyLength >= task.history().size()`, which does not catch negative values. A negative `historyLength` fell through to `subList(size - historyLength, size)` — i.e. `subList(size + 1, size)` — throwing `IndexOutOfBoundsException`. While `TaskQueryParams` rejects negative values at construction today, `limitTaskHistory` lacked defensive validation and would crash if a negative value ever reached it.

**Fix (server-common/src/main/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandler.java):**
- Extended the early-return guard to `historyLength < 0`, so a negative value returns the task untouched instead of crashing.
- Semantics are aligned with the Python SDK (`apply_history_length`): negative → history untouched; `0` → empty history; `N >= history size` → no limiting. The existing `0 → empty history` behavior is preserved (unlike a `<= 0` guard, which would have broken it).

**Fix (server-common/src/test/java/org/a2aproject/sdk/server/requesthandlers/DefaultRequestHandlerTest.java):**
- `testLimitTaskHistoryNegativeHistoryLengthReturnsTaskUnchanged` — invokes the private `limitTaskHistory` via reflection with `-1` and asserts no exception is thrown and the task is returned unchanged.
- `testOnGetTaskHistoryLengthLimitsHistory` — `historyLength=2` returns only the 2 most recent messages.
- `testOnGetTaskHistoryLengthZeroReturnsEmptyHistory` — locks in that `historyLength=0` still returns an empty history.

Behavior change: none for valid inputs (`>= 0`). Negative `historyLength` previously crashed; it now returns the task unchanged.

## Testing

- `mvn -pl server-common test` — **450 tests run, 0 failures, 0 errors, 0 skipped** (BUILD SUCCESS), including the 3 new regression tests.
