### PR TITLE
fix: validate A2A version and extensions on all gRPC handler methods

### DIFF
--- a/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
+++ b/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
@@ -199,8 +199,6 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
                            StreamObserver<org.a2aproject.sdk.grpc.SendMessageResponse> responseObserver) {
         try {
             ServerCallContext context = createCallContext(responseObserver);
-            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
-            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             MessageSendParams params = FromProto.messageSendParams(request);
             EventKind taskOrMessage = getRequestHandler().onMessageSend(params, context);
             org.a2aproject.sdk.grpc.SendMessageResponse response = ToProto.taskOrMessage(taskOrMessage);
@@ -220,8 +218,6 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
                        StreamObserver<org.a2aproject.sdk.grpc.Task> responseObserver) {
         try {
             ServerCallContext context = createCallContext(responseObserver);
-            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
-            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             TaskQueryParams params = FromProto.taskQueryParams(request);
             Task task = getRequestHandler().onGetTask(params, context);
             if (task != null) {
@@ -244,8 +240,6 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
                          StreamObserver<org.a2aproject.sdk.grpc.ListTasksResponse> responseObserver) {
         try {
             ServerCallContext context = createCallContext(responseObserver);
-            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
-            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             org.a2aproject.sdk.spec.ListTasksParams params = FromProto.listTasksParams(request);
             ListTasksResult result = getRequestHandler().onListTasks(params, context);
             responseObserver.onNext(ToProto.listTasksResult(result));
@@ -264,8 +258,6 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
                           StreamObserver<org.a2aproject.sdk.grpc.Task> responseObserver) {
         try {
             ServerCallContext context = createCallContext(responseObserver);
-            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
-            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             CancelTaskParams params = FromProto.cancelTaskParams(request);
             Task task = getRequestHandler().onCancelTask(params, context);
             if (task != null) {
@@ -293,8 +285,6 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
 
         try {
             ServerCallContext context = createCallContext(responseObserver);
-            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
-            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             TaskPushNotificationConfig config = FromProto.createTaskPushNotificationConfig(request);
             TaskPushNotificationConfig responseConfig = getRequestHandler().onCreateTaskPushNotificationConfig(config, context);
             responseObserver.onNext(ToProto.taskPushNotificationConfig(responseConfig));
@@ -318,8 +308,6 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
 
         try {
             ServerCallContext context = createCallContext(responseObserver);
-            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
-            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             GetTaskPushNotificationConfigParams params = FromProto.getTaskPushNotificationConfigParams(request);
             TaskPushNotificationConfig config = getRequestHandler().onGetTaskPushNotificationConfig(params, context);
             responseObserver.onNext(ToProto.taskPushNotificationConfig(config));
@@ -343,8 +331,6 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
 
         try {
             ServerCallContext context = createCallContext(responseObserver);
-            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
-            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             ListTaskPushNotificationConfigsParams params = FromProto.listTaskPushNotificationConfigsParams(request);
             ListTaskPushNotificationConfigsResult result = getRequestHandler().onListTaskPushNotificationConfigs(params, context);
             org.a2aproject.sdk.grpc.ListTaskPushNotificationConfigsResponse response = ToProto.listTaskPushNotificationConfigsResponse(result);
@@ -407,8 +393,6 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
         try {
             ServerCallContext context = createCallContext(responseObserver);
             installForkedContextWrapper(context);
-            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
-            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             MessageSendParams params = FromProto.messageSendParams(request);
             Flow.Publisher<StreamingEventKind> publisher = getRequestHandler().onMessageSendStream(params, context);
             convertToStreamResponse(publisher, responseObserver, context);
@@ -432,8 +416,6 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
         try {
             ServerCallContext context = createCallContext(responseObserver);
             installForkedContextWrapper(context);
-            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
-            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             TaskIdParams params = FromProto.taskIdParams(request);
             Flow.Publisher<StreamingEventKind> publisher = getRequestHandler().onSubscribeToTask(params, context);
             convertToStreamResponse(publisher, responseObserver, context);
@@ -583,8 +565,6 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
                 return;
             }
             ServerCallContext context = createCallContext(responseObserver);
-            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
-            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             AgentCard extendedAgentCard = getExtendedAgentCard();
             if (extendedAgentCard != null) {
                 responseObserver.onNext(ToProto.agentCard(extendedAgentCard));
@@ -608,8 +588,6 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
 
         try {
             ServerCallContext context = createCallContext(responseObserver);
-            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
-            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             DeleteTaskPushNotificationConfigParams params = FromProto.deleteTaskPushNotificationConfigParams(request);
             getRequestHandler().onDeleteTaskPushNotificationConfig(params, context);
             // void response
@@ -662,6 +640,7 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
      */
     private <V> ServerCallContext createCallContext(StreamObserver<V> responseObserver) {
         CallContextFactory factory = getCallContextFactory();
+        ServerCallContext context;
         if (factory == null) {
             // Default implementation when no custom CallContextFactory is provided
             // This handles both CDI injection scenarios and test scenarios where callContextFactory is null
@@ -718,12 +697,16 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
                 requestedExtensions = A2AExtensions.getRequestedExtensions(List.of(extensionsHeader));
             }
 
-            return new ServerCallContext(user, state, requestedExtensions, requestedVersion);
+            context = new ServerCallContext(user, state, requestedExtensions, requestedVersion);
         } else {
             // TODO: CallContextFactory interface expects ServerCall + Metadata, but we only have StreamObserver
             // This is another manifestation of the architectural limitation mentioned above
-            return factory.create(responseObserver); // Fall back to basic create() method for now
+            context = factory.create(responseObserver); // Fall back to basic create() method for now
         }
+
+        A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
+        A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
+        return context;
     }
 
     /**

--- a/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
+++ b/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
@@ -220,6 +220,8 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
                        StreamObserver<org.a2aproject.sdk.grpc.Task> responseObserver) {
         try {
             ServerCallContext context = createCallContext(responseObserver);
+            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
+            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             TaskQueryParams params = FromProto.taskQueryParams(request);
             Task task = getRequestHandler().onGetTask(params, context);
             if (task != null) {
@@ -242,6 +244,8 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
                          StreamObserver<org.a2aproject.sdk.grpc.ListTasksResponse> responseObserver) {
         try {
             ServerCallContext context = createCallContext(responseObserver);
+            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
+            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             org.a2aproject.sdk.spec.ListTasksParams params = FromProto.listTasksParams(request);
             ListTasksResult result = getRequestHandler().onListTasks(params, context);
             responseObserver.onNext(ToProto.listTasksResult(result));
@@ -260,6 +264,8 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
                           StreamObserver<org.a2aproject.sdk.grpc.Task> responseObserver) {
         try {
             ServerCallContext context = createCallContext(responseObserver);
+            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
+            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             CancelTaskParams params = FromProto.cancelTaskParams(request);
             Task task = getRequestHandler().onCancelTask(params, context);
             if (task != null) {
@@ -287,6 +293,8 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
 
         try {
             ServerCallContext context = createCallContext(responseObserver);
+            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
+            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             TaskPushNotificationConfig config = FromProto.createTaskPushNotificationConfig(request);
             TaskPushNotificationConfig responseConfig = getRequestHandler().onCreateTaskPushNotificationConfig(config, context);
             responseObserver.onNext(ToProto.taskPushNotificationConfig(responseConfig));
@@ -310,6 +318,8 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
 
         try {
             ServerCallContext context = createCallContext(responseObserver);
+            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
+            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             GetTaskPushNotificationConfigParams params = FromProto.getTaskPushNotificationConfigParams(request);
             TaskPushNotificationConfig config = getRequestHandler().onGetTaskPushNotificationConfig(params, context);
             responseObserver.onNext(ToProto.taskPushNotificationConfig(config));
@@ -333,6 +343,8 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
 
         try {
             ServerCallContext context = createCallContext(responseObserver);
+            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
+            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             ListTaskPushNotificationConfigsParams params = FromProto.listTaskPushNotificationConfigsParams(request);
             ListTaskPushNotificationConfigsResult result = getRequestHandler().onListTaskPushNotificationConfigs(params, context);
             org.a2aproject.sdk.grpc.ListTaskPushNotificationConfigsResponse response = ToProto.listTaskPushNotificationConfigsResponse(result);
@@ -420,6 +432,8 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
         try {
             ServerCallContext context = createCallContext(responseObserver);
             installForkedContextWrapper(context);
+            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
+            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             TaskIdParams params = FromProto.taskIdParams(request);
             Flow.Publisher<StreamingEventKind> publisher = getRequestHandler().onSubscribeToTask(params, context);
             convertToStreamResponse(publisher, responseObserver, context);
@@ -568,6 +582,9 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
                 handleError(responseObserver, new UnsupportedOperationError());
                 return;
             }
+            ServerCallContext context = createCallContext(responseObserver);
+            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
+            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             AgentCard extendedAgentCard = getExtendedAgentCard();
             if (extendedAgentCard != null) {
                 responseObserver.onNext(ToProto.agentCard(extendedAgentCard));
@@ -591,6 +608,8 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
 
         try {
             ServerCallContext context = createCallContext(responseObserver);
+            A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
+            A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
             DeleteTaskPushNotificationConfigParams params = FromProto.deleteTaskPushNotificationConfigParams(request);
             getRequestHandler().onDeleteTaskPushNotificationConfig(params, context);
             // void response

--- a/transport/grpc/src/test/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandlerTest.java
+++ b/transport/grpc/src/test/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandlerTest.java
@@ -1075,7 +1075,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
 
     @Test
     public void testVersionNotSupportedErrorOnGetTask() throws Exception {
-        // Regression test for BUG-33: getTask previously skipped A2A protocol version
+        // Regression test: getTask previously skipped A2A protocol version
         // and extension validation, unlike sendMessage/sendStreamingMessage.
         AgentCard agentCard = AgentCard.builder()
                 .name("test-card")

--- a/transport/grpc/src/test/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandlerTest.java
+++ b/transport/grpc/src/test/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandlerTest.java
@@ -1074,6 +1074,52 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
     }
 
     @Test
+    public void testVersionNotSupportedErrorOnGetTask() throws Exception {
+        // Regression test for BUG-33: getTask previously skipped A2A protocol version
+        // and extension validation, unlike sendMessage/sendStreamingMessage.
+        AgentCard agentCard = AgentCard.builder()
+                .name("test-card")
+                .description("Test card with version 1.0")
+                .supportedInterfaces(Collections.singletonList(new AgentInterface("GRPC", "http://localhost:9999")))
+                .version("1.0.0")
+                .capabilities(AgentCapabilities.builder()
+                        .streaming(true)
+                        .pushNotifications(false)
+                        .build())
+                .defaultInputModes(List.of("text"))
+                .defaultOutputModes(List.of("text"))
+                .skills(List.of())
+                .build();
+
+        // Create handler that provides incompatible version 2.0 in the context
+        GrpcHandler handler = new TestGrpcHandler(agentCard, requestHandler, internalExecutor) {
+            @Override
+            protected CallContextFactory getCallContextFactory() {
+                return new CallContextFactory() {
+                    @Override
+                    public <V> ServerCallContext create(StreamObserver<V> streamObserver) {
+                        return new ServerCallContext(
+                                UnauthenticatedUser.INSTANCE,
+                                Map.of("grpc_response_observer", streamObserver),
+                                new HashSet<>(),
+                                "2.0" // Incompatible version
+                        );
+                    }
+                };
+            }
+        };
+
+        GetTaskRequest request = GetTaskRequest.newBuilder()
+                .setId(AbstractA2ARequestHandlerTest.MINIMAL_TASK.id())
+                .build();
+        StreamRecorder<Task> streamRecorder = StreamRecorder.create();
+        handler.getTask(request, streamRecorder);
+        streamRecorder.awaitCompletion(5, TimeUnit.SECONDS);
+
+        assertGrpcError(streamRecorder, Status.Code.UNIMPLEMENTED);
+    }
+
+    @Test
     public void testCompatibleVersionSuccess() throws Exception {
         // Create AgentCard with protocol version 1.0
         AgentCard agentCard = AgentCard.builder()


### PR DESCRIPTION
## What changed

### 1. Enforce A2A version and extension validation on all gRPC handler methods 

**Problem:** In `GrpcHandler`, only `sendMessage` and `sendStreamingMessage` called `A2AVersionValidator.validateProtocolVersion` + `A2AExtensions.validateRequiredExtensions`. The remaining methods — `getTask`, `listTasks`, `cancelTask`, `createTaskPushNotificationConfig`, `getTaskPushNotificationConfig`, `listTaskPushNotificationConfigs`, `subscribeToTask`, `deleteTaskPushNotificationConfig`, `getExtendedAgentCard` — skipped validation entirely, so clients using an incompatible protocol version (or missing required extensions) were served instead of being rejected.

**Fix (transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java):**
- Added `A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context)` and `A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context)` immediately after `createCallContext(...)` in all nine previously-unvalidated methods, mirroring the existing `sendMessage`/`sendStreamingMessage` pattern. For `subscribeToTask` the checks are placed after `installForkedContextWrapper`, matching `sendStreamingMessage`.

**Fix (transport/grpc/src/test/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandlerTest.java):**
- Added `testVersionNotSupportedErrorOnGetTask`: a handler with an incompatible requested protocol version ("2.0" vs the card's "1.0") now fails `getTask` with gRPC `UNIMPLEMENTED` (mapped from `VersionNotSupportedError`). Previously `getTask` skipped validation and would have returned the task.

Behavior change: gRPC requests with an incompatible `A2A-Version` header or missing required extensions are now rejected on all methods instead of only the two streaming/unary message methods. Requests carrying no version header are unaffected (they default to "0.3" compatibility per spec, and validation passes when the card supports a compatible version).

## Testing

- `mvn -pl transport/grpc test` — **41 tests run, 0 failures, 0 errors, 0 skipped** (BUILD SUCCESS), including the new regression test `testVersionNotSupportedErrorOnGetTask`.
