### PR TITLE
fix: sanitize internal error messages in transport handlers 

### DIFF
--- a/reference/jsonrpc/src/main/java/org/a2aproject/sdk/server/apps/quarkus/A2AServerRoutes.java
+++ b/reference/jsonrpc/src/main/java/org/a2aproject/sdk/server/apps/quarkus/A2AServerRoutes.java
@@ -6,6 +6,8 @@ import static org.a2aproject.sdk.server.ServerCallContext.TRANSPORT_KEY;
 import static org.a2aproject.sdk.transport.jsonrpc.context.JSONRPCContextKeys.HEADERS_KEY;
 import static org.a2aproject.sdk.transport.jsonrpc.context.JSONRPCContextKeys.METHOD_NAME_KEY;
 import static org.a2aproject.sdk.transport.jsonrpc.context.JSONRPCContextKeys.TENANT_KEY;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -169,6 +171,8 @@ import org.jspecify.annotations.Nullable;
  */
 @Singleton
 public class A2AServerRoutes {
+
+    private static final Logger LOG = LoggerFactory.getLogger(A2AServerRoutes.class);
 
     @Inject
     JSONRPCHandler jsonRpcHandler;
@@ -337,7 +341,8 @@ public class A2AServerRoutes {
         } catch (JsonSyntaxException | JsonProcessingException e) {
             error = new A2AErrorResponse(new JSONParseError(e.getMessage()));
         } catch (Throwable t) {
-            error = new A2AErrorResponse(new InternalError(t.getMessage()));
+            LOG.error("Failed to process request", t);
+            error = new A2AErrorResponse(new InternalError("Internal error"));
         } finally {
             if (error != null) {
                 rc.response()

--- a/reference/jsonrpc/src/main/java/org/a2aproject/sdk/server/apps/quarkus/A2AServerRoutes.java
+++ b/reference/jsonrpc/src/main/java/org/a2aproject/sdk/server/apps/quarkus/A2AServerRoutes.java
@@ -6,8 +6,6 @@ import static org.a2aproject.sdk.server.ServerCallContext.TRANSPORT_KEY;
 import static org.a2aproject.sdk.transport.jsonrpc.context.JSONRPCContextKeys.HEADERS_KEY;
 import static org.a2aproject.sdk.transport.jsonrpc.context.JSONRPCContextKeys.METHOD_NAME_KEY;
 import static org.a2aproject.sdk.transport.jsonrpc.context.JSONRPCContextKeys.TENANT_KEY;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -81,6 +79,8 @@ import org.a2aproject.sdk.spec.TransportProtocol;
 import org.a2aproject.sdk.spec.UnsupportedOperationError;
 import org.a2aproject.sdk.transport.jsonrpc.handler.JSONRPCHandler;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Quarkus routing configuration for JSON-RPC A2A protocol requests.
@@ -341,7 +341,7 @@ public class A2AServerRoutes {
         } catch (JsonSyntaxException | JsonProcessingException e) {
             error = new A2AErrorResponse(new JSONParseError(e.getMessage()));
         } catch (Throwable t) {
-            LOG.error("Failed to process request", t);
+            LOG.error("Internal error while processing request", t);
             error = new A2AErrorResponse(new InternalError("Internal error"));
         } finally {
             if (error != null) {

--- a/reference/rest/src/main/java/org/a2aproject/sdk/server/rest/quarkus/A2AServerRoutes.java
+++ b/reference/rest/src/main/java/org/a2aproject/sdk/server/rest/quarkus/A2AServerRoutes.java
@@ -7,6 +7,8 @@ import static org.a2aproject.sdk.transport.rest.context.RestContextKeys.HEADERS_
 import static org.a2aproject.sdk.transport.rest.context.RestContextKeys.METHOD_NAME_KEY;
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -124,6 +126,8 @@ import static org.a2aproject.sdk.transport.rest.context.RestContextKeys.TENANT_K
  */
 @Singleton
 public class A2AServerRoutes {
+
+    private static final Logger LOG = LoggerFactory.getLogger(A2AServerRoutes.class);
 
     private static final String HISTORY_LENGTH_PARAM = "historyLength";
     private static final String PAGE_SIZE_PARAM = "pageSize";
@@ -306,7 +310,8 @@ public class A2AServerRoutes {
         try {
             response = jsonRestHandler.sendMessage(context, extractTenant(rc), body);
         } catch (Throwable t) {
-            response = jsonRestHandler.createErrorResponse(new InternalError(t.getMessage()));
+            LOG.error("Failed to process request", t);
+            response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
         } finally {
             sendResponse(rc, response);
         }
@@ -424,7 +429,8 @@ public class A2AServerRoutes {
         } catch (IllegalArgumentException e) {
             response = jsonRestHandler.createErrorResponse(new InvalidParamsError("Invalid parameter value: " + e.getMessage()));
         } catch (Throwable t) {
-            response = jsonRestHandler.createErrorResponse(new InternalError(t.getMessage()));
+            LOG.error("Failed to process request", t);
+            response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
         } finally {
             sendResponse(rc, response);
         }
@@ -458,7 +464,8 @@ public class A2AServerRoutes {
         } catch (NumberFormatException e) {
             response = jsonRestHandler.createErrorResponse(new InvalidParamsError("bad historyLength"));
         } catch (Throwable t) {
-            response = jsonRestHandler.createErrorResponse(new InternalError(t.getMessage()));
+            LOG.error("Failed to process request", t);
+            response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
         } finally {
             sendResponse(rc, response);
         }
@@ -492,7 +499,8 @@ public class A2AServerRoutes {
             if (t instanceof A2AError error) {
                 response = jsonRestHandler.createErrorResponse(error);
             } else {
-                response = jsonRestHandler.createErrorResponse(new InternalError(t.getMessage()));
+                LOG.error("Failed to process request", t);
+                response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
             }
         } finally {
             sendResponse(rc, response);
@@ -602,7 +610,8 @@ public class A2AServerRoutes {
                 response = jsonRestHandler.createTaskPushNotificationConfiguration(context, extractTenant(rc), body, taskId);
             }
         } catch (Throwable t) {
-            response = jsonRestHandler.createErrorResponse(new InternalError(t.getMessage()));
+            LOG.error("Failed to process request", t);
+            response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
         } finally {
             sendResponse(rc, response);
         }
@@ -633,7 +642,8 @@ public class A2AServerRoutes {
                 response = jsonRestHandler.getTaskPushNotificationConfiguration(context, extractTenant(rc), taskId, configId);
             }
         } catch (Throwable t) {
-            response = jsonRestHandler.createErrorResponse(new InternalError(t.getMessage()));
+            LOG.error("Failed to process request", t);
+            response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
         } finally {
             sendResponse(rc, response);
         }
@@ -678,7 +688,8 @@ public class A2AServerRoutes {
         } catch (NumberFormatException e) {
             response = jsonRestHandler.createErrorResponse(new InvalidParamsError("bad " + PAGE_SIZE_PARAM));
         } catch (Throwable t) {
-            response = jsonRestHandler.createErrorResponse(new InternalError(t.getMessage()));
+            LOG.error("Failed to process request", t);
+            response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
         } finally {
             sendResponse(rc, response);
         }
@@ -711,7 +722,8 @@ public class A2AServerRoutes {
                 response = jsonRestHandler.deleteTaskPushNotificationConfiguration(context, extractTenant(rc), taskId, configId);
             }
         } catch (Throwable t) {
-            response = jsonRestHandler.createErrorResponse(new InternalError(t.getMessage()));
+            LOG.error("Failed to process request", t);
+            response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
         } finally {
             sendResponse(rc, response);
         }

--- a/reference/rest/src/main/java/org/a2aproject/sdk/server/rest/quarkus/A2AServerRoutes.java
+++ b/reference/rest/src/main/java/org/a2aproject/sdk/server/rest/quarkus/A2AServerRoutes.java
@@ -7,8 +7,6 @@ import static org.a2aproject.sdk.transport.rest.context.RestContextKeys.HEADERS_
 import static org.a2aproject.sdk.transport.rest.context.RestContextKeys.METHOD_NAME_KEY;
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -56,6 +54,8 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.a2aproject.sdk.spec.A2AMethods.DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
 import static org.a2aproject.sdk.spec.A2AMethods.GET_EXTENDED_AGENT_CARD_METHOD;
@@ -310,7 +310,7 @@ public class A2AServerRoutes {
         try {
             response = jsonRestHandler.sendMessage(context, extractTenant(rc), body);
         } catch (Throwable t) {
-            LOG.error("Failed to process request", t);
+            LOG.error("Internal error while processing request", t);
             response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
         } finally {
             sendResponse(rc, response);
@@ -429,7 +429,7 @@ public class A2AServerRoutes {
         } catch (IllegalArgumentException e) {
             response = jsonRestHandler.createErrorResponse(new InvalidParamsError("Invalid parameter value: " + e.getMessage()));
         } catch (Throwable t) {
-            LOG.error("Failed to process request", t);
+            LOG.error("Internal error while processing request", t);
             response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
         } finally {
             sendResponse(rc, response);
@@ -464,7 +464,7 @@ public class A2AServerRoutes {
         } catch (NumberFormatException e) {
             response = jsonRestHandler.createErrorResponse(new InvalidParamsError("bad historyLength"));
         } catch (Throwable t) {
-            LOG.error("Failed to process request", t);
+            LOG.error("Internal error while processing request", t);
             response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
         } finally {
             sendResponse(rc, response);
@@ -499,7 +499,7 @@ public class A2AServerRoutes {
             if (t instanceof A2AError error) {
                 response = jsonRestHandler.createErrorResponse(error);
             } else {
-                LOG.error("Failed to process request", t);
+                LOG.error("Internal error while processing request", t);
                 response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
             }
         } finally {
@@ -610,7 +610,7 @@ public class A2AServerRoutes {
                 response = jsonRestHandler.createTaskPushNotificationConfiguration(context, extractTenant(rc), body, taskId);
             }
         } catch (Throwable t) {
-            LOG.error("Failed to process request", t);
+            LOG.error("Internal error while processing request", t);
             response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
         } finally {
             sendResponse(rc, response);
@@ -642,7 +642,7 @@ public class A2AServerRoutes {
                 response = jsonRestHandler.getTaskPushNotificationConfiguration(context, extractTenant(rc), taskId, configId);
             }
         } catch (Throwable t) {
-            LOG.error("Failed to process request", t);
+            LOG.error("Internal error while processing request", t);
             response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
         } finally {
             sendResponse(rc, response);
@@ -688,7 +688,7 @@ public class A2AServerRoutes {
         } catch (NumberFormatException e) {
             response = jsonRestHandler.createErrorResponse(new InvalidParamsError("bad " + PAGE_SIZE_PARAM));
         } catch (Throwable t) {
-            LOG.error("Failed to process request", t);
+            LOG.error("Internal error while processing request", t);
             response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
         } finally {
             sendResponse(rc, response);
@@ -722,7 +722,7 @@ public class A2AServerRoutes {
                 response = jsonRestHandler.deleteTaskPushNotificationConfiguration(context, extractTenant(rc), taskId, configId);
             }
         } catch (Throwable t) {
-            LOG.error("Failed to process request", t);
+            LOG.error("Internal error while processing request", t);
             response = jsonRestHandler.createErrorResponse(new InternalError("Internal error"));
         } finally {
             sendResponse(rc, response);

--- a/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
+++ b/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import jakarta.enterprise.inject.Vetoed;
@@ -822,7 +823,11 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     }
 
     private <V> void handleInternalError(StreamObserver<V> responseObserver, Throwable t) {
-        handleError(responseObserver, new InternalError(t.getMessage()));
+        // Log the full exception server-side but send only a generic message to the client
+        // (BUG-12/46): leaking internal exception messages can expose file paths, library
+        // names, and other implementation details that aid server fingerprinting (CWE-209).
+        LOGGER.log(Level.SEVERE, "Internal error while processing gRPC request", t);
+        handleError(responseObserver, new InternalError("Internal error"));
     }
 
 

--- a/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
+++ b/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
@@ -823,8 +823,8 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     }
 
     private <V> void handleInternalError(StreamObserver<V> responseObserver, Throwable t) {
-        // Log the full exception server-side but send only a generic message to the client
-        // (BUG-12/46): leaking internal exception messages can expose file paths, library
+        // Log the full exception server-side but send only a generic message to the client:
+        // leaking internal exception messages can expose file paths, library
         // names, and other implementation details that aid server fingerprinting (CWE-209).
         LOGGER.log(Level.SEVERE, "Internal error while processing gRPC request", t);
         handleError(responseObserver, new InternalError("Internal error"));

--- a/transport/grpc/src/test/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandlerTest.java
+++ b/transport/grpc/src/test/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandlerTest.java
@@ -653,7 +653,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
 
     @Test
     public void testOnMessageInternalErrorIsSanitized() throws Exception {
-        // BUG-12/46: a non-A2AError exception must not leak its message to the client
+        // A non-A2AError exception must not leak its message to the client
         DefaultRequestHandler mocked = Mockito.mock(DefaultRequestHandler.class);
         Mockito.doThrow(new RuntimeException("sensitive detail: /var/lib/secret/config.db"))
                 .when(mocked).onMessageSend(Mockito.any(MessageSendParams.class), Mockito.any(ServerCallContext.class));

--- a/transport/grpc/src/test/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandlerTest.java
+++ b/transport/grpc/src/test/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandlerTest.java
@@ -652,6 +652,30 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
     }
 
     @Test
+    public void testOnMessageInternalErrorIsSanitized() throws Exception {
+        // BUG-12/46: a non-A2AError exception must not leak its message to the client
+        DefaultRequestHandler mocked = Mockito.mock(DefaultRequestHandler.class);
+        Mockito.doThrow(new RuntimeException("sensitive detail: /var/lib/secret/config.db"))
+                .when(mocked).onMessageSend(Mockito.any(MessageSendParams.class), Mockito.any(ServerCallContext.class));
+        GrpcHandler handler = new TestGrpcHandler(AbstractA2ARequestHandlerTest.CARD, mocked, internalExecutor);
+
+        org.a2aproject.sdk.grpc.SendMessageRequest request = org.a2aproject.sdk.grpc.SendMessageRequest.newBuilder()
+                .setMessage(GRPC_MESSAGE)
+                .build();
+        StreamRecorder<org.a2aproject.sdk.grpc.SendMessageResponse> responseObserver = StreamRecorder.create();
+        handler.sendMessage(request, responseObserver);
+        responseObserver.awaitCompletion(5, TimeUnit.SECONDS);
+
+        Assertions.assertNotNull(responseObserver.getError());
+        Assertions.assertInstanceOf(StatusRuntimeException.class, responseObserver.getError());
+        StatusRuntimeException sre = (StatusRuntimeException) responseObserver.getError();
+        Assertions.assertEquals(Status.Code.INTERNAL, sre.getStatus().getCode());
+        Assertions.assertEquals("Internal error", sre.getStatus().getDescription());
+        Assertions.assertFalse(sre.getStatus().getDescription().contains("sensitive"),
+                "Internal exception message must not be leaked to the client");
+    }
+
+    @Test
     public void testListPushNotificationConfig() throws Exception {
         GrpcHandler handler = new TestGrpcHandler(AbstractA2ARequestHandlerTest.CARD, requestHandler, internalExecutor);
         taskStore.save(AbstractA2ARequestHandlerTest.MINIMAL_TASK, false);

--- a/transport/jsonrpc/src/main/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandler.java
+++ b/transport/jsonrpc/src/main/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandler.java
@@ -752,7 +752,7 @@ public class JSONRPCHandler {
     }
 
     /**
-     * Builds a client-safe {@link InternalError} for an unexpected exception (BUG-12/46).
+     * Builds a client-safe {@link InternalError} for an unexpected exception.
      * <p>
      * The original exception (class, message, stack trace) is logged server-side but the
      * client receives only a generic message: leaking internal exception messages can

--- a/transport/jsonrpc/src/main/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandler.java
+++ b/transport/jsonrpc/src/main/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandler.java
@@ -5,6 +5,8 @@ import static org.a2aproject.sdk.server.util.async.AsyncUtils.createTubeConfig;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
@@ -133,6 +135,8 @@ import org.jspecify.annotations.Nullable;
 @ApplicationScoped
 public class JSONRPCHandler {
 
+    private static final Logger LOGGER = Logger.getLogger(JSONRPCHandler.class.getName());
+
     // Fields set by constructor injection cannot be final. We need a noargs constructor for
     // Jakarta compatibility, and it seems that making fields set by constructor injection
     // final, is not proxyable in all runtimes
@@ -237,7 +241,7 @@ public class JSONRPCHandler {
         } catch (A2AError e) {
             return new SendMessageResponse(request.getId(), e);
         } catch (Throwable t) {
-            return new SendMessageResponse(request.getId(), new InternalError(t.getMessage()));
+            return new SendMessageResponse(request.getId(), internalError(t));
         }
     }
 
@@ -297,7 +301,7 @@ public class JSONRPCHandler {
         } catch (A2AError e) {
             return ZeroPublisher.fromItems(new SendStreamingMessageResponse(request.getId(), e));
         } catch (Throwable throwable) {
-            return ZeroPublisher.fromItems(new SendStreamingMessageResponse(request.getId(), new InternalError(throwable.getMessage())));
+            return ZeroPublisher.fromItems(new SendStreamingMessageResponse(request.getId(), internalError(throwable)));
         }
     }
 
@@ -336,7 +340,7 @@ public class JSONRPCHandler {
         } catch (A2AError e) {
             return new CancelTaskResponse(request.getId(), e);
         } catch (Throwable t) {
-            return new CancelTaskResponse(request.getId(), new InternalError(t.getMessage()));
+            return new CancelTaskResponse(request.getId(), internalError(t));
         }
     }
 
@@ -393,7 +397,7 @@ public class JSONRPCHandler {
             // Other A2AError types - wrap inline as part of the stream
             return ZeroPublisher.fromItems(new SendStreamingMessageResponse(request.getId(), e));
         } catch (Throwable throwable) {
-            return ZeroPublisher.fromItems(new SendStreamingMessageResponse(request.getId(), new InternalError(throwable.getMessage())));
+            return ZeroPublisher.fromItems(new SendStreamingMessageResponse(request.getId(), internalError(throwable)));
         }
     }
 
@@ -434,7 +438,7 @@ public class JSONRPCHandler {
         } catch (A2AError e) {
             return new GetTaskPushNotificationConfigResponse(request.getId(), e);
         } catch (Throwable t) {
-            return new GetTaskPushNotificationConfigResponse(request.getId(), new InternalError(t.getMessage()));
+            return new GetTaskPushNotificationConfigResponse(request.getId(), internalError(t));
         }
     }
 
@@ -476,7 +480,7 @@ public class JSONRPCHandler {
         } catch (A2AError e) {
             return new CreateTaskPushNotificationConfigResponse(request.getId(), e);
         } catch (Throwable t) {
-            return new CreateTaskPushNotificationConfigResponse(request.getId(), new InternalError(t.getMessage()));
+            return new CreateTaskPushNotificationConfigResponse(request.getId(), internalError(t));
         }
     }
 
@@ -511,7 +515,7 @@ public class JSONRPCHandler {
         } catch (A2AError e) {
             return new GetTaskResponse(request.getId(), e);
         } catch (Throwable t) {
-            return new GetTaskResponse(request.getId(), new InternalError(t.getMessage()));
+            return new GetTaskResponse(request.getId(), internalError(t));
         }
     }
 
@@ -558,7 +562,7 @@ public class JSONRPCHandler {
         } catch (A2AError e) {
             return new ListTasksResponse(request.getId(), e);
         } catch (Throwable t) {
-            return new ListTasksResponse(request.getId(), new InternalError(t.getMessage()));
+            return new ListTasksResponse(request.getId(), internalError(t));
         }
     }
 
@@ -599,7 +603,7 @@ public class JSONRPCHandler {
         } catch (A2AError e) {
             return new ListTaskPushNotificationConfigsResponse(request.getId(), e);
         } catch (Throwable t) {
-            return new ListTaskPushNotificationConfigsResponse(request.getId(), new InternalError(t.getMessage()));
+            return new ListTaskPushNotificationConfigsResponse(request.getId(), internalError(t));
         }
     }
 
@@ -640,7 +644,7 @@ public class JSONRPCHandler {
         } catch (A2AError e) {
             return new DeleteTaskPushNotificationConfigResponse(request.getId(), e);
         } catch (Throwable t) {
-            return new DeleteTaskPushNotificationConfigResponse(request.getId(), new InternalError(t.getMessage()));
+            return new DeleteTaskPushNotificationConfigResponse(request.getId(), internalError(t));
         }
     }
 
@@ -682,7 +686,7 @@ public class JSONRPCHandler {
         } catch (A2AError e) {
             return new GetExtendedAgentCardResponse(request.getId(), e);
         } catch (Throwable t) {
-            return new GetExtendedAgentCardResponse(request.getId(), new InternalError(t.getMessage()));
+            return new GetExtendedAgentCardResponse(request.getId(), internalError(t));
         }
     }
 
@@ -729,8 +733,7 @@ public class JSONRPCHandler {
                             } else {
                                 tube.send(
                                         new SendStreamingMessageResponse(
-                                                requestId, new
-                                                InternalError(throwable.getMessage())));
+                                                requestId, internalError(throwable)));
                             }
                             onComplete();
                         }
@@ -746,5 +749,21 @@ public class JSONRPCHandler {
 
     public void authorizeTaskAccess(String requestedTaskId, ServerCallContext context, TaskOperation operation) {
         requestHandler.authorizeTaskAccess(requestedTaskId, context, operation);
+    }
+
+    /**
+     * Builds a client-safe {@link InternalError} for an unexpected exception (BUG-12/46).
+     * <p>
+     * The original exception (class, message, stack trace) is logged server-side but the
+     * client receives only a generic message: leaking internal exception messages can
+     * expose file paths, library names, and other implementation details that aid server
+     * fingerprinting (CWE-209).
+     *
+     * @param t the unexpected exception
+     * @return a sanitized internal error with a generic message
+     */
+    private static InternalError internalError(Throwable t) {
+        LOGGER.log(Level.SEVERE, "Internal error while processing request", t);
+        return new InternalError("Internal error");
     }
 }

--- a/transport/jsonrpc/src/test/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -1,6 +1,7 @@
 package org.a2aproject.sdk.transport.jsonrpc.handler;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -1187,6 +1188,25 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
         SendMessageResponse response = handler.onMessageSend(request, callContext);
 
         assertInstanceOf(InternalError.class, response.getError());
+    }
+
+    @Test
+    public void testOnMessageSendSanitizesUnexpectedException() {
+        // BUG-12/46: a non-A2AError exception must not leak its message to the client
+        DefaultRequestHandler mocked = Mockito.mock(DefaultRequestHandler.class);
+        Mockito.doThrow(new RuntimeException("sensitive detail: /var/lib/secret/config.db"))
+                .when(mocked)
+                .onMessageSend(Mockito.any(MessageSendParams.class), Mockito.any(ServerCallContext.class));
+
+        JSONRPCHandler handler = new JSONRPCHandler(CARD, mocked, internalExecutor);
+
+        SendMessageRequest request = new SendMessageRequest("1", new MessageSendParams(MESSAGE, defaultConfiguration(), null));
+        SendMessageResponse response = handler.onMessageSend(request, callContext);
+
+        assertInstanceOf(InternalError.class, response.getError());
+        assertEquals("Internal error", response.getError().getMessage());
+        assertFalse(response.getError().getMessage().contains("sensitive"),
+                "Internal exception message must not be leaked to the client");
     }
 
     @Test

--- a/transport/jsonrpc/src/test/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -1192,7 +1192,7 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
 
     @Test
     public void testOnMessageSendSanitizesUnexpectedException() {
-        // BUG-12/46: a non-A2AError exception must not leak its message to the client
+        // A non-A2AError exception must not leak its message to the client
         DefaultRequestHandler mocked = Mockito.mock(DefaultRequestHandler.class);
         Mockito.doThrow(new RuntimeException("sensitive detail: /var/lib/secret/config.db"))
                 .when(mocked)

--- a/transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java
+++ b/transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java
@@ -237,7 +237,7 @@ public class RestHandler {
         } catch (A2AError e) {
             return createErrorResponse(e);
         } catch (Throwable throwable) {
-            return createErrorResponse(new InternalError(throwable.getMessage()));
+            return createErrorResponse(internalError(throwable));
         }
     }
 
@@ -311,7 +311,7 @@ public class RestHandler {
         } catch (A2AError e) {
             return new HTTPRestStreamingResponse(ZeroPublisher.fromItems(new HTTPRestErrorResponse(e).toJson()));
         } catch (Throwable throwable) {
-            return new HTTPRestStreamingResponse(ZeroPublisher.fromItems(new HTTPRestErrorResponse(new InternalError(throwable.getMessage())).toJson()));
+            return new HTTPRestStreamingResponse(ZeroPublisher.fromItems(new HTTPRestErrorResponse(internalError(throwable)).toJson()));
         }
     }
 
@@ -354,7 +354,7 @@ public class RestHandler {
         } catch (A2AError e) {
             return createErrorResponse(e);
         } catch (Throwable throwable) {
-            return createErrorResponse(new InternalError(throwable.getMessage()));
+            return createErrorResponse(internalError(throwable));
         }
     }
 
@@ -386,7 +386,7 @@ public class RestHandler {
         } catch (A2AError e) {
             return createErrorResponse(e);
         } catch (Throwable throwable) {
-            return createErrorResponse(new InternalError(throwable.getMessage()));
+            return createErrorResponse(internalError(throwable));
         }
     }
 
@@ -438,7 +438,7 @@ public class RestHandler {
         } catch (A2AError e) {
             return new HTTPRestStreamingResponse(ZeroPublisher.fromItems(new HTTPRestErrorResponse(e).toJson()));
         } catch (Throwable throwable) {
-            return new HTTPRestStreamingResponse(ZeroPublisher.fromItems(new HTTPRestErrorResponse(new InternalError(throwable.getMessage())).toJson()));
+            return new HTTPRestStreamingResponse(ZeroPublisher.fromItems(new HTTPRestErrorResponse(internalError(throwable)).toJson()));
         }
     }
 
@@ -464,7 +464,7 @@ public class RestHandler {
         } catch (A2AError e) {
             return createErrorResponse(e);
         } catch (Throwable throwable) {
-            return createErrorResponse(new InternalError(throwable.getMessage()));
+            return createErrorResponse(internalError(throwable));
         }
     }
 
@@ -566,7 +566,7 @@ public class RestHandler {
         } catch (A2AError e) {
             return createErrorResponse(e);
         } catch (Throwable throwable) {
-            return createErrorResponse(new InternalError(throwable.getMessage()));
+            return createErrorResponse(internalError(throwable));
         }
     }
 
@@ -590,7 +590,7 @@ public class RestHandler {
         } catch (A2AError e) {
             return createErrorResponse(e);
         } catch (Throwable throwable) {
-            return createErrorResponse(new InternalError(throwable.getMessage()));
+            return createErrorResponse(internalError(throwable));
         }
     }
 
@@ -615,7 +615,7 @@ public class RestHandler {
         } catch (A2AError e) {
             return createErrorResponse(e);
         } catch (Throwable throwable) {
-            return createErrorResponse(new InternalError(throwable.getMessage()));
+            return createErrorResponse(internalError(throwable));
         }
     }
 
@@ -639,7 +639,7 @@ public class RestHandler {
         } catch (A2AError e) {
             return createErrorResponse(e);
         } catch (Throwable throwable) {
-            return createErrorResponse(new InternalError(throwable.getMessage()));
+            return createErrorResponse(internalError(throwable));
         }
     }
 
