### PR TITLE
fix: reject CR/LF in push notification Authorization header

### DIFF
--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/BasePushNotificationSender.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/BasePushNotificationSender.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ExecutionException;
 import org.a2aproject.sdk.client.http.A2AHttpClient;
 import org.a2aproject.sdk.client.http.A2AHttpClientFactory;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonUtil;
+import org.a2aproject.sdk.spec.AuthenticationInfo;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsParams;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsResult;
 import org.a2aproject.sdk.spec.Message;
@@ -197,8 +198,7 @@ public class BasePushNotificationSender implements PushNotificationSender {
             postBuilder.addHeader(X_A2A_NOTIFICATION_TOKEN, token);
         }
         if (pushInfo.authentication() != null && pushInfo.authentication().credentials() != null) {
-            postBuilder.addHeader("Authorization",
-                    pushInfo.authentication().scheme() + " " + pushInfo.authentication().credentials());
+            postBuilder.addHeader("Authorization", buildAuthorizationHeader(pushInfo.authentication()));
         }
 
         try {
@@ -212,5 +212,28 @@ public class BasePushNotificationSender implements PushNotificationSender {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Builds the Authorization header value for a push notification config.
+     *
+     * <p>The {@code scheme} and {@code credentials} are client-controlled values that are
+     * concatenated directly into the header. Rejecting CR/LF characters here prevents
+     * HTTP header injection (CWE-113). The {@link A2AHttpClient} SPI is pluggable, so we
+     * cannot rely on every implementation (or the underlying HTTP client) to validate
+     * header values.</p>
+     *
+     * @param authentication the push notification authentication info (scheme non-null,
+     *                       credentials non-null per the caller's check)
+     * @return the assembled {@code "scheme credentials"} header value
+     * @throws IllegalArgumentException if the assembled value contains CR or LF
+     */
+    private static String buildAuthorizationHeader(AuthenticationInfo authentication) {
+        String value = authentication.scheme() + " " + authentication.credentials();
+        if (value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0) {
+            throw new IllegalArgumentException(
+                    "Push notification Authorization header must not contain CR/LF characters");
+        }
+        return value;
     }
 }

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/PushNotificationSenderTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/PushNotificationSenderTest.java
@@ -516,4 +516,64 @@ public class PushNotificationSenderTest {
 
         assertTrue(testHttpClient.rawBodies.isEmpty());
     }
+
+    @Test
+    public void testSendNotificationWithAuthHeader() throws InterruptedException {
+        String taskId = "task_send_auth";
+        Task taskData = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
+        TaskPushNotificationConfig config = TaskPushNotificationConfig.builder()
+                .url("http://notify.me/here")
+                .id("cfg-auth")
+                .taskId(taskId)
+                .authentication(new org.a2aproject.sdk.spec.AuthenticationInfo("Bearer", "token123"))
+                .build();
+        configStore.setInfo(config);
+
+        testHttpClient.latch = new CountDownLatch(1);
+        sender.sendNotification(taskData, null);
+
+        assertTrue(testHttpClient.latch.await(5, TimeUnit.SECONDS), "HTTP call should complete within 5 seconds");
+        assertEquals(1, testHttpClient.headers.size());
+        Map<String, String> sentHeaders = testHttpClient.headers.get(0);
+        assertEquals("Bearer token123", sentHeaders.get("Authorization"));
+    }
+
+    @Test
+    public void testSendNotificationRejectsCrlfInCredentials() throws InterruptedException {
+        String taskId = "task_send_crlf";
+        Task taskData = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
+        // CRLF in client-controlled credentials must not be injected into the Authorization
+        // header (BUG-34). The notification is dropped instead of sending an injected header.
+        TaskPushNotificationConfig config = TaskPushNotificationConfig.builder()
+                .url("http://notify.me/here")
+                .id("cfg-crlf")
+                .taskId(taskId)
+                .authentication(new org.a2aproject.sdk.spec.AuthenticationInfo("Bearer", "token\r\nX-Injected: 1"))
+                .build();
+        configStore.setInfo(config);
+
+        sender.sendNotification(taskData, null);
+
+        // The header is never constructed with the injected value - no HTTP call is made
+        assertTrue(testHttpClient.events.isEmpty(), "Notification with CRLF credentials must not be dispatched");
+        assertTrue(testHttpClient.headers.isEmpty(), "No headers should have been sent");
+    }
+
+    @Test
+    public void testSendNotificationRejectsCrlfInScheme() throws InterruptedException {
+        String taskId = "task_send_crlf_scheme";
+        Task taskData = createSampleTask(taskId, TaskState.TASK_STATE_COMPLETED);
+        TaskPushNotificationConfig config = TaskPushNotificationConfig.builder()
+                .url("http://notify.me/here")
+                .id("cfg-crlf-scheme")
+                .taskId(taskId)
+                .authentication(new org.a2aproject.sdk.spec.AuthenticationInfo("Bearer\nX-Injected: 1", "token"))
+                .build();
+        configStore.setInfo(config);
+
+        sender.sendNotification(taskData, null);
+
+        assertTrue(testHttpClient.events.isEmpty(), "Notification with CRLF scheme must not be dispatched");
+        assertTrue(testHttpClient.headers.isEmpty(), "No headers should have been sent");
+    }
 }


### PR DESCRIPTION
## What changed

### 1. Reject CR/LF characters in push notification Authorization header 

**Problem:** `BasePushNotificationSender.dispatchNotification` built the `Authorization` header as `scheme + " " + credentials` with direct string concatenation. Both values are client-controlled (stored in the push notification config), so a credential or scheme containing `\r`/`\n` could inject arbitrary extra headers (CWE-113). The JDK `HttpClient` happens to validate headers, but `A2AHttpClient` is a pluggable SPI whose implementations (including custom ones) cannot be assumed to do the same.

**Fix (server-common/src/main/java/org/a2aproject/sdk/server/tasks/BasePushNotificationSender.java):**
- Added `buildAuthorizationHeader(AuthenticationInfo)`, which assembles `"scheme credentials"` and throws `IllegalArgumentException` if the resulting value contains CR or LF. The notification dispatch then fails safely (logged) and the injected header is never sent.

**Fix (server-common/src/test/java/org/a2aproject/sdk/server/tasks/PushNotificationSenderTest.java):**
- `testSendNotificationWithAuthHeader` — a valid `AuthenticationInfo("Bearer", "token123")` sends `Authorization: Bearer token123`.
- `testSendNotificationRejectsCrlfInCredentials` — credentials containing `\r\nX-Injected: 1` cause the notification to be dropped; no HTTP call is made.
- `testSendNotificationRejectsCrlfInScheme` — a scheme containing `\n` causes the notification to be dropped.

Behavior change: push notifications whose configured auth scheme/credentials contain CR or LF are no longer dispatched (previously the raw value was passed through to the HTTP client). Valid credentials are unaffected.

## Testing

- `mvn -pl server-common test` — **450 tests run, 0 failures, 0 errors, 0 skipped** (BUILD SUCCESS), including the 3 new regression tests.
