### PR TITLE
fix: return UnsupportedOperationError (-32004) when streaming is not supported

### DIFF
--- a/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
+++ b/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
@@ -375,7 +375,7 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
      *
      * <p><b>Error Handling:</b>
      * <ul>
-     *   <li>Streaming not enabled → {@link org.a2aproject.sdk.spec.InvalidRequestError}</li>
+     *   <li>Streaming not enabled → {@link org.a2aproject.sdk.spec.UnsupportedOperationError}</li>
      *   <li>Other {@link A2AError} → mapped to appropriate gRPC status code</li>
      *   <li>{@link SecurityException} → {@code UNAUTHENTICATED} or {@code PERMISSION_DENIED}</li>
      *   <li>{@link Throwable} → {@code INTERNAL} error</li>
@@ -388,7 +388,7 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     public void sendStreamingMessage(org.a2aproject.sdk.grpc.SendMessageRequest request,
                                      StreamObserver<org.a2aproject.sdk.grpc.StreamResponse> responseObserver) {
         if (!getAgentCardInternal().capabilities().streaming()) {
-            handleError(responseObserver, new InvalidRequestError());
+            handleError(responseObserver, new UnsupportedOperationError());
             return;
         }
 
@@ -413,7 +413,7 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     public void subscribeToTask(org.a2aproject.sdk.grpc.SubscribeToTaskRequest request,
                                  StreamObserver<org.a2aproject.sdk.grpc.StreamResponse> responseObserver) {
         if (!getAgentCardInternal().capabilities().streaming()) {
-            handleError(responseObserver, new InvalidRequestError());
+            handleError(responseObserver, new UnsupportedOperationError());
             return;
         }
 

--- a/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
+++ b/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
@@ -388,7 +388,8 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     public void sendStreamingMessage(org.a2aproject.sdk.grpc.SendMessageRequest request,
                                      StreamObserver<org.a2aproject.sdk.grpc.StreamResponse> responseObserver) {
         if (!getAgentCardInternal().capabilities().streaming()) {
-            handleError(responseObserver, new UnsupportedOperationError());
+            handleError(responseObserver,
+                    new UnsupportedOperationError(null, "Streaming is not supported by the agent", null));
             return;
         }
 
@@ -413,7 +414,8 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     public void subscribeToTask(org.a2aproject.sdk.grpc.SubscribeToTaskRequest request,
                                  StreamObserver<org.a2aproject.sdk.grpc.StreamResponse> responseObserver) {
         if (!getAgentCardInternal().capabilities().streaming()) {
-            handleError(responseObserver, new UnsupportedOperationError());
+            handleError(responseObserver,
+                    new UnsupportedOperationError(null, "Streaming is not supported by the agent", null));
             return;
         }
 

--- a/transport/grpc/src/test/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandlerTest.java
+++ b/transport/grpc/src/test/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandlerTest.java
@@ -625,7 +625,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
         AgentCard card = AbstractA2ARequestHandlerTest.createAgentCard(false, true);
         GrpcHandler handler = new TestGrpcHandler(card, requestHandler, internalExecutor);
         StreamRecorder<StreamResponse> streamRecorder = sendStreamingMessageRequest(handler);
-        assertGrpcError(streamRecorder, Status.Code.INVALID_ARGUMENT);
+        assertGrpcError(streamRecorder, Status.Code.UNIMPLEMENTED);
     }
 
     @Test
@@ -639,7 +639,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
         StreamRecorder<StreamResponse> streamRecorder = StreamRecorder.create();
         handler.subscribeToTask(request, streamRecorder);
         streamRecorder.awaitCompletion(5, TimeUnit.SECONDS);
-        assertGrpcError(streamRecorder, Status.Code.INVALID_ARGUMENT);
+        assertGrpcError(streamRecorder, Status.Code.UNIMPLEMENTED);
     }
 
     @Test

--- a/transport/jsonrpc/src/main/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandler.java
+++ b/transport/jsonrpc/src/main/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandler.java
@@ -46,7 +46,6 @@ import org.a2aproject.sdk.spec.CancelTaskParams;
 import org.a2aproject.sdk.spec.ExtendedAgentCardNotConfiguredError;
 import org.a2aproject.sdk.spec.EventKind;
 import org.a2aproject.sdk.spec.InternalError;
-import org.a2aproject.sdk.spec.InvalidRequestError;
 import org.a2aproject.sdk.spec.UnsupportedOperationError;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsResult;
 import org.a2aproject.sdk.spec.PushNotificationNotSupportedError;
@@ -283,7 +282,7 @@ public class JSONRPCHandler {
             return ZeroPublisher.fromItems(
                     new SendStreamingMessageResponse(
                             request.getId(),
-                            new InvalidRequestError("Streaming is not supported by the agent")));
+                            new UnsupportedOperationError(null, "Streaming is not supported by the agent", null)));
         }
 
         try {
@@ -380,7 +379,7 @@ public class JSONRPCHandler {
             return ZeroPublisher.fromItems(
                     new SendStreamingMessageResponse(
                             request.getId(),
-                            new InvalidRequestError("Streaming is not supported by the agent")));
+                            new UnsupportedOperationError(null, "Streaming is not supported by the agent", null)));
         }
         requestHandler.authorizeTaskAccess(request.getParams().id(), context, TaskOperation.SUBSCRIBE_TO_TASK);
         try {

--- a/transport/jsonrpc/src/test/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -61,7 +61,6 @@ import org.a2aproject.sdk.spec.ExtendedAgentCardNotConfiguredError;
 import org.a2aproject.sdk.spec.ExtensionSupportRequiredError;
 import org.a2aproject.sdk.spec.GetTaskPushNotificationConfigParams;
 import org.a2aproject.sdk.spec.InternalError;
-import org.a2aproject.sdk.spec.InvalidRequestError;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsParams;
 import org.a2aproject.sdk.spec.ListTasksParams;
 import org.a2aproject.sdk.spec.Message;
@@ -1047,7 +1046,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
         });
 
         assertEquals(1, results.size());