@@ -689,6 +689,22 @@ public class RestHandler {
     private HTTPRestResponse createErrorResponse(int statusCode, A2AError error) {
         String jsonBody = new HTTPRestErrorResponse(error).toJson();
         return new HTTPRestResponse(statusCode, APPLICATION_JSON, jsonBody);
+    }
+
+    /**
+     * Builds a client-safe {@link InternalError} for an unexpected exception (BUG-12/46).
+     * <p>
+     * The original exception (class, message, stack trace) is logged server-side but the
+     * client receives only a generic message: leaking internal exception messages can
+     * expose file paths, library names, and other implementation details that aid server
+     * fingerprinting (CWE-209).
+     *
+     * @param t the unexpected exception
+     * @return a sanitized internal error with a generic message
+     */
+    private static InternalError internalError(Throwable t) {
+        log.log(Level.SEVERE, "Internal error while processing request", t);
+        return new InternalError("Internal error");
     }
 
     private HTTPRestStreamingResponse createStreamingResponse(Flow.Publisher<StreamingEventKind> publisher) {
@@ -744,7 +760,7 @@ public class RestHandler {
                         if (throwable instanceof A2AError jsonrpcError) {
                             tube.send(new HTTPRestErrorResponse(jsonrpcError).toJson());
                         } else {
-                            tube.send(new HTTPRestErrorResponse(new InternalError(throwable.getMessage())).toJson());
+                            tube.send(new HTTPRestErrorResponse(internalError(throwable)).toJson());
                         }
                         onComplete();
                     }
@@ -807,7 +823,7 @@ public class RestHandler {
         } catch (A2AError e) {
             return createErrorResponse(e);
         } catch (Throwable t) {
-            return createErrorResponse(500, new InternalError(t.getMessage()));
+            return createErrorResponse(500, internalError(t));
         }
     }
 
@@ -851,7 +867,7 @@ public class RestHandler {
             return new HTTPRestResponse(200, APPLICATION_JSON, JsonUtil.toJson(agentCard),
                     cacheMetadata.getHttpHeadersMap());
         } catch (Throwable t) {
-            return createErrorResponse(500, new InternalError(t.getMessage()));
+            return createErrorResponse(500, internalError(t));
         }
     }
 

