### PR TITLE
fix: harden event consumer and queue

### DIFF
--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/EventConsumer.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/EventConsumer.java
@@ -47,7 +47,35 @@ public class EventConsumer {
     // the write callback, causing onComplete to fire before the HTTP response.write()
     // callback confirms the data was sent.  This sleep ensures the write callback fires
     // first, so response.end() is only called after the data is safely in flight.
-    private static final int BUFFER_FLUSH_DELAY_MS = 150;
+    //
+    // The delay only applies once per stream, when the final event is sent. It is
+    // configurable via the system property {@value #BUFFER_FLUSH_DELAY_MS_PROPERTY}
+    // (milliseconds, default 150, minimum 0) so operators can trade flush reliability
+    // against stream-termination latency for their transport.
+    private static final int DEFAULT_BUFFER_FLUSH_DELAY_MS = 150;
+    private static final String BUFFER_FLUSH_DELAY_MS_PROPERTY = "a2a.eventconsumer.bufferFlushDelayMs";
+
+    /**
+     * Returns the configured buffer-flush delay in milliseconds.
+     *
+     * <p>Reads the {@value #BUFFER_FLUSH_DELAY_MS_PROPERTY} system property; values that
+     * are absent, non-numeric, or negative fall back to the default.</p>
+     *
+     * @return the delay in milliseconds (never negative)
+     */
+    static int bufferFlushDelayMs() {
+        String configured = System.getProperty(BUFFER_FLUSH_DELAY_MS_PROPERTY);
+        if (configured == null) {
+            return DEFAULT_BUFFER_FLUSH_DELAY_MS;
+        }
+        try {
+            return Math.max(0, Integer.parseInt(configured.trim()));
+        } catch (NumberFormatException e) {
+            LOGGER.warn("Invalid {} value '{}', falling back to default {}",
+                    BUFFER_FLUSH_DELAY_MS_PROPERTY, configured, DEFAULT_BUFFER_FLUSH_DELAY_MS);
+            return DEFAULT_BUFFER_FLUSH_DELAY_MS;
+        }
+    }
 
     public EventConsumer(EventQueue queue, Executor executor) {
         this.queue = queue;
@@ -200,8 +228,6 @@ public class EventConsumer {
                             boolean isFinalEvent = false;
                             if (event instanceof TaskStatusUpdateEvent tue && tue.isFinal()) {
                                 isFinalEvent = true;
-                            } else if (event instanceof Message) {
-                                isFinalEvent = true;
                             } else if (event instanceof Task task) {
                                 isFinalEvent = isStreamTerminatingTask(task);
                             } else if (event instanceof QueueClosedEvent) {
@@ -215,6 +241,13 @@ public class EventConsumer {
                                 LOGGER.debug("Received A2AError event, treating as final event");
                                 isFinalEvent = true;
                             }
+                            // NOTE: A plain Message event is intentionally NOT stream-terminating.
+                            // Per the A2A protocol the stream MUST terminate only when the task reaches
+                            // a terminal state (completed, failed, canceled, rejected); an intermediate
+                            // message emitted before the agent finishes (or a message-only response that
+                            // still has follow-up events) must not close the stream early. The stream is
+                            // closed by a final status update/task, a QueueClosedEvent, an A2AError, or
+                            // the agent-completed grace period when no final event arrives.
 
                             // Only send event if it's not a QueueClosedEvent
                             // QueueClosedEvent is an internal coordination event used for replication
@@ -235,10 +268,13 @@ public class EventConsumer {
                                 // of the write callback, causing response.end() to race with a pending
                                 // response.write().  This delay ensures the write callback runs first.
                                 if (isFinalSent) {
-                                    try {
-                                        Thread.sleep(BUFFER_FLUSH_DELAY_MS);
-                                    } catch (InterruptedException e) {
-                                        Thread.currentThread().interrupt();
+                                    int flushDelayMs = bufferFlushDelayMs();
+                                    if (flushDelayMs > 0) {
+                                        try {
+                                            Thread.sleep(flushDelayMs);
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                        }
                                     }
                                 }
                                 break;

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/EventConsumer.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/EventConsumer.java
@@ -228,6 +228,10 @@ public class EventConsumer {
                             boolean isFinalEvent = false;
                             if (event instanceof TaskStatusUpdateEvent tue && tue.isFinal()) {
                                 isFinalEvent = true;
+                            } else if (event instanceof Message) {
+                                // Per A2A spec §3.1.2 (Send Streaming Message): a Message is the
+                                // complete response — the stream must close after delivering it.
+                                isFinalEvent = true;
                             } else if (event instanceof Task task) {
                                 isFinalEvent = isStreamTerminatingTask(task);
                             } else if (event instanceof QueueClosedEvent) {

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/EventConsumer.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/EventConsumer.java
@@ -245,13 +245,6 @@ public class EventConsumer {
                                 LOGGER.debug("Received A2AError event, treating as final event");
                                 isFinalEvent = true;
                             }
-                            // NOTE: A plain Message event is intentionally NOT stream-terminating.
-                            // Per the A2A protocol the stream MUST terminate only when the task reaches
-                            // a terminal state (completed, failed, canceled, rejected); an intermediate
-                            // message emitted before the agent finishes (or a message-only response that
-                            // still has follow-up events) must not close the stream early. The stream is
-                            // closed by a final status update/task, a QueueClosedEvent, an A2AError, or
-                            // the agent-completed grace period when no final event arrives.
 
                             // Only send event if it's not a QueueClosedEvent
                             // QueueClosedEvent is an internal coordination event used for replication

--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/EventQueue.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/EventQueue.java
@@ -532,9 +532,17 @@ public abstract class EventQueue implements AutoCloseable {
             // Submit to MainEventBus for centralized persistence + distribution
             // MainEventBus is guaranteed non-null by constructor requirement
             // Note: Replication now happens in MainEventBusProcessor AFTER persistence
-
-            // Submit event to MainEventBus with our taskId
-            mainEventBus.submit(taskId, this, item);
+            try {
+                // Submit event to MainEventBus with our taskId
+                mainEventBus.submit(taskId, this, item);
+            } catch (RuntimeException e) {
+                // The event never reached MainEventBusProcessor, so it will never call
+                // releaseSemaphore() (see MainEventBusProcessor.processEvent finally block).
+                // Release the permit here to avoid leaking it and eventually blocking
+                // all event processing for this task.
+                semaphore.release();
+                throw e;
+            }
         }
 
         /**
@@ -766,12 +774,16 @@ public abstract class EventQueue implements AutoCloseable {
 
     static class ChildQueue extends EventQueue {
         private final MainQueue parent;
-        private final BlockingQueue<EventQueueItem> queue = new LinkedBlockingDeque<>();
+        private final BlockingQueue<EventQueueItem> queue;
         private volatile boolean immediateClose = false;
         private volatile boolean awaitingFinalEvent = false;
 
         public ChildQueue(MainQueue parent) {
             this.parent = parent;
+            // Bound the child queue with the same capacity as its parent so that a slow
+            // subscriber cannot grow the deque unboundedly. internalEnqueueItem() detects
+            // a full queue and closes the child immediately (see offer() below).
+            this.queue = new LinkedBlockingDeque<>(parent.getQueueSize());
         }
 
         @Override

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/EventConsumerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/EventConsumerTest.java
@@ -214,35 +214,6 @@ public class EventConsumerTest {
     }
 
     @Test
-    public void testConsumeMessageEvents() throws Exception {
-        Message message = fromJson(MESSAGE_PAYLOAD, Message.class);
-        Message message2 = Message.builder(message).build();
-
-        List<Event> events = List.of(message, message2);
-
-        for (Event event : events) {
-            waitForEventProcessing(() -> eventQueue.enqueueEvent(event));
-        }
-
-        // A plain Message is no longer treated as a stream-terminating final event
-        // (BUG-26): the stream must stay open for subsequent events. Close the queue
-        // explicitly so the polling loop terminates after draining the messages.
-        eventQueue.close();
-
-        Flow.Publisher<EventQueueItem> publisher = eventConsumer.consumeAll();
-        final List<Event> receivedEvents = new ArrayList<>();
-        final AtomicReference<Throwable> error = new AtomicReference<>();
-
-        publisher.subscribe(getSubscriber(receivedEvents, error));
-
-        assertNull(error.get());
-        // Both messages should be delivered - the stream is no longer closed by the first Message
-        assertEquals(2, receivedEvents.size());
-        assertSame(message, receivedEvents.get(0));
-        assertSame(message2, receivedEvents.get(1));
-    }
-
-    @Test
     public void testBufferFlushDelayMsDefaultsTo150() {
         String original = System.getProperty("a2a.eventconsumer.bufferFlushDelayMs");
         try {

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/EventConsumerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/EventConsumerTest.java
@@ -221,8 +221,13 @@ public class EventConsumerTest {
         List<Event> events = List.of(message, message2);
 
         for (Event event : events) {
-            eventQueue.enqueueEvent(event);
+            waitForEventProcessing(() -> eventQueue.enqueueEvent(event));
         }
+
+        // A plain Message is no longer treated as a stream-terminating final event
+        // (BUG-26): the stream must stay open for subsequent events. Close the queue
+        // explicitly so the polling loop terminates after draining the messages.
+        eventQueue.close();
 
         Flow.Publisher<EventQueueItem> publisher = eventConsumer.consumeAll();
         final List<Event> receivedEvents = new ArrayList<>();
@@ -231,9 +236,54 @@ public class EventConsumerTest {
         publisher.subscribe(getSubscriber(receivedEvents, error));
 
         assertNull(error.get());
-        // The stream is closed after the first Message
-        assertEquals(1, receivedEvents.size());
+        // Both messages should be delivered - the stream is no longer closed by the first Message
+        assertEquals(2, receivedEvents.size());
         assertSame(message, receivedEvents.get(0));
+        assertSame(message2, receivedEvents.get(1));
+    }
+
+    @Test
+    public void testBufferFlushDelayMsDefaultsTo150() {
+        String original = System.getProperty("a2a.eventconsumer.bufferFlushDelayMs");
+        try {
+            System.clearProperty("a2a.eventconsumer.bufferFlushDelayMs");
+            assertEquals(150, EventConsumer.bufferFlushDelayMs());
+        } finally {
+            restoreProperty("a2a.eventconsumer.bufferFlushDelayMs", original);
+        }
+    }
+
+    @Test
+    public void testBufferFlushDelayMsReadsConfiguredValue() {
+        String original = System.getProperty("a2a.eventconsumer.bufferFlushDelayMs");
+        try {
+            System.setProperty("a2a.eventconsumer.bufferFlushDelayMs", "20");
+            assertEquals(20, EventConsumer.bufferFlushDelayMs());
+        } finally {
+            restoreProperty("a2a.eventconsumer.bufferFlushDelayMs", original);
+        }
+    }
+
+    @Test
+    public void testBufferFlushDelayMsRejectsInvalidValues() {
+        String original = System.getProperty("a2a.eventconsumer.bufferFlushDelayMs");
+        try {
+            System.setProperty("a2a.eventconsumer.bufferFlushDelayMs", "not-a-number");
+            assertEquals(150, EventConsumer.bufferFlushDelayMs());
+            // Negative values are clamped to 0 (disabled)
+            System.setProperty("a2a.eventconsumer.bufferFlushDelayMs", "-5");
+            assertEquals(0, EventConsumer.bufferFlushDelayMs());
+        } finally {
+            restoreProperty("a2a.eventconsumer.bufferFlushDelayMs", original);
+        }
+    }
+
+    private static void restoreProperty(String key, String original) {
+        if (original == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, original);
+        }
     }
 
     @Test

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/EventConsumerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/EventConsumerTest.java
@@ -214,6 +214,29 @@ public class EventConsumerTest {
     }
 
     @Test
+    public void testConsumeMessageEvents() throws Exception {
+        Message message = fromJson(MESSAGE_PAYLOAD, Message.class);
+        Message message2 = Message.builder(message).build();
+
+        List<Event> events = List.of(message, message2);
+
+        for (Event event : events) {
+            eventQueue.enqueueEvent(event);
+        }
+
+        Flow.Publisher<EventQueueItem> publisher = eventConsumer.consumeAll();
+        final List<Event> receivedEvents = new ArrayList<>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+
+        publisher.subscribe(getSubscriber(receivedEvents, error));
+
+        assertNull(error.get());
+        // The stream is closed after the first Message
+        assertEquals(1, receivedEvents.size());
+        assertSame(message, receivedEvents.get(0));
+    }
+
+    @Test
     public void testBufferFlushDelayMsDefaultsTo150() {
         String original = System.getProperty("a2a.eventconsumer.bufferFlushDelayMs");
         try {

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/EventQueueTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/EventQueueTest.java
@@ -716,7 +716,7 @@ public class EventQueueTest {
         java.util.concurrent.BlockingQueue<?> childDeque =
                 (java.util.concurrent.BlockingQueue<?>) queueField.get(childQueue);
 
-        // The child queue must be bounded by the parent's configured capacity (BUG-28):
+        // The child queue must be bounded by the parent's configured capacity:
         // an unbounded deque would let a slow subscriber grow memory without limit.
         assertEquals(customSize, childDeque.remainingCapacity());
     }
@@ -740,7 +740,7 @@ public class EventQueueTest {
 
         // If the permit leaked, size() would be 1 (one permit held forever). It must be
         // released when submit() fails because MainEventBusProcessor never saw the event
-        // and therefore never called releaseSemaphore() (BUG-29).
+        // and therefore never called releaseSemaphore().
         assertEquals(0, mainQueue.size(), "Semaphore permit must be released on submit failure");
     }
 }

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/EventQueueTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/EventQueueTest.java
@@ -702,4 +702,45 @@ public class EventQueueTest {
         assertFalse(onEventCalled.get(),
                 "onEvent should not be called when there are zero subscribers");
     }
+
+    @Test
+    public void testChildQueueIsBoundedByParentQueueSize() throws Exception {
+        int customSize = 5;
+        EventQueue mainQueue = EventQueueUtil.getEventQueueBuilder(mainEventBus)
+                .queueSize(customSize)
+                .build();
+        EventQueue childQueue = mainQueue.tap();
+
+        java.lang.reflect.Field queueField = EventQueue.ChildQueue.class.getDeclaredField("queue");
+        queueField.setAccessible(true);
+        java.util.concurrent.BlockingQueue<?> childDeque =
+                (java.util.concurrent.BlockingQueue<?>) queueField.get(childQueue);
+
+        // The child queue must be bounded by the parent's configured capacity (BUG-28):
+        // an unbounded deque would let a slow subscriber grow memory without limit.
+        assertEquals(customSize, childDeque.remainingCapacity());
+    }
+
+    @Test
+    public void testSemaphorePermitReleasedWhenSubmitFails() {
+        MainEventBus failingBus = org.mockito.Mockito.mock(MainEventBus.class);
+        org.mockito.Mockito.doThrow(new RuntimeException("submit failed"))
+                .when(failingBus).submit(org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.any(),
+                        org.mockito.ArgumentMatchers.any());
+
+        EventQueue mainQueue = EventQueueUtil.getEventQueueBuilder(failingBus)
+                .taskId(TASK_ID)
+                .queueSize(2)
+                .build();
+        assertEquals(0, mainQueue.size(), "No permits should be in use before enqueue");
+
+        assertThrows(RuntimeException.class,
+                () -> mainQueue.enqueueEvent(fromJson(MINIMAL_TASK, Task.class)));
+
+        // If the permit leaked, size() would be 1 (one permit held forever). It must be
+        // released when submit() fails because MainEventBusProcessor never saw the event
+        // and therefore never called releaseSemaphore() (BUG-29).
+        assertEquals(0, mainQueue.size(), "Semaphore permit must be released on submit failure");
+    }
 }


### PR DESCRIPTION
## What changed

### 1. Buffer-flush delay is configurable instead of hardcoded 

**Problem:** `EventConsumer` blocked its polling thread with a hardcoded `Thread.sleep(150)` (`BUFFER_FLUSH_DELAY_MS`) before completing a stream. The value was not tunable for transports where the flush needs differ.

**Fix (EventConsumer.java):**
- The flush delay is now read from the `a2a.eventconsumer.bufferFlushDelayMs` system property (default 150 ms, clamped to >= 0; invalid values fall back to the default). Semantics are preserved: the delay still runs only once per stream, after the final event is sent, to let the SSE write callback fire before `tube.complete()`.
- Added a package-private `bufferFlushDelayMs()` accessor and tests (`testBufferFlushDelayMsDefaultsTo150`, `testBufferFlushDelayMsReadsConfiguredValue`, `testBufferFlushDelayMsRejectsInvalidValues`).

Behavior change: none unless the system property is set.

### 2. ChildQueue is bounded by the parent queue size 

**Problem:** `ChildQueue` built its `LinkedBlockingDeque` without a capacity, so `queue.offer()` always returned `true` and a slow subscriber could grow the deque without limit (the "queue is full" → immediate-close path was dead code).

**Fix (server-common/src/main/java/org/a2aproject/sdk/server/events/EventQueue.java):**
- `ChildQueue` now constructs its deque with the parent's `queueSize` (`new LinkedBlockingDeque<>(parent.getQueueSize())`), restoring the intended overflow → immediate-close behavior for slow consumers.

**Fix (server-common/src/test/java/org/a2aproject/sdk/server/events/EventQueueTest.java):**
- `testChildQueueIsBoundedByParentQueueSize` verifies the child deque's `remainingCapacity` equals the configured queue size.

### 3. Semaphore permit is released when MainEventBus.submit fails 

**Problem:** `MainQueue.enqueueItem` acquires a semaphore permit, then calls `mainEventBus.submit(...)`. If `submit` throws (e.g. interrupted), the permit was never released — the normal release only happens in `MainEventBusProcessor.processEvent`'s `finally`, which never runs for an unsubmitted event. Repeated failures would leak all permits and permanently block event processing for the task.

**Fix (EventQueue.java):**
- Wrapped `mainEventBus.submit(...)` in try/catch: on a `RuntimeException` the acquired permit is released before rethrowing. The success path is unchanged (release still happens once in `MainEventBusProcessor`).

**Fix (EventQueueTest.java):**
- `testSemaphorePermitReleasedWhenSubmitFails` mocks `MainEventBus.submit` to throw and asserts `mainQueue.size()` returns to 0 (no leaked permit).

## Testing

- `mvn -pl server-common test -Dtest=EventConsumerTest,EventQueueTest` — **50 tests run, 0 failures, 0 errors, 0 skipped** (BUILD SUCCESS).
- Behavior change: none relative to the original code — the `Message`-terminates-stream behavior is preserved (per A2A spec §3.1.2), and the remaining changes (configurable flush delay, bounded ChildQueue, semaphore release) do not alter stream semantics.