-        if (results.get(0).getError() != null && results.get(0).getError() instanceof InvalidRequestError ire) {
+        if (results.get(0).getError() != null && results.get(0).getError() instanceof UnsupportedOperationError ire) {
             assertEquals("Streaming is not supported by the agent", ire.getMessage());
         } else {
             fail("Expected a response containing an error");
@@ -1094,7 +1093,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
         });
 
         assertEquals(1, results.size());
-        if (results.get(0).getError() != null && results.get(0).getError() instanceof InvalidRequestError ire) {
+        if (results.get(0).getError() != null && results.get(0).getError() instanceof UnsupportedOperationError ire) {
             assertEquals("Streaming is not supported by the agent", ire.getMessage());
         } else {
             fail("Expected a response containing an error");

--- a/transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java
+++ b/transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java
@@ -293,7 +293,7 @@ public class RestHandler {
     public HTTPRestResponse sendStreamingMessage(ServerCallContext context, String tenant, String body) {
         try {
             if (!agentCard.capabilities().streaming()) {
-                return createErrorResponse(new InvalidRequestError("Streaming is not supported by the agent"));
+                return createErrorResponse(new UnsupportedOperationError(null, "Streaming is not supported by the agent", null));
             }
             A2AVersionValidator.validateProtocolVersion(agentCard, context);
             A2AExtensions.validateRequiredExtensions(agentCard, context);
@@ -425,7 +425,7 @@ public class RestHandler {
     public HTTPRestResponse subscribeToTask(ServerCallContext context, String tenant, String taskId) {
         try {
             if (!agentCard.capabilities().streaming()) {
-                return createErrorResponse(new InvalidRequestError("Streaming is not supported by the agent"));
+                return createErrorResponse(new UnsupportedOperationError(null, "Streaming is not supported by the agent", null));
             }
             TaskIdParams params = TaskIdParams.builder().id(taskId).tenant(tenant).build();
             try {

--- a/transport/rest/src/test/java/org/a2aproject/sdk/transport/rest/handler/RestHandlerTest.java
+++ b/transport/rest/src/test/java/org/a2aproject/sdk/transport/rest/handler/RestHandlerTest.java
@@ -362,7 +362,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         RestHandler.HTTPRestResponse response = handler.sendStreamingMessage(callContext, "", requestBody);
 
         assertProblemDetail(response, 400,
-                "INVALID_REQUEST",
+                "UNSUPPORTED_OPERATION",
                 "Streaming is not supported by the agent");
     }
 


### PR DESCRIPTION
## What changed

### 1. Streaming-not-supported now returns `UnsupportedOperationError` (-32004) instead of `InvalidRequestError` (-32600) 

**Problem:** When the agent card does not advertise `streaming()` capability, the JSON-RPC, gRPC, and REST handlers rejected streaming calls with `InvalidRequestError` (code -32600, "invalid request"), while other SDKs return `UnsupportedOperationError` (code -32004, "operation not supported"). -32600 is the wrong semantic for a valid-but-unavailable operation and diverges from the other SDKs.

**Fix (transport/jsonrpc/src/main/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandler.java):**
- `onMessageSendStream` and `onSubscribeToTask` now emit `new UnsupportedOperationError(null, "Streaming is not supported by the agent", null)` (message preserved, code now -32004). Removed the now-unused `InvalidRequestError` import.

**Fix (transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java):**
- `sendStreamingMessage` and `subscribeToTask` now call `handleError(responseObserver, new UnsupportedOperationError())`; the gRPC status therefore maps from `INVALID_ARGUMENT` to `UNIMPLEMENTED`. Updated the method javadoc accordingly.

**Fix (transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java):**
- `sendStreamingMessage` and `subscribeToTask` now build the error response with `new UnsupportedOperationError(null, "Streaming is not supported by the agent", null)`. HTTP status stays 400; the error reason changes from `INVALID_REQUEST` to `UNSUPPORTED_OPERATION` (via `A2AErrorCodes.UNSUPPORTED_OPERATION`).

**Fix (tests updated in lockstep):**
- `JSONRPCHandlerTest` (`testStreamingNotSupportedErrorOnSendMessageStream`, `testStreamingNotSupportedErrorOnSubscribeToTask`): assert `UnsupportedOperationError` instead of `InvalidRequestError`.
- `GrpcHandlerTest` (`testStreamingNotSupportedError`, `testStreamingNotSupportedErrorOnSubscribeToTask`): assert gRPC `Status.Code.UNIMPLEMENTED` instead of `INVALID_ARGUMENT`.
- `RestHandlerTest` (`testSendStreamingMessageNotSupported`): assert reason `UNSUPPORTED_OPERATION` instead of `INVALID_REQUEST`.

Behavior change: the JSON-RPC error code for streaming-not-supported changes from -32600 to -32004; the gRPC status changes from INVALID_ARGUMENT to UNIMPLEMENTED; the REST error reason changes from INVALID_REQUEST to UNSUPPORTED_OPERATION (HTTP status remains 400). The error message is unchanged.

Note: the `compat-0.3` module (legacy 0.3-spec compatibility shim) has its own copies of the handlers with `InvalidRequestError` for this path; it was intentionally left unchanged as it is outside the scope of the current transports.

## Testing

- `mvn -pl transport/jsonrpc,transport/grpc,transport/rest test` — **124 tests run, 0 failures, 1 skipped** (BUILD SUCCESS): JSON-RPC 48 (1 skipped), gRPC 40, REST 36.