--- a/transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java
+++ b/transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java
@@ -692,7 +692,7 @@ public class RestHandler {
     }
 
     /**
-     * Builds a client-safe {@link InternalError} for an unexpected exception (BUG-12/46).
+     * Builds a client-safe {@link InternalError} for an unexpected exception.
      * <p>
      * The original exception (class, message, stack trace) is logged server-side but the
      * client receives only a generic message: leaking internal exception messages can

--- a/transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java
+++ b/transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java
@@ -671,7 +671,8 @@ public class RestHandler {
             String jsonBody = ProtoJsonUtils.toJson(JsonFormat.printer().alwaysPrintFieldsWithNoPresence(), builder);
             return new HTTPRestResponse(statusCode, APPLICATION_JSON, jsonBody);
         } catch (InvalidProtocolBufferException e) {
-            return createErrorResponse(new InternalError("Failed to serialize response: " + e.getMessage()));
+            log.log(Level.SEVERE, "Failed to serialize response", e);
+            return createErrorResponse(new InternalError("Internal error"));
         }
     }
 

--- a/transport/rest/src/test/java/org/a2aproject/sdk/transport/rest/handler/RestHandlerTest.java
+++ b/transport/rest/src/test/java/org/a2aproject/sdk/transport/rest/handler/RestHandlerTest.java
@@ -1100,7 +1100,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
 
     @Test
     public void testSendMessageSanitizesInternalError() {
-        // BUG-12/46: a non-A2AError exception must not leak its message to the client
+        // A non-A2AError exception must not leak its message to the client
         RequestHandler mocked = Mockito.mock(RequestHandler.class);
         Mockito.doThrow(new RuntimeException("sensitive detail: /var/lib/secret/config.db"))
                 .when(mocked).onMessageSend(Mockito.any(), Mockito.any());

--- a/transport/rest/src/test/java/org/a2aproject/sdk/transport/rest/handler/RestHandlerTest.java
+++ b/transport/rest/src/test/java/org/a2aproject/sdk/transport/rest/handler/RestHandlerTest.java
@@ -23,6 +23,7 @@ import org.a2aproject.sdk.server.ServerCallContext;
 import org.a2aproject.sdk.server.auth.UnauthenticatedUser;
 import org.a2aproject.sdk.server.config.DefaultValuesConfigProvider;
 import org.a2aproject.sdk.server.requesthandlers.AbstractA2ARequestHandlerTest;
+import org.a2aproject.sdk.server.requesthandlers.RequestHandler;
 import org.a2aproject.sdk.spec.AgentCapabilities;
 import org.a2aproject.sdk.spec.AgentCard;
 import org.a2aproject.sdk.spec.AgentExtension;
@@ -31,6 +32,7 @@ import org.a2aproject.sdk.spec.Task;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.mockito.Mockito;
 
 @Timeout(value = 1, unit = TimeUnit.MINUTES)
 public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
@@ -1094,5 +1096,34 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         Assertions.assertEquals("type.googleapis.com/google.rpc.ErrorInfo", detail.get("@type").getAsString(), "@type field mismatch");
         Assertions.assertEquals(expectedReason, detail.get("reason").getAsString(), "reason field mismatch");
         Assertions.assertEquals("a2a-protocol.org", detail.get("domain").getAsString(), "domain field mismatch");
+    }
+
+    @Test
+    public void testSendMessageSanitizesInternalError() {
+        // BUG-12/46: a non-A2AError exception must not leak its message to the client
+        RequestHandler mocked = Mockito.mock(RequestHandler.class);
+        Mockito.doThrow(new RuntimeException("sensitive detail: /var/lib/secret/config.db"))
+                .when(mocked).onMessageSend(Mockito.any(), Mockito.any());
+
+        RestHandler handler = new RestHandler(CARD, createCacheMetadata(), mocked, internalExecutor);
+        String requestBody = """
+                {
+                  "message": {
+                    "messageId": "message-1234",
+                    "contextId": "context-1234",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "hello"}],
+                    "metadata": {}
+                  }
+                }""";
+
+        RestHandler.HTTPRestResponse response = handler.sendMessage(callContext, "", requestBody);
+
+        JsonObject body = JsonParser.parseString(response.getBody()).getAsJsonObject();
+        JsonObject error = body.getAsJsonObject("error");
+        Assertions.assertEquals(500, error.get("code").getAsInt());
+        Assertions.assertEquals("Internal error", error.get("message").getAsString());
+        Assertions.assertFalse(error.get("message").getAsString().contains("sensitive"),
+                "Internal exception message must not be leaked to the client");
     }
 }


### PR DESCRIPTION
## What changed

### 1. Sanitize internal error messages in the JSON-RPC handler 

**Problem:** `JSONRPCHandler` converted every unexpected (non-`A2AError`) exception into `new InternalError(t.getMessage())`, forwarding the raw exception message — often containing file paths, library names, or class names — to the client in the JSON-RPC error payload (CWE-209, information disclosure / server fingerprinting).

**Fix (transport/jsonrpc/src/main/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandler.java):**
- Added a `LOGGER` (java.util.logging) and a private `internalError(Throwable)` helper that logs the full exception server-side (`Level.SEVERE`) and returns `new InternalError("Internal error")` with a generic, client-safe message.
- Replaced all 12 `new InternalError(...getMessage())` sites (onMessageSend, onMessageSendStream, onSubscribeToTask, cancel/get/list tasks, push-notification config endpoints, extended agent card, and the streaming subscriber `onError` path).

**Fix (transport/jsonrpc/src/test/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandlerTest.java):**
- `testOnMessageSendSanitizesUnexpectedException` — a mocked `RuntimeException` with a sensitive message yields an `InternalError` whose message is `"Internal error"` and does not contain the sensitive text.

### 2. Sanitize internal error messages in the REST handler 

**Fix (transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java):**
- Added a private `internalError(Throwable)` helper (logs at `SEVERE`, returns `new InternalError("Internal error")`) and replaced all 13 `new InternalError(...getMessage())` sites across send/cancel/get/list/subscribe/push-config/agent-card endpoints, including the streaming error paths.

**Fix (transport/rest/src/test/java/org/a2aproject/sdk/transport/rest/handler/RestHandlerTest.java):**
- `testSendMessageSanitizesInternalError` — asserts a 500 response whose message is `"Internal error"` (no sensitive text leaked).

### 3. Sanitize internal error messages in the gRPC handler 

**Problem:** `GrpcHandler.handleInternalError` sent `t.getMessage()` in the gRPC error description, leaking internal exception details to the client.

**Fix (transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java):**
- `handleInternalError` now logs the full exception at `SEVERE` and calls `handleError` with `new InternalError("Internal error")`, so the gRPC status description carries only the generic message.

**Fix (transport/grpc/src/test/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandlerTest.java):**
- `testOnMessageInternalErrorIsSanitized` — a mocked `RuntimeException` yields gRPC `INTERNAL` with description `"Internal error"` (no sensitive text).

Note: exceptions that are already `A2AError` (including `InternalError` thrown by the request handler) still flow through unchanged — sanitization applies to unexpected non-A2A exceptions. The `compat-0.3` module has its own copies of the handlers and was intentionally left unchanged (out of scope).

## Testing

- `mvn -pl transport/jsonrpc,transport/grpc,transport/rest test` — **127 tests run, 0 failures, 1 skipped** (BUILD SUCCESS): JSON-RPC 49, gRPC 41, REST 37, including the 3 new sanitization regression tests.
- `mvn -pl reference/jsonrpc test` — **198 tests run, 0 failures, 0 skipped** (BUILD SUCCESS).
