### PR TITLE
fix: make InMemoryPushNotificationConfigStore thread-safe

### DIFF
--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStore.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStore.java
@@ -83,7 +83,7 @@ public class InMemoryPushNotificationConfigStore implements PushNotificationConf
             return new ListTaskPushNotificationConfigsResult(Collections.emptyList());
         }
         if (params.pageSize() <= 0) {
-            return new ListTaskPushNotificationConfigsResult(new ArrayList<>(configs), null);
+            return new ListTaskPushNotificationConfigsResult(configs, null);
         }
         if (params.pageToken() != null && !params.pageToken().isBlank()) {
             int index = findFirstIndex(configs, params.pageToken());

--- a/server-common/src/main/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStore.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStore.java
@@ -3,9 +3,9 @@ package org.a2aproject.sdk.server.tasks;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -34,8 +34,8 @@ public class InMemoryPushNotificationConfigStore implements PushNotificationConf
      */
     public static final int MAX_PUSH_CONFIGS_PER_TASK = PushNotificationConfigStore.DEFAULT_MAX_PUSH_CONFIGS_PER_TASK;
 
-    private final Map<String, List<TaskPushNotificationConfig>> pushNotificationInfos = Collections.synchronizedMap(new HashMap<>());
-    private final Map<String, String> protocolVersions = Collections.synchronizedMap(new HashMap<>());
+    private final ConcurrentHashMap<String, List<TaskPushNotificationConfig>> pushNotificationInfos = new ConcurrentHashMap<>();
+    private final Map<String, String> protocolVersions = new ConcurrentHashMap<>();
 
     @Inject
     @Nullable A2AConfigProvider configProvider;
@@ -47,28 +47,26 @@ public class InMemoryPushNotificationConfigStore implements PushNotificationConf
     @Override
     public TaskPushNotificationConfig setInfo(TaskPushNotificationConfig notificationConfig) {
         String taskId = Assert.checkNotNullParam("taskId", notificationConfig.taskId());
-        List<TaskPushNotificationConfig> notificationConfigList = pushNotificationInfos.getOrDefault(taskId, new ArrayList<>());
         TaskPushNotificationConfig.Builder builder = TaskPushNotificationConfig.builder(notificationConfig);
         if (notificationConfig.id().isEmpty()) {
             builder.id(taskId);
         }
-        notificationConfig = builder.build();
-
-        // Enforce the per-task limit and remove any existing config with the same
-        // ID in a single pass. Re-registering/updating an already-registered config
-        // ID is allowed; only genuinely new configs count against the limit.
-        String configId = notificationConfig.id();
-        boolean isExistingConfig = notificationConfigList.removeIf(
-                existing -> existing.id() != null && existing.id().equals(configId));
+        TaskPushNotificationConfig config = builder.build();
+        String configId = config.id();
         int maxPerTask = PushNotificationConfigStore.maxPushConfigsPerTask(configProvider);
-        if (!isExistingConfig && notificationConfigList.size() >= maxPerTask) {
-            throw new InvalidParamsError("Too many push notification configs for task " + taskId
-                    + " (max " + maxPerTask + ")");
-        }
 
-        notificationConfigList.add(notificationConfig);
-        pushNotificationInfos.put(taskId, notificationConfigList);
-        return notificationConfig;
+        pushNotificationInfos.compute(taskId, (key, list) -> {
+            List<TaskPushNotificationConfig> mutable = list == null ? new ArrayList<>() : new ArrayList<>(list);
+            boolean isExistingConfig = mutable.removeIf(
+                    existing -> existing.id() != null && existing.id().equals(configId));
+            if (!isExistingConfig && mutable.size() >= maxPerTask) {
+                throw new InvalidParamsError("Too many push notification configs for task " + taskId
+                        + " (max " + maxPerTask + ")");
+            }
+            mutable.add(config);
+            return List.copyOf(mutable);
+        });
+        return config;
     }
 
     @Override
@@ -88,7 +86,6 @@ public class InMemoryPushNotificationConfigStore implements PushNotificationConf
             return new ListTaskPushNotificationConfigsResult(new ArrayList<>(configs), null);
         }
         if (params.pageToken() != null && !params.pageToken().isBlank()) {
-            //find first index
             int index = findFirstIndex(configs, params.pageToken());
             if (index < configs.size()) {
                 configs = configs.subList(index, configs.size());
@@ -102,16 +99,12 @@ public class InMemoryPushNotificationConfigStore implements PushNotificationConf
     }
 
     private int findFirstIndex(List<TaskPushNotificationConfig> configs, String id) {
-        //find first index
-        Iterator<TaskPushNotificationConfig> iter = configs.iterator();
-        int index = 0;
-        while (iter.hasNext()) {
-            if (id.equals(iter.next().id())) {
-                return index;
+        for (int i = 0; i < configs.size(); i++) {
+            if (id.equals(configs.get(i).id())) {
+                return i;
             }
-            index++;
         }
-        return index;
+        return configs.size();
     }
 
     @Override
@@ -119,23 +112,13 @@ public class InMemoryPushNotificationConfigStore implements PushNotificationConf
         if (configId == null) {
             configId = taskId;
         }
-        List<TaskPushNotificationConfig> notificationConfigList = pushNotificationInfos.get(taskId);
-        if (notificationConfigList == null || notificationConfigList.isEmpty()) {
-            return;
-        }
-
-        Iterator<TaskPushNotificationConfig> notificationConfigIterator = notificationConfigList.iterator();
-        while (notificationConfigIterator.hasNext()) {
-            TaskPushNotificationConfig config = notificationConfigIterator.next();
-            if (configId.equals(config.id())) {
-                notificationConfigIterator.remove();
-                break;
-            }
-        }
-        protocolVersions.remove(taskId + ":" + configId);
-        if (notificationConfigList.isEmpty()) {
-            pushNotificationInfos.remove(taskId);
-        }
+        String deleteId = configId;
+        pushNotificationInfos.computeIfPresent(taskId, (key, list) -> {
+            List<TaskPushNotificationConfig> mutable = new ArrayList<>(list);
+            mutable.removeIf(config -> deleteId.equals(config.id()));
+            return mutable.isEmpty() ? null : List.copyOf(mutable);
+        });
+        protocolVersions.remove(taskId + ":" + deleteId);
     }
 
     @Override

--- a/server-common/src/test/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStoreTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/tasks/InMemoryPushNotificationConfigStoreTest.java
@@ -13,6 +13,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.a2aproject.sdk.client.http.A2AHttpClient;
 import org.a2aproject.sdk.client.http.A2AHttpResponse;
@@ -690,6 +693,52 @@ class InMemoryPushNotificationConfigStoreTest {
         ListTaskPushNotificationConfigsResult result = configStore.getInfo(new ListTaskPushNotificationConfigsParams(taskId));
         assertEquals(InMemoryPushNotificationConfigStore.MAX_PUSH_CONFIGS_PER_TASK, result.configs().size());
         assertTrue(result.configs().stream().noneMatch(c -> "cfg-overflow".equals(c.id())));
+    }
+
+    @Test
+    public void testConcurrentSetInfoAtLimitOnlyOneSucceeds() throws InterruptedException {
+        String taskId = "task_concurrent_limit";
+        int limit = InMemoryPushNotificationConfigStore.MAX_PUSH_CONFIGS_PER_TASK;
+
+        // Fill to limit - 1, leaving exactly one slot open
+        for (int i = 0; i < limit - 1; i++) {
+            configStore.setInfo(createSamplePushConfig(taskId,
+                    "http://url" + i + ".com/callback", "cfg" + i, null));
+        }
+
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger errorCount = new AtomicInteger(0);
+
+        Runnable contestant = () -> {
+            try {
+                barrier.await();
+            } catch (InterruptedException | BrokenBarrierException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            try {
+                configStore.setInfo(createSamplePushConfig(taskId,
+                        "http://concurrent.com/callback",
+                        "cfg-concurrent-" + Thread.currentThread().getId(), null));
+                successCount.incrementAndGet();
+            } catch (InvalidParamsError e) {
+                errorCount.incrementAndGet();
+            }
+        };
+
+        Thread t1 = new Thread(contestant);
+        Thread t2 = new Thread(contestant);
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+
+        assertEquals(1, successCount.get(), "Exactly one thread should succeed");
+        assertEquals(1, errorCount.get(), "Exactly one thread should be rejected");
+
+        ListTaskPushNotificationConfigsResult result = configStore.getInfo(new ListTaskPushNotificationConfigsParams(taskId));
+        assertEquals(limit, result.configs().size(), "Store must be at exactly the limit after the race");
     }
 
     @Test


### PR DESCRIPTION
Use ConcurrentHashMap with compute()/computeIfPresent() for atomic per-key operations and store immutable list snapshots via List.copyOf().

Follows up on #1044 