### PR TITLE
fix: defer AgentCard resolution to prevent eager startup failures

### DIFF
--- a/reference/grpc/pom.xml
+++ b/reference/grpc/pom.xml
@@ -38,6 +38,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>a2a-java-sdk-server-common</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>a2a-java-sdk-tests-server-common</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/reference/grpc/src/main/java/org/a2aproject/sdk/server/grpc/quarkus/QuarkusGrpcHandler.java
+++ b/reference/grpc/src/main/java/org/a2aproject/sdk/server/grpc/quarkus/QuarkusGrpcHandler.java
@@ -75,7 +75,7 @@ import org.jspecify.annotations.Nullable;
 public class QuarkusGrpcHandler extends GrpcHandler {
 
     private final Instance<AgentCard> agentCard;
-    private final Instance<AgentCard> extendedAgentCard;
+    private final @Nullable Instance<AgentCard> extendedAgentCard;
     private final RequestHandler requestHandler;
     private final Instance<CallContextFactory> callContextFactoryInstance;
     private final Executor executor;

--- a/reference/grpc/src/main/java/org/a2aproject/sdk/server/grpc/quarkus/QuarkusGrpcHandler.java
+++ b/reference/grpc/src/main/java/org/a2aproject/sdk/server/grpc/quarkus/QuarkusGrpcHandler.java
@@ -74,8 +74,8 @@ import org.jspecify.annotations.Nullable;
 @Blocking
 public class QuarkusGrpcHandler extends GrpcHandler {
 
-    private final AgentCard agentCard;
-    private final AgentCard extendedAgentCard;
+    private final Instance<AgentCard> agentCard;
+    private final Instance<AgentCard> extendedAgentCard;
     private final RequestHandler requestHandler;
     private final Instance<CallContextFactory> callContextFactoryInstance;
     private final Executor executor;
@@ -106,17 +106,13 @@ public class QuarkusGrpcHandler extends GrpcHandler {
      * @param executor the executor for async operations (qualified with {@code @Internal})
      */
     @Inject
-    public QuarkusGrpcHandler(@PublicAgentCard AgentCard agentCard,
+    public QuarkusGrpcHandler(@PublicAgentCard Instance<AgentCard> agentCard,
                               @ExtendedAgentCard Instance<AgentCard> extendedAgentCard,
                               RequestHandler requestHandler,
                               Instance<CallContextFactory> callContextFactoryInstance,
                               @Internal Executor executor) {
         this.agentCard = agentCard;
-        if (extendedAgentCard != null && extendedAgentCard.isResolvable()) {
-            this.extendedAgentCard = extendedAgentCard.get();
-        } else {
-            this.extendedAgentCard = null;
-        }
+        this.extendedAgentCard = extendedAgentCard;
         this.requestHandler = requestHandler;
         this.callContextFactoryInstance = callContextFactoryInstance;
         this.executor = executor;
@@ -129,12 +125,15 @@ public class QuarkusGrpcHandler extends GrpcHandler {
 
     @Override
     protected AgentCard getAgentCard() {
-        return agentCard;
+        return agentCard.get();
     }
 
     @Override
     protected AgentCard getExtendedAgentCard() {
-        return extendedAgentCard;
+        if (extendedAgentCard != null && extendedAgentCard.isResolvable()) {
+            return extendedAgentCard.get();
+        }
+        return null;
     }
 
     @Override

--- a/reference/grpc/src/test/java/org/a2aproject/sdk/server/grpc/quarkus/QuarkusGrpcHandlerLazyResolutionTest.java
+++ b/reference/grpc/src/test/java/org/a2aproject/sdk/server/grpc/quarkus/QuarkusGrpcHandlerLazyResolutionTest.java
@@ -1,0 +1,44 @@
+package org.a2aproject.sdk.server.grpc.quarkus;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.a2aproject.sdk.server.ResolvedInstance;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.transport.grpc.handler.CallContextFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Verifies that {@link QuarkusGrpcHandler} does not eagerly resolve {@link Instance} parameters
+ * during construction. This guards against the regression described in
+ * <a href="https://github.com/a2aproject/a2a-java/issues/1033">issue #1033</a>, where eager
+ * resolution prevented startup when the AgentCard producer depended on the HTTP server address.
+ */
+class QuarkusGrpcHandlerLazyResolutionTest {
+
+    @Test
+    void constructorDoesNotResolveAgentCardInstances() {
+        Instance<AgentCard> throwOnGet = new ResolvedInstance<>(null) {
+            @Override
+            public AgentCard get() {
+                throw new AssertionError("Instance.get() must not be called during construction");
+            }
+
+            @Override
+            public boolean isUnsatisfied() {
+                return false;
+            }
+        };
+
+        @SuppressWarnings("unchecked")
+        Instance<CallContextFactory> emptyCallContextFactory = (Instance<CallContextFactory>) (Instance<?>) new ResolvedInstance<>(null);
+
+        assertDoesNotThrow(() -> new QuarkusGrpcHandler(
+                throwOnGet,
+                throwOnGet,
+                null,
+                emptyCallContextFactory,
+                Runnable::run));
+    }
+}

--- a/reference/grpc/src/test/java/org/a2aproject/sdk/server/grpc/quarkus/QuarkusGrpcHandlerLazyResolutionTest.java
+++ b/reference/grpc/src/test/java/org/a2aproject/sdk/server/grpc/quarkus/QuarkusGrpcHandlerLazyResolutionTest.java
@@ -1,13 +1,23 @@
 package org.a2aproject.sdk.server.grpc.quarkus;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import jakarta.enterprise.inject.Instance;
 
-import org.a2aproject.sdk.server.ResolvedInstance;
+import org.a2aproject.sdk.server.FixedInstance;
+import org.a2aproject.sdk.server.TestInstances;
+import org.a2aproject.sdk.spec.AgentCapabilities;
 import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.AgentInterface;
 import org.a2aproject.sdk.transport.grpc.handler.CallContextFactory;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies that {@link QuarkusGrpcHandler} does not eagerly resolve {@link Instance} parameters
@@ -19,26 +29,45 @@ class QuarkusGrpcHandlerLazyResolutionTest {
 
     @Test
     void constructorDoesNotResolveAgentCardInstances() {
-        Instance<AgentCard> throwOnGet = new ResolvedInstance<>(null) {
-            @Override
-            public AgentCard get() {
-                throw new AssertionError("Instance.get() must not be called during construction");
-            }
-
-            @Override
-            public boolean isUnsatisfied() {
-                return false;
-            }
-        };
-
-        @SuppressWarnings("unchecked")
-        Instance<CallContextFactory> emptyCallContextFactory = (Instance<CallContextFactory>) (Instance<?>) new ResolvedInstance<>(null);
+        Instance<AgentCard> throwOnGet = TestInstances.throwOnGet();
 
         assertDoesNotThrow(() -> new QuarkusGrpcHandler(
                 throwOnGet,
                 throwOnGet,
                 null,
-                emptyCallContextFactory,
+                FixedInstance.empty(),
                 Runnable::run));
+    }
+
+    @Test
+    void getExtendedAgentCardResolvesOnAccess() {
+        AtomicBoolean resolved = new AtomicBoolean(false);
+        AgentCard expected = AgentCard.builder()
+                .name("extended").description("test").version("1.0.0")
+                .supportedInterfaces(Collections.singletonList(new AgentInterface("gRPC", "http://localhost:9999")))
+                .capabilities(AgentCapabilities.builder().build())
+                .defaultInputModes(new ArrayList<>())
+                .defaultOutputModes(new ArrayList<>())
+                .skills(new ArrayList<>()).build();
+
+        Instance<AgentCard> trackingInstance = new FixedInstance<>(expected) {
+            @Override
+            public AgentCard get() {
+                resolved.set(true);
+                return super.get();
+            }
+        };
+
+        QuarkusGrpcHandler handler = new QuarkusGrpcHandler(
+                FixedInstance.empty(),
+                trackingInstance,
+                null,
+                FixedInstance.empty(),
+                Runnable::run);
+
+        assertFalse(resolved.get(), "should not resolve during construction");
+        AgentCard result = handler.getExtendedAgentCard();
+        assertTrue(resolved.get(), "should resolve on access");
+        assertEquals(expected, result);
     }
 }

--- a/server-common/src/main/java/org/a2aproject/sdk/server/AgentCardValidator.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/AgentCardValidator.java
@@ -5,8 +5,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
+import jakarta.enterprise.inject.Instance;
 
 import org.a2aproject.sdk.spec.AgentCard;
 import org.a2aproject.sdk.spec.AgentInterface;
@@ -26,9 +31,50 @@ public class AgentCardValidator {
     public static final String SKIP_REST_PROPERTY = "org.a2aproject.sdk.transport.rest.skipValidation";
 
     /**
+     * Resolves an {@link AgentCard} from the given {@link Instance} and validates its transport
+     * configuration exactly once using the default {@link #validateTransportConfiguration} check.
+     * The {@code transportValidated} guard is reset on failure so validation can be retried on
+     * the next call.
+     *
+     * @param agentCardInstance the CDI instance holding the agent card
+     * @param transportValidated atomic guard ensuring validation runs once
+     * @return the resolved agent card
+     */
+    public static AgentCard resolveAndValidateOnce(Instance<AgentCard> agentCardInstance,
+            AtomicBoolean transportValidated) {
+        return resolveAndValidateOnce(agentCardInstance::get, transportValidated,
+                AgentCardValidator::validateTransportConfiguration);
+    }
+
+    /**
+     * Obtains an {@link AgentCard} from the given supplier and applies the provided validator
+     * exactly once. The {@code transportValidated} guard is reset on failure so validation can
+     * be retried on the next call.
+     *
+     * @param agentCardSupplier supplier that produces the agent card
+     * @param transportValidated atomic guard ensuring validation runs once
+     * @param validator validation logic to apply on first access
+     * @return the resolved agent card
+     */
+    public static AgentCard resolveAndValidateOnce(Supplier<AgentCard> agentCardSupplier,
+            AtomicBoolean transportValidated,
+            Consumer<AgentCard> validator) {
+        AgentCard card = agentCardSupplier.get();
+        if (transportValidated.compareAndSet(false, true)) {
+            try {
+                validator.accept(card);
+            } catch (RuntimeException e) {
+                transportValidated.set(false);
+                throw e;
+            }
+        }
+        return card;
+    }
+
+    /**
      * Validates the transport configuration of an AgentCard against available transports found on the classpath.
      * Logs warnings for missing transports and errors for unsupported transports.
-     * 
+     *
      * @param agentCard the agent card to validate
      */
     public static void validateTransportConfiguration(AgentCard agentCard) {

--- a/server-common/src/main/java/org/a2aproject/sdk/server/FixedInstance.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/FixedInstance.java
@@ -11,17 +11,42 @@ import jakarta.enterprise.util.TypeLiteral;
 import org.jspecify.annotations.Nullable;
 
 /**
- * An {@link Instance} wrapper for a pre-resolved value, for use in non-CDI contexts
- * such as convenience constructors and tests.
+ * A static {@link Instance} wrapper holding a pre-resolved (or absent) value,
+ * for use in non-CDI contexts such as convenience constructors and tests.
+ * A {@code null} value represents an unsatisfied instance.
+ *
+ * <p>Usage example (wrapping a concrete value):
+ * <pre>{@code
+ * Instance<AgentCard> instance = new FixedInstance<>(myAgentCard);
+ * }</pre>
+ *
+ * <p>Usage example (empty / unsatisfied):
+ * <pre>{@code
+ * Instance<AgentCard> empty = FixedInstance.empty();
+ * }</pre>
  *
  * @param <T> the bean type
  */
-public class ResolvedInstance<T> implements Instance<T> {
+public class FixedInstance<T> implements Instance<T> {
+
+    @SuppressWarnings("rawtypes")
+    private static final FixedInstance EMPTY = new FixedInstance<>(null);
 
     private final @Nullable T value;
 
-    public ResolvedInstance(@Nullable T value) {
+    public FixedInstance(@Nullable T value) {
         this.value = value;
+    }
+
+    /**
+     * Returns a {@code FixedInstance} with no value (unsatisfied).
+     *
+     * @param <T> the bean type
+     * @return an empty instance
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> FixedInstance<T> empty() {
+        return (FixedInstance<T>) EMPTY;
     }
 
     @Override

--- a/server-common/src/main/java/org/a2aproject/sdk/server/ResolvedInstance.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/ResolvedInstance.java
@@ -1,0 +1,78 @@
+package org.a2aproject.sdk.server;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.Iterator;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.UnsatisfiedResolutionException;
+import jakarta.enterprise.util.TypeLiteral;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An {@link Instance} wrapper for a pre-resolved value, for use in non-CDI contexts
+ * such as convenience constructors and tests.
+ *
+ * @param <T> the bean type
+ */
+public class ResolvedInstance<T> implements Instance<T> {
+
+    private final @Nullable T value;
+
+    public ResolvedInstance(@Nullable T value) {
+        this.value = value;
+    }
+
+    @Override
+    public T get() {
+        if (value == null) {
+            throw new UnsatisfiedResolutionException("No value available");
+        }
+        return value;
+    }
+
+    @Override
+    public boolean isUnsatisfied() {
+        return value == null;
+    }
+
+    @Override
+    public boolean isAmbiguous() {
+        return false;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return value != null ? Collections.singleton(value).iterator() : Collections.emptyIterator();
+    }
+
+    @Override
+    public void destroy(T instance) {
+    }
+
+    @Override
+    public Instance<T> select(Annotation... qualifiers) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <U extends T> Instance<U> select(Class<U> subtype, Annotation... qualifiers) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <U extends T> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Handle<T> getHandle() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterable<? extends Handle<T>> handles() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/server-common/src/test/java/org/a2aproject/sdk/server/AgentCardValidatorTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/AgentCardValidatorTest.java
@@ -1,6 +1,7 @@
 package org.a2aproject.sdk.server;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -8,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -227,6 +230,44 @@ public class AgentCardValidatorTest {
         } finally {
             System.clearProperty(AgentCardValidator.SKIP_GRPC_PROPERTY);
         }
+    }
+
+    @Test
+    void resolveAndValidateOnceRetriesAfterFailure() {
+        AgentCard card = createTestAgentCardBuilder().build();
+        AtomicBoolean guard = new AtomicBoolean(false);
+        AtomicInteger validationCount = new AtomicInteger(0);
+
+        assertThrows(IllegalStateException.class, () ->
+                AgentCardValidator.resolveAndValidateOnce(
+                        () -> card, guard, c -> {
+                            validationCount.incrementAndGet();
+                            throw new IllegalStateException("transient failure");
+                        }));
+
+        assertFalse(guard.get(), "guard should be reset after failure");
+        assertEquals(1, validationCount.get());
+
+        AgentCard result = AgentCardValidator.resolveAndValidateOnce(
+                () -> card, guard, c -> validationCount.incrementAndGet());
+
+        assertTrue(guard.get(), "guard should be set after success");
+        assertEquals(2, validationCount.get());
+        assertEquals(card, result);
+    }
+
+    @Test
+    void resolveAndValidateOnceSkipsValidationOnSubsequentCalls() {
+        AgentCard card = createTestAgentCardBuilder().build();
+        AtomicBoolean guard = new AtomicBoolean(false);
+        AtomicInteger validationCount = new AtomicInteger(0);
+
+        AgentCardValidator.resolveAndValidateOnce(
+                () -> card, guard, c -> validationCount.incrementAndGet());
+        AgentCardValidator.resolveAndValidateOnce(
+                () -> card, guard, c -> validationCount.incrementAndGet());
+
+        assertEquals(1, validationCount.get(), "validation should run only once");
     }
 
     // A simple log handler for testing

--- a/server-common/src/test/java/org/a2aproject/sdk/server/TestInstances.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/TestInstances.java
@@ -1,0 +1,33 @@
+package org.a2aproject.sdk.server;
+
+import jakarta.enterprise.inject.Instance;
+
+/**
+ * Factory methods for {@link Instance} test doubles built on {@link FixedInstance}.
+ */
+public final class TestInstances {
+
+    private TestInstances() {
+    }
+
+    /**
+     * Returns an {@link Instance} that throws {@link AssertionError} on {@link Instance#get()},
+     * useful for verifying that a constructor does not eagerly resolve the instance.
+     *
+     * @param <T> the bean type
+     * @return an instance that throws on resolution
+     */
+    public static <T> Instance<T> throwOnGet() {
+        return new FixedInstance<>(null) {
+            @Override
+            public T get() {
+                throw new AssertionError("Instance.get() must not be called during construction");
+            }
+
+            @Override
+            public boolean isUnsatisfied() {
+                return false;
+            }
+        };
+    }
+}

--- a/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
+++ b/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
@@ -838,8 +838,13 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     private AgentCard getAgentCardInternal() {
         AgentCard agentCard = getAgentCard();
         if (initialised.compareAndSet(false, true)) {
-            // Validate transport configuration with proper classloader context
-            validateTransportConfigurationWithCorrectClassLoader(agentCard);
+            try {
+                // Validate transport configuration with proper classloader context
+                validateTransportConfigurationWithCorrectClassLoader(agentCard);
+            } catch (RuntimeException e) {
+                initialised.set(false);
+                throw e;
+            }
         }
         return agentCard;
     }

--- a/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
+++ b/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
@@ -159,7 +159,7 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     // Without this we get intermittent failures
     private static volatile @Nullable Runnable streamingSubscribedRunnable;
 
-    private final AtomicBoolean initialised = new AtomicBoolean(false);
+    private final AtomicBoolean transportValidated = new AtomicBoolean(false);
 
     private static final Logger LOGGER = Logger.getLogger(GrpcHandler.class.getName());
 
@@ -279,7 +279,7 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     @Override
     public void createTaskPushNotificationConfig(org.a2aproject.sdk.grpc.TaskPushNotificationConfig request,
                                                StreamObserver<org.a2aproject.sdk.grpc.TaskPushNotificationConfig> responseObserver) {
-        if (!getAgentCardInternal().capabilities().pushNotifications()) {
+        if (!resolveAgentCard().capabilities().pushNotifications()) {
             handleError(responseObserver, new PushNotificationNotSupportedError());
             return;
         }
@@ -302,7 +302,7 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     @Override
     public void getTaskPushNotificationConfig(org.a2aproject.sdk.grpc.GetTaskPushNotificationConfigRequest request,
                                             StreamObserver<org.a2aproject.sdk.grpc.TaskPushNotificationConfig> responseObserver) {
-        if (!getAgentCardInternal().capabilities().pushNotifications()) {
+        if (!resolveAgentCard().capabilities().pushNotifications()) {
             handleError(responseObserver, new PushNotificationNotSupportedError());
             return;
         }
@@ -325,7 +325,7 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     @Override
     public void listTaskPushNotificationConfigs(org.a2aproject.sdk.grpc.ListTaskPushNotificationConfigsRequest request,
                                              StreamObserver<org.a2aproject.sdk.grpc.ListTaskPushNotificationConfigsResponse> responseObserver) {
-        if (!getAgentCardInternal().capabilities().pushNotifications()) {
+        if (!resolveAgentCard().capabilities().pushNotifications()) {
             handleError(responseObserver, new PushNotificationNotSupportedError());
             return;
         }
@@ -386,7 +386,7 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     @Override
     public void sendStreamingMessage(org.a2aproject.sdk.grpc.SendMessageRequest request,
                                      StreamObserver<org.a2aproject.sdk.grpc.StreamResponse> responseObserver) {
-        if (!getAgentCardInternal().capabilities().streaming()) {
+        if (!resolveAgentCard().capabilities().streaming()) {
             handleError(responseObserver,
                     new UnsupportedOperationError(null, "Streaming is not supported by the agent", null));
             return;
@@ -410,7 +410,7 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     @Override
     public void subscribeToTask(org.a2aproject.sdk.grpc.SubscribeToTaskRequest request,
                                  StreamObserver<org.a2aproject.sdk.grpc.StreamResponse> responseObserver) {
-        if (!getAgentCardInternal().capabilities().streaming()) {
+        if (!resolveAgentCard().capabilities().streaming()) {
             handleError(responseObserver,
                     new UnsupportedOperationError(null, "Streaming is not supported by the agent", null));
             return;
@@ -584,7 +584,7 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     @Override
     public void deleteTaskPushNotificationConfig(org.a2aproject.sdk.grpc.DeleteTaskPushNotificationConfigRequest request,
                                                StreamObserver<Empty> responseObserver) {
-        if (!getAgentCardInternal().capabilities().pushNotifications()) {
+        if (!resolveAgentCard().capabilities().pushNotifications()) {
             handleError(responseObserver, new PushNotificationNotSupportedError());
             return;
         }
@@ -707,8 +707,8 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
             context = factory.create(responseObserver); // Fall back to basic create() method for now
         }
 
-        A2AVersionValidator.validateProtocolVersion(getAgentCardInternal(), context);
-        A2AExtensions.validateRequiredExtensions(getAgentCardInternal(), context);
+        A2AVersionValidator.validateProtocolVersion(resolveAgentCard(), context);
+        A2AExtensions.validateRequiredExtensions(resolveAgentCard(), context);
         return context;
     }
 
@@ -835,18 +835,9 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
     }
 
 
-    private AgentCard getAgentCardInternal() {
-        AgentCard agentCard = getAgentCard();
-        if (initialised.compareAndSet(false, true)) {
-            try {
-                // Validate transport configuration with proper classloader context
-                validateTransportConfigurationWithCorrectClassLoader(agentCard);
-            } catch (RuntimeException e) {
-                initialised.set(false);
-                throw e;
-            }
-        }
-        return agentCard;
+    private AgentCard resolveAgentCard() {
+        return AgentCardValidator.resolveAndValidateOnce(
+                this::getAgentCard, transportValidated, this::validateTransportConfigurationWithCorrectClassLoader);
     }
 
     private void validateTransportConfigurationWithCorrectClassLoader(AgentCard agentCard) {

--- a/transport/jsonrpc/src/main/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandler.java
+++ b/transport/jsonrpc/src/main/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandler.java
@@ -38,8 +38,8 @@ import org.a2aproject.sdk.jsonrpc.common.wrappers.SendStreamingMessageResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.SubscribeToTaskRequest;
 import org.a2aproject.sdk.server.AgentCardValidator;
 import org.a2aproject.sdk.server.ExtendedAgentCard;
+import org.a2aproject.sdk.server.FixedInstance;
 import org.a2aproject.sdk.server.PublicAgentCard;
-import org.a2aproject.sdk.server.ResolvedInstance;
 import org.a2aproject.sdk.server.ServerCallContext;
 import org.a2aproject.sdk.server.auth.TaskOperation;
 import org.a2aproject.sdk.server.extensions.A2AExtensions;
@@ -186,7 +186,7 @@ public class JSONRPCHandler {
      * @param executor the executor for asynchronous operations
      */
     public JSONRPCHandler(@PublicAgentCard AgentCard agentCard, RequestHandler requestHandler, Executor executor) {
-        this(new ResolvedInstance<>(agentCard), null, requestHandler, executor);
+        this(new FixedInstance<>(agentCard), null, requestHandler, executor);
     }
 
     /**
@@ -233,8 +233,8 @@ public class JSONRPCHandler {
      */
     public SendMessageResponse onMessageSend(SendMessageRequest request, ServerCallContext context) {
         try {
-            A2AVersionValidator.validateProtocolVersion(agentCard(), context);
-            A2AExtensions.validateRequiredExtensions(agentCard(), context);
+            A2AVersionValidator.validateProtocolVersion(resolveAgentCard(), context);
+            A2AExtensions.validateRequiredExtensions(resolveAgentCard(), context);
             EventKind taskOrMessage = requestHandler.onMessageSend(request.getParams(), context);
             return new SendMessageResponse(request.getId(), taskOrMessage);
         } catch (A2AError e) {
@@ -282,7 +282,7 @@ public class JSONRPCHandler {
      */
     public Flow.Publisher<SendStreamingMessageResponse> onMessageSendStream(
             SendStreamingMessageRequest request, ServerCallContext context) {
-        if (!agentCard().capabilities().streaming()) {
+        if (!resolveAgentCard().capabilities().streaming()) {
             return ZeroPublisher.fromItems(
                     new SendStreamingMessageResponse(
                             request.getId(),
@@ -290,8 +290,8 @@ public class JSONRPCHandler {
         }
 
         try {
-            A2AVersionValidator.validateProtocolVersion(agentCard(), context);
-            A2AExtensions.validateRequiredExtensions(agentCard(), context);
+            A2AVersionValidator.validateProtocolVersion(resolveAgentCard(), context);
+            A2AExtensions.validateRequiredExtensions(resolveAgentCard(), context);
             Flow.Publisher<StreamingEventKind> publisher =
                     requestHandler.onMessageSendStream(request.getParams(), context);
             // We can't use the convertingProcessor convenience method since that propagates any errors as an error handled
@@ -379,7 +379,7 @@ public class JSONRPCHandler {
      */
     public Flow.Publisher<SendStreamingMessageResponse> onSubscribeToTask(
             SubscribeToTaskRequest request, ServerCallContext context) throws A2AError {
-        if (!agentCard().capabilities().streaming()) {
+        if (!resolveAgentCard().capabilities().streaming()) {
             return ZeroPublisher.fromItems(
                     new SendStreamingMessageResponse(
                             request.getId(),
@@ -426,7 +426,7 @@ public class JSONRPCHandler {
      */
     public GetTaskPushNotificationConfigResponse getPushNotificationConfig(
             GetTaskPushNotificationConfigRequest request, ServerCallContext context) {
-        if (!agentCard().capabilities().pushNotifications()) {
+        if (!resolveAgentCard().capabilities().pushNotifications()) {
             return new GetTaskPushNotificationConfigResponse(request.getId(),
                     new PushNotificationNotSupportedError());
         }
@@ -468,7 +468,7 @@ public class JSONRPCHandler {
      */
     public CreateTaskPushNotificationConfigResponse setPushNotificationConfig(
             CreateTaskPushNotificationConfigRequest request, ServerCallContext context) {
-        if (!agentCard().capabilities().pushNotifications()) {
+        if (!resolveAgentCard().capabilities().pushNotifications()) {
             return new CreateTaskPushNotificationConfigResponse(request.getId(),
                     new PushNotificationNotSupportedError());
         }
@@ -591,7 +591,7 @@ public class JSONRPCHandler {
      */
     public ListTaskPushNotificationConfigsResponse listPushNotificationConfigs(
             ListTaskPushNotificationConfigsRequest request, ServerCallContext context) {
-        if (!agentCard().capabilities().pushNotifications()) {
+        if (!resolveAgentCard().capabilities().pushNotifications()) {
             return new ListTaskPushNotificationConfigsResponse(request.getId(),
                     new PushNotificationNotSupportedError());
         }
@@ -633,7 +633,7 @@ public class JSONRPCHandler {
      */
     public DeleteTaskPushNotificationConfigResponse deletePushNotificationConfig(
             DeleteTaskPushNotificationConfigRequest request, ServerCallContext context) {
-        if (!agentCard().capabilities().pushNotifications()) {
+        if (!resolveAgentCard().capabilities().pushNotifications()) {
             return new DeleteTaskPushNotificationConfigResponse(request.getId(),
                     new PushNotificationNotSupportedError());
         }
@@ -673,7 +673,7 @@ public class JSONRPCHandler {
     // TODO: Add authentication (https://github.com/a2aproject/a2a-java/issues/77)
     public GetExtendedAgentCardResponse onGetExtendedCardRequest(
             GetExtendedAgentCardRequest request, ServerCallContext context) {
-        if (!agentCard().capabilities().extendedAgentCard()) {
+        if (!resolveAgentCard().capabilities().extendedAgentCard()) {
             return new GetExtendedAgentCardResponse(request.getId(), new UnsupportedOperationError());
         }
         if (extendedAgentCard == null || !extendedAgentCard.isResolvable()) {
@@ -700,20 +700,11 @@ public class JSONRPCHandler {
      * @see AgentCard
      */
     public AgentCard getAgentCard() {
-        return agentCard();
+        return resolveAgentCard();
     }
 
-    private AgentCard agentCard() {
-        AgentCard card = agentCardInstance.get();
-        if (transportValidated.compareAndSet(false, true)) {
-            try {
-                AgentCardValidator.validateTransportConfiguration(card);
-            } catch (RuntimeException e) {
-                transportValidated.set(false);
-                throw e;
-            }
-        }
-        return card;
+    private AgentCard resolveAgentCard() {
+        return AgentCardValidator.resolveAndValidateOnce(agentCardInstance, transportValidated);
     }
 
     private Flow.Publisher<SendStreamingMessageResponse> convertToSendStreamingMessageResponse(

--- a/transport/jsonrpc/src/main/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandler.java
+++ b/transport/jsonrpc/src/main/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandler.java
@@ -5,6 +5,7 @@ import static org.a2aproject.sdk.server.util.async.AsyncUtils.createTubeConfig;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -12,8 +13,11 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
+import mutiny.zero.ZeroPublisher;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.CancelTaskRequest;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.CancelTaskResponse;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.CreateTaskPushNotificationConfigRequest;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.CreateTaskPushNotificationConfigResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.DeleteTaskPushNotificationConfigRequest;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.DeleteTaskPushNotificationConfigResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.GetExtendedAgentCardRequest;
@@ -31,13 +35,13 @@ import org.a2aproject.sdk.jsonrpc.common.wrappers.SendMessageRequest;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.SendMessageResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.SendStreamingMessageRequest;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.SendStreamingMessageResponse;
-import org.a2aproject.sdk.jsonrpc.common.wrappers.CreateTaskPushNotificationConfigRequest;
-import org.a2aproject.sdk.jsonrpc.common.wrappers.CreateTaskPushNotificationConfigResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.SubscribeToTaskRequest;
 import org.a2aproject.sdk.server.AgentCardValidator;
 import org.a2aproject.sdk.server.ExtendedAgentCard;
 import org.a2aproject.sdk.server.PublicAgentCard;
+import org.a2aproject.sdk.server.ResolvedInstance;
 import org.a2aproject.sdk.server.ServerCallContext;
+import org.a2aproject.sdk.server.auth.TaskOperation;
 import org.a2aproject.sdk.server.extensions.A2AExtensions;
 import org.a2aproject.sdk.server.requesthandlers.RequestHandler;
 import org.a2aproject.sdk.server.util.async.Internal;
@@ -45,19 +49,16 @@ import org.a2aproject.sdk.server.version.A2AVersionValidator;
 import org.a2aproject.sdk.spec.A2AError;
 import org.a2aproject.sdk.spec.AgentCard;
 import org.a2aproject.sdk.spec.CancelTaskParams;
-import org.a2aproject.sdk.spec.ExtendedAgentCardNotConfiguredError;
 import org.a2aproject.sdk.spec.EventKind;
+import org.a2aproject.sdk.spec.ExtendedAgentCardNotConfiguredError;
 import org.a2aproject.sdk.spec.InternalError;
-import org.a2aproject.sdk.spec.UnsupportedOperationError;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsResult;
 import org.a2aproject.sdk.spec.PushNotificationNotSupportedError;
 import org.a2aproject.sdk.spec.StreamingEventKind;
 import org.a2aproject.sdk.spec.Task;
 import org.a2aproject.sdk.spec.TaskNotFoundError;
 import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
-
-import mutiny.zero.ZeroPublisher;
-import org.a2aproject.sdk.server.auth.TaskOperation;
+import org.a2aproject.sdk.spec.UnsupportedOperationError;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -139,10 +140,11 @@ public class JSONRPCHandler {
     // Fields set by constructor injection cannot be final. We need a noargs constructor for
     // Jakarta compatibility, and it seems that making fields set by constructor injection
     // final, is not proxyable in all runtimes
-    private AgentCard agentCard;
+    private Instance<AgentCard> agentCardInstance;
     private @Nullable Instance<AgentCard> extendedAgentCard;
     private RequestHandler requestHandler;
     private Executor executor;
+    private final AtomicBoolean transportValidated = new AtomicBoolean(false);
 
     /**
      * No-args constructor for CDI proxy creation.
@@ -152,7 +154,7 @@ public class JSONRPCHandler {
     @SuppressWarnings("NullAway")
     protected JSONRPCHandler() {
         // For CDI proxy creation
-        this.agentCard = null;
+        this.agentCardInstance = null;
         this.extendedAgentCard = null;
         this.requestHandler = null;
         this.executor = null;
@@ -161,21 +163,19 @@ public class JSONRPCHandler {
     /**
      * Creates a JSON-RPC handler with full CDI injection support.
      *
-     * @param agentCard the public agent card containing agent capabilities
+     * @param agentCardInstance the public agent card instance containing agent capabilities
      * @param extendedAgentCard optional extended agent card instance
      * @param requestHandler the handler for processing A2A requests
      * @param executor the executor for asynchronous operations
      */
     @Inject
-    public JSONRPCHandler(@PublicAgentCard AgentCard agentCard, @Nullable @ExtendedAgentCard Instance<AgentCard> extendedAgentCard,
+    public JSONRPCHandler(@PublicAgentCard Instance<AgentCard> agentCardInstance,
+                          @Nullable @ExtendedAgentCard Instance<AgentCard> extendedAgentCard,
                           RequestHandler requestHandler, @Internal Executor executor) {
-        this.agentCard = agentCard;
+        this.agentCardInstance = agentCardInstance;
         this.extendedAgentCard = extendedAgentCard;
         this.requestHandler = requestHandler;
         this.executor = executor;
-
-        // Validate transport configuration
-        AgentCardValidator.validateTransportConfiguration(agentCard);
     }
 
     /**
@@ -186,7 +186,7 @@ public class JSONRPCHandler {
      * @param executor the executor for asynchronous operations
      */
     public JSONRPCHandler(@PublicAgentCard AgentCard agentCard, RequestHandler requestHandler, Executor executor) {
-        this(agentCard, null, requestHandler, executor);
+        this(new ResolvedInstance<>(agentCard), null, requestHandler, executor);
     }
 
     /**
@@ -233,8 +233,8 @@ public class JSONRPCHandler {
      */
     public SendMessageResponse onMessageSend(SendMessageRequest request, ServerCallContext context) {
         try {
-            A2AVersionValidator.validateProtocolVersion(agentCard, context);
-            A2AExtensions.validateRequiredExtensions(agentCard, context);
+            A2AVersionValidator.validateProtocolVersion(agentCard(), context);
+            A2AExtensions.validateRequiredExtensions(agentCard(), context);
             EventKind taskOrMessage = requestHandler.onMessageSend(request.getParams(), context);
             return new SendMessageResponse(request.getId(), taskOrMessage);
         } catch (A2AError e) {
@@ -282,7 +282,7 @@ public class JSONRPCHandler {
      */
     public Flow.Publisher<SendStreamingMessageResponse> onMessageSendStream(
             SendStreamingMessageRequest request, ServerCallContext context) {
-        if (!agentCard.capabilities().streaming()) {
+        if (!agentCard().capabilities().streaming()) {
             return ZeroPublisher.fromItems(
                     new SendStreamingMessageResponse(
                             request.getId(),
@@ -290,8 +290,8 @@ public class JSONRPCHandler {
         }
 
         try {
-            A2AVersionValidator.validateProtocolVersion(agentCard, context);
-            A2AExtensions.validateRequiredExtensions(agentCard, context);
+            A2AVersionValidator.validateProtocolVersion(agentCard(), context);
+            A2AExtensions.validateRequiredExtensions(agentCard(), context);
             Flow.Publisher<StreamingEventKind> publisher =
                     requestHandler.onMessageSendStream(request.getParams(), context);
             // We can't use the convertingProcessor convenience method since that propagates any errors as an error handled
@@ -379,7 +379,7 @@ public class JSONRPCHandler {
      */
     public Flow.Publisher<SendStreamingMessageResponse> onSubscribeToTask(
             SubscribeToTaskRequest request, ServerCallContext context) throws A2AError {
-        if (!agentCard.capabilities().streaming()) {
+        if (!agentCard().capabilities().streaming()) {
             return ZeroPublisher.fromItems(
                     new SendStreamingMessageResponse(
                             request.getId(),
@@ -426,7 +426,7 @@ public class JSONRPCHandler {
      */
     public GetTaskPushNotificationConfigResponse getPushNotificationConfig(
             GetTaskPushNotificationConfigRequest request, ServerCallContext context) {
-        if (!agentCard.capabilities().pushNotifications()) {
+        if (!agentCard().capabilities().pushNotifications()) {
             return new GetTaskPushNotificationConfigResponse(request.getId(),
                     new PushNotificationNotSupportedError());
         }
@@ -468,7 +468,7 @@ public class JSONRPCHandler {
      */
     public CreateTaskPushNotificationConfigResponse setPushNotificationConfig(
             CreateTaskPushNotificationConfigRequest request, ServerCallContext context) {
-        if (!agentCard.capabilities().pushNotifications()) {
+        if (!agentCard().capabilities().pushNotifications()) {
             return new CreateTaskPushNotificationConfigResponse(request.getId(),
                     new PushNotificationNotSupportedError());
         }
@@ -591,7 +591,7 @@ public class JSONRPCHandler {
      */
     public ListTaskPushNotificationConfigsResponse listPushNotificationConfigs(
             ListTaskPushNotificationConfigsRequest request, ServerCallContext context) {
-        if ( !agentCard.capabilities().pushNotifications()) {
+        if (!agentCard().capabilities().pushNotifications()) {
             return new ListTaskPushNotificationConfigsResponse(request.getId(),
                     new PushNotificationNotSupportedError());
         }
@@ -633,7 +633,7 @@ public class JSONRPCHandler {
      */
     public DeleteTaskPushNotificationConfigResponse deletePushNotificationConfig(
             DeleteTaskPushNotificationConfigRequest request, ServerCallContext context) {
-        if ( !agentCard.capabilities().pushNotifications()) {
+        if (!agentCard().capabilities().pushNotifications()) {
             return new DeleteTaskPushNotificationConfigResponse(request.getId(),
                     new PushNotificationNotSupportedError());
         }
@@ -673,7 +673,7 @@ public class JSONRPCHandler {
     // TODO: Add authentication (https://github.com/a2aproject/a2a-java/issues/77)
     public GetExtendedAgentCardResponse onGetExtendedCardRequest(
             GetExtendedAgentCardRequest request, ServerCallContext context) {
-        if (!agentCard.capabilities().extendedAgentCard()) {
+        if (!agentCard().capabilities().extendedAgentCard()) {
             return new GetExtendedAgentCardResponse(request.getId(), new UnsupportedOperationError());
         }
         if (extendedAgentCard == null || !extendedAgentCard.isResolvable()) {
@@ -700,7 +700,20 @@ public class JSONRPCHandler {
      * @see AgentCard
      */
     public AgentCard getAgentCard() {
-        return agentCard;
+        return agentCard();
+    }
+
+    private AgentCard agentCard() {
+        AgentCard card = agentCardInstance.get();
+        if (transportValidated.compareAndSet(false, true)) {
+            try {
+                AgentCardValidator.validateTransportConfiguration(card);
+            } catch (RuntimeException e) {
+                transportValidated.set(false);
+                throw e;
+            }
+        }
+        return card;
     }
 
     private Flow.Publisher<SendStreamingMessageResponse> convertToSendStreamingMessageResponse(

--- a/transport/jsonrpc/src/test/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -80,9 +80,12 @@ import org.a2aproject.sdk.spec.TaskState;
 import org.a2aproject.sdk.spec.TaskStatus;
 import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
 import org.a2aproject.sdk.spec.TextPart;
+import org.a2aproject.sdk.server.TestInstances;
 import org.a2aproject.sdk.spec.UnsupportedOperationError;
 import org.a2aproject.sdk.spec.VersionNotSupportedError;
+
 import jakarta.enterprise.inject.Instance;
+
 import mutiny.zero.ZeroPublisher;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
@@ -2028,10 +2031,8 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
     }
 
     @Test
-    void constructorDoesNotResolveAgentCardInstance() {
-        @SuppressWarnings("unchecked")
-        Instance<AgentCard> throwOnGet = Mockito.mock(Instance.class);
-        Mockito.when(throwOnGet.get()).thenThrow(new AssertionError("Instance.get() must not be called during construction"));
+    void constructorDoesNotResolveAgentCardInstances() {
+        Instance<AgentCard> throwOnGet = TestInstances.throwOnGet();
 
         assertDoesNotThrow(() -> new JSONRPCHandler(throwOnGet, null, requestHandler, internalExecutor));
     }

--- a/transport/jsonrpc/src/test/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -1,5 +1,6 @@
 package org.a2aproject.sdk.transport.jsonrpc.handler;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -81,6 +82,7 @@ import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
 import org.a2aproject.sdk.spec.TextPart;
 import org.a2aproject.sdk.spec.UnsupportedOperationError;
 import org.a2aproject.sdk.spec.VersionNotSupportedError;
+import jakarta.enterprise.inject.Instance;
 import mutiny.zero.ZeroPublisher;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
@@ -2023,5 +2025,14 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
         assertEquals(0, result.totalSize(), "totalSize should be 0");
         assertEquals(0, result.pageSize(), "pageSize should be 0");
         // nextPageToken can be null for empty results
+    }
+
+    @Test
+    void constructorDoesNotResolveAgentCardInstance() {
+        @SuppressWarnings("unchecked")
+        Instance<AgentCard> throwOnGet = Mockito.mock(Instance.class);
+        Mockito.when(throwOnGet.get()).thenThrow(new AssertionError("Instance.get() must not be called during construction"));
+
+        assertDoesNotThrow(() -> new JSONRPCHandler(throwOnGet, null, requestHandler, internalExecutor));
     }
 }

--- a/transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java
+++ b/transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java
@@ -34,8 +34,8 @@ import org.a2aproject.sdk.jsonrpc.common.wrappers.ListTasksResult;
 import org.a2aproject.sdk.server.AgentCardCacheMetadata;
 import org.a2aproject.sdk.server.AgentCardValidator;
 import org.a2aproject.sdk.server.ExtendedAgentCard;
+import org.a2aproject.sdk.server.FixedInstance;
 import org.a2aproject.sdk.server.PublicAgentCard;
-import org.a2aproject.sdk.server.ResolvedInstance;
 import org.a2aproject.sdk.server.ServerCallContext;
 import org.a2aproject.sdk.server.auth.TaskOperation;
 import org.a2aproject.sdk.server.extensions.A2AExtensions;
@@ -174,7 +174,7 @@ public class RestHandler {
      */
     public RestHandler(AgentCard agentCard, AgentCardCacheMetadata cacheMetadata,
             RequestHandler requestHandler, Executor executor) {
-        this.agentCardInstance = new ResolvedInstance<>(agentCard);
+        this.agentCardInstance = new FixedInstance<>(agentCard);
         this.cacheMetadata = cacheMetadata;
         this.requestHandler = requestHandler;
         this.executor = executor;
@@ -228,8 +228,8 @@ public class RestHandler {
      */
     public HTTPRestResponse sendMessage(ServerCallContext context, String tenant, String body) {
         try {
-            A2AVersionValidator.validateProtocolVersion(agentCard(), context);
-            A2AExtensions.validateRequiredExtensions(agentCard(), context);
+            A2AVersionValidator.validateProtocolVersion(resolveAgentCard(), context);
+            A2AExtensions.validateRequiredExtensions(resolveAgentCard(), context);
             org.a2aproject.sdk.grpc.SendMessageRequest.Builder request = org.a2aproject.sdk.grpc.SendMessageRequest.newBuilder();
             parseRequestBody(body, request);
             request.setTenant(tenant);
@@ -293,11 +293,11 @@ public class RestHandler {
      */
     public HTTPRestResponse sendStreamingMessage(ServerCallContext context, String tenant, String body) {
         try {
-            if (!agentCard().capabilities().streaming()) {
+            if (!resolveAgentCard().capabilities().streaming()) {
                 return createErrorResponse(new UnsupportedOperationError(null, "Streaming is not supported by the agent", null));
             }
-            A2AVersionValidator.validateProtocolVersion(agentCard(), context);
-            A2AExtensions.validateRequiredExtensions(agentCard(), context);
+            A2AVersionValidator.validateProtocolVersion(resolveAgentCard(), context);
+            A2AExtensions.validateRequiredExtensions(resolveAgentCard(), context);
             org.a2aproject.sdk.grpc.SendMessageRequest.Builder request = org.a2aproject.sdk.grpc.SendMessageRequest.newBuilder();
             parseRequestBody(body, request);
             request.setTenant(tenant);
@@ -370,7 +370,7 @@ public class RestHandler {
      */
     public HTTPRestResponse createTaskPushNotificationConfiguration(ServerCallContext context, String tenant, String body, String taskId) {
         try {
-            if (!agentCard().capabilities().pushNotifications()) {
+            if (!resolveAgentCard().capabilities().pushNotifications()) {
                 throw new PushNotificationNotSupportedError();
             }
             org.a2aproject.sdk.grpc.TaskPushNotificationConfig.Builder builder = org.a2aproject.sdk.grpc.TaskPushNotificationConfig.newBuilder();
@@ -425,7 +425,7 @@ public class RestHandler {
      */
     public HTTPRestResponse subscribeToTask(ServerCallContext context, String tenant, String taskId) {
         try {
-            if (!agentCard().capabilities().streaming()) {
+            if (!resolveAgentCard().capabilities().streaming()) {
                 return createErrorResponse(new UnsupportedOperationError(null, "Streaming is not supported by the agent", null));
             }
             TaskIdParams params = TaskIdParams.builder().id(taskId).tenant(tenant).build();
@@ -582,7 +582,7 @@ public class RestHandler {
      */
     public HTTPRestResponse getTaskPushNotificationConfiguration(ServerCallContext context, String tenant, String taskId, String configId) {
         try {
-            if (!agentCard().capabilities().pushNotifications()) {
+            if (!resolveAgentCard().capabilities().pushNotifications()) {
                 throw new PushNotificationNotSupportedError();
             }
             GetTaskPushNotificationConfigParams params = new GetTaskPushNotificationConfigParams(taskId, configId, tenant);
@@ -607,7 +607,7 @@ public class RestHandler {
      */
     public HTTPRestResponse listTaskPushNotificationConfigurations(ServerCallContext context, String tenant, String taskId, int pageSize, String pageToken) {
         try {
-            if (!agentCard().capabilities().pushNotifications()) {
+            if (!resolveAgentCard().capabilities().pushNotifications()) {
                 throw new PushNotificationNotSupportedError();
             }
             ListTaskPushNotificationConfigsParams params = new ListTaskPushNotificationConfigsParams(taskId, pageSize, pageToken, tenant);
@@ -631,7 +631,7 @@ public class RestHandler {
      */
     public HTTPRestResponse deleteTaskPushNotificationConfiguration(ServerCallContext context, String tenant, String taskId, String configId) {
         try {
-            if (!agentCard().capabilities().pushNotifications()) {
+            if (!resolveAgentCard().capabilities().pushNotifications()) {
                 throw new PushNotificationNotSupportedError();
             }
             DeleteTaskPushNotificationConfigParams params = new DeleteTaskPushNotificationConfigParams(taskId, configId, tenant);
@@ -815,7 +815,7 @@ public class RestHandler {
      */
     public HTTPRestResponse getExtendedAgentCard(ServerCallContext context, String tenant) {
         try {
-            if (!agentCard().capabilities().extendedAgentCard()) {
+            if (!resolveAgentCard().capabilities().extendedAgentCard()) {
                 throw new UnsupportedOperationError();
             }
             if (extendedAgentCard == null || !extendedAgentCard.isResolvable()) {
@@ -864,22 +864,13 @@ public class RestHandler {
      * @see AgentCard
      * @see #getExtendedAgentCard(ServerCallContext, String)
      */
-    private AgentCard agentCard() {
-        AgentCard card = agentCardInstance.get();
-        if (transportValidated.compareAndSet(false, true)) {
-            try {
-                AgentCardValidator.validateTransportConfiguration(card);
-            } catch (RuntimeException e) {
-                transportValidated.set(false);
-                throw e;
-            }
-        }
-        return card;
+    private AgentCard resolveAgentCard() {
+        return AgentCardValidator.resolveAndValidateOnce(agentCardInstance, transportValidated);
     }
 
     public HTTPRestResponse getAgentCard() {
         try {
-            return new HTTPRestResponse(200, APPLICATION_JSON, JsonUtil.toJson(agentCard()),
+            return new HTTPRestResponse(200, APPLICATION_JSON, JsonUtil.toJson(resolveAgentCard()),
                     cacheMetadata.getHttpHeadersMap());
         } catch (Throwable t) {
             return createErrorResponse(500, internalError(t));

--- a/transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java
+++ b/transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -34,6 +35,7 @@ import org.a2aproject.sdk.server.AgentCardCacheMetadata;
 import org.a2aproject.sdk.server.AgentCardValidator;
 import org.a2aproject.sdk.server.ExtendedAgentCard;
 import org.a2aproject.sdk.server.PublicAgentCard;
+import org.a2aproject.sdk.server.ResolvedInstance;
 import org.a2aproject.sdk.server.ServerCallContext;
 import org.a2aproject.sdk.server.auth.TaskOperation;
 import org.a2aproject.sdk.server.extensions.A2AExtensions;
@@ -124,11 +126,12 @@ public class RestHandler {
     // Fields set by constructor injection cannot be final. We need a noargs constructor for
     // Jakarta compatibility, and it seems that making fields set by constructor injection
     // final, is not proxyable in all runtimes
-    private AgentCard agentCard;
+    private Instance<AgentCard> agentCardInstance;
     private @Nullable Instance<AgentCard> extendedAgentCard;
     private AgentCardCacheMetadata cacheMetadata;
     private RequestHandler requestHandler;
     private Executor executor;
+    private final AtomicBoolean transportValidated = new AtomicBoolean(false);
 
     /**
      * No-args constructor for CDI proxy creation.
@@ -144,23 +147,21 @@ public class RestHandler {
     /**
      * Creates a REST handler with full CDI injection support.
      *
-     * @param agentCard the public agent card containing agent capabilities
+     * @param agentCardInstance the public agent card instance containing agent capabilities
      * @param extendedAgentCard optional extended agent card instance
      * @param cacheMetadata the agent card caching metadata
      * @param requestHandler the handler for processing A2A requests
      * @param executor the executor for asynchronous operations
      */
     @Inject
-    public RestHandler(@PublicAgentCard AgentCard agentCard, @ExtendedAgentCard Instance<AgentCard> extendedAgentCard,
+    public RestHandler(@PublicAgentCard Instance<AgentCard> agentCardInstance,
+            @ExtendedAgentCard Instance<AgentCard> extendedAgentCard,
             AgentCardCacheMetadata cacheMetadata, RequestHandler requestHandler, @Internal Executor executor) {
-        this.agentCard = agentCard;
+        this.agentCardInstance = agentCardInstance;
         this.extendedAgentCard = extendedAgentCard;
         this.cacheMetadata = cacheMetadata;
         this.requestHandler = requestHandler;
         this.executor = executor;
-
-        // Validate transport configuration
-        AgentCardValidator.validateTransportConfiguration(agentCard);
     }
 
     /**
@@ -173,7 +174,7 @@ public class RestHandler {
      */
     public RestHandler(AgentCard agentCard, AgentCardCacheMetadata cacheMetadata,
             RequestHandler requestHandler, Executor executor) {
-        this.agentCard = agentCard;
+        this.agentCardInstance = new ResolvedInstance<>(agentCard);
         this.cacheMetadata = cacheMetadata;
         this.requestHandler = requestHandler;
         this.executor = executor;
@@ -227,8 +228,8 @@ public class RestHandler {
      */
     public HTTPRestResponse sendMessage(ServerCallContext context, String tenant, String body) {
         try {
-            A2AVersionValidator.validateProtocolVersion(agentCard, context);
-            A2AExtensions.validateRequiredExtensions(agentCard, context);
+            A2AVersionValidator.validateProtocolVersion(agentCard(), context);
+            A2AExtensions.validateRequiredExtensions(agentCard(), context);
             org.a2aproject.sdk.grpc.SendMessageRequest.Builder request = org.a2aproject.sdk.grpc.SendMessageRequest.newBuilder();
             parseRequestBody(body, request);
             request.setTenant(tenant);
@@ -292,11 +293,11 @@ public class RestHandler {
      */
     public HTTPRestResponse sendStreamingMessage(ServerCallContext context, String tenant, String body) {
         try {
-            if (!agentCard.capabilities().streaming()) {
+            if (!agentCard().capabilities().streaming()) {
                 return createErrorResponse(new UnsupportedOperationError(null, "Streaming is not supported by the agent", null));
             }
-            A2AVersionValidator.validateProtocolVersion(agentCard, context);
-            A2AExtensions.validateRequiredExtensions(agentCard, context);
+            A2AVersionValidator.validateProtocolVersion(agentCard(), context);
+            A2AExtensions.validateRequiredExtensions(agentCard(), context);
             org.a2aproject.sdk.grpc.SendMessageRequest.Builder request = org.a2aproject.sdk.grpc.SendMessageRequest.newBuilder();
             parseRequestBody(body, request);
             request.setTenant(tenant);
@@ -369,7 +370,7 @@ public class RestHandler {
      */
     public HTTPRestResponse createTaskPushNotificationConfiguration(ServerCallContext context, String tenant, String body, String taskId) {
         try {
-            if (!agentCard.capabilities().pushNotifications()) {
+            if (!agentCard().capabilities().pushNotifications()) {
                 throw new PushNotificationNotSupportedError();
             }
             org.a2aproject.sdk.grpc.TaskPushNotificationConfig.Builder builder = org.a2aproject.sdk.grpc.TaskPushNotificationConfig.newBuilder();
@@ -424,7 +425,7 @@ public class RestHandler {
      */
     public HTTPRestResponse subscribeToTask(ServerCallContext context, String tenant, String taskId) {
         try {
-            if (!agentCard.capabilities().streaming()) {
+            if (!agentCard().capabilities().streaming()) {
                 return createErrorResponse(new UnsupportedOperationError(null, "Streaming is not supported by the agent", null));
             }
             TaskIdParams params = TaskIdParams.builder().id(taskId).tenant(tenant).build();
@@ -581,7 +582,7 @@ public class RestHandler {
      */
     public HTTPRestResponse getTaskPushNotificationConfiguration(ServerCallContext context, String tenant, String taskId, String configId) {
         try {
-            if (!agentCard.capabilities().pushNotifications()) {
+            if (!agentCard().capabilities().pushNotifications()) {
                 throw new PushNotificationNotSupportedError();
             }
             GetTaskPushNotificationConfigParams params = new GetTaskPushNotificationConfigParams(taskId, configId, tenant);
@@ -606,7 +607,7 @@ public class RestHandler {
      */
     public HTTPRestResponse listTaskPushNotificationConfigurations(ServerCallContext context, String tenant, String taskId, int pageSize, String pageToken) {
         try {
-            if (!agentCard.capabilities().pushNotifications()) {
+            if (!agentCard().capabilities().pushNotifications()) {
                 throw new PushNotificationNotSupportedError();
             }
             ListTaskPushNotificationConfigsParams params = new ListTaskPushNotificationConfigsParams(taskId, pageSize, pageToken, tenant);
@@ -630,7 +631,7 @@ public class RestHandler {
      */
     public HTTPRestResponse deleteTaskPushNotificationConfiguration(ServerCallContext context, String tenant, String taskId, String configId) {
         try {
-            if (!agentCard.capabilities().pushNotifications()) {
+            if (!agentCard().capabilities().pushNotifications()) {
                 throw new PushNotificationNotSupportedError();
             }
             DeleteTaskPushNotificationConfigParams params = new DeleteTaskPushNotificationConfigParams(taskId, configId, tenant);
@@ -814,7 +815,7 @@ public class RestHandler {
      */
     public HTTPRestResponse getExtendedAgentCard(ServerCallContext context, String tenant) {
         try {
-            if (!agentCard.capabilities().extendedAgentCard()) {
+            if (!agentCard().capabilities().extendedAgentCard()) {
                 throw new UnsupportedOperationError();
             }
             if (extendedAgentCard == null || !extendedAgentCard.isResolvable()) {
@@ -863,9 +864,22 @@ public class RestHandler {
      * @see AgentCard
      * @see #getExtendedAgentCard(ServerCallContext, String)
      */
+    private AgentCard agentCard() {
+        AgentCard card = agentCardInstance.get();
+        if (transportValidated.compareAndSet(false, true)) {
+            try {
+                AgentCardValidator.validateTransportConfiguration(card);
+            } catch (RuntimeException e) {
+                transportValidated.set(false);
+                throw e;
+            }
+        }
+        return card;
+    }
+
     public HTTPRestResponse getAgentCard() {
         try {
-            return new HTTPRestResponse(200, APPLICATION_JSON, JsonUtil.toJson(agentCard),
+            return new HTTPRestResponse(200, APPLICATION_JSON, JsonUtil.toJson(agentCard()),
                     cacheMetadata.getHttpHeadersMap());
         } catch (Throwable t) {
             return createErrorResponse(500, internalError(t));

--- a/transport/rest/src/test/java/org/a2aproject/sdk/transport/rest/handler/RestHandlerTest.java
+++ b/transport/rest/src/test/java/org/a2aproject/sdk/transport/rest/handler/RestHandlerTest.java
@@ -17,6 +17,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import jakarta.enterprise.inject.Instance;
 import org.a2aproject.sdk.common.MediaType;
 import org.a2aproject.sdk.server.AgentCardCacheMetadata;
 import org.a2aproject.sdk.server.ServerCallContext;
@@ -556,7 +557,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         AgentCard cardWithExtension = AgentCard.builder()
                 .name("test-card")
                 .description("Test card with required extension")
-                .supportedInterfaces(Collections.singletonList(new AgentInterface("REST", "http://localhost:9999")))
+                .supportedInterfaces(Collections.singletonList(new AgentInterface("HTTP+JSON", "http://localhost:9999")))
                 .version("1.0.0")
                 .capabilities(AgentCapabilities.builder()
                         .streaming(true)
@@ -604,7 +605,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         AgentCard cardWithExtension = AgentCard.builder()
                 .name("test-card")
                 .description("Test card with required extension")
-                .supportedInterfaces(Collections.singletonList(new AgentInterface("REST", "http://localhost:9999")))
+                .supportedInterfaces(Collections.singletonList(new AgentInterface("HTTP+JSON", "http://localhost:9999")))
                 .version("1.0.0")
                 .capabilities(AgentCapabilities.builder()
                         .streaming(true)
@@ -699,7 +700,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         AgentCard cardWithExtension = AgentCard.builder()
                 .name("test-card")
                 .description("Test card with required extension")
-                .supportedInterfaces(Collections.singletonList(new AgentInterface("REST", "http://localhost:9999")))
+                .supportedInterfaces(Collections.singletonList(new AgentInterface("HTTP+JSON", "http://localhost:9999")))
                 .version("1.0.0")
                 .capabilities(AgentCapabilities.builder()
                         .streaming(true)
@@ -762,7 +763,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         AgentCard agentCard = AgentCard.builder()
                 .name("test-card")
                 .description("Test card with version 1.0")
-                .supportedInterfaces(Collections.singletonList(new AgentInterface("REST", "http://localhost:9999")))
+                .supportedInterfaces(Collections.singletonList(new AgentInterface("HTTP+JSON", "http://localhost:9999")))
                 .version("1.0.0")
                 .capabilities(AgentCapabilities.builder()
                         .streaming(true)
@@ -812,7 +813,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         AgentCard agentCard = AgentCard.builder()
                 .name("test-card")
                 .description("Test card with version 1.0")
-                .supportedInterfaces(Collections.singletonList(new AgentInterface("REST", "http://localhost:9999")))
+                .supportedInterfaces(Collections.singletonList(new AgentInterface("HTTP+JSON", "http://localhost:9999")))
                 .version("1.0.0")
                 .capabilities(AgentCapabilities.builder()
                         .streaming(true)
@@ -908,7 +909,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         AgentCard agentCard = AgentCard.builder()
                 .name("test-card")
                 .description("Test card with version 1.0")
-                .supportedInterfaces(Collections.singletonList(new AgentInterface("REST", "http://localhost:9999")))
+                .supportedInterfaces(Collections.singletonList(new AgentInterface("HTTP+JSON", "http://localhost:9999")))
                 .version("1.0.0")
                 .capabilities(AgentCapabilities.builder()
                         .streaming(true)
@@ -963,7 +964,7 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         AgentCard agentCard = AgentCard.builder()
                 .name("test-card")
                 .description("Test card with version 1.0")
-                .supportedInterfaces(Collections.singletonList(new AgentInterface("REST", "http://localhost:9999")))
+                .supportedInterfaces(Collections.singletonList(new AgentInterface("HTTP+JSON", "http://localhost:9999")))
                 .version("1.0.0")
                 .capabilities(AgentCapabilities.builder()
                         .streaming(true)
@@ -1077,6 +1078,16 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         // Verify empty array, not null
         Assertions.assertTrue(body.contains("\"tasks\":[]") || body.contains("\"tasks\": []"),
                 "tasks should be empty array");
+    }
+
+    @Test
+    void constructorDoesNotResolveAgentCardInstance() {
+        @SuppressWarnings("unchecked")
+        Instance<AgentCard> throwOnGet = Mockito.mock(Instance.class);
+        Mockito.when(throwOnGet.get()).thenThrow(new AssertionError("Instance.get() must not be called during construction"));
+
+        Assertions.assertDoesNotThrow(() -> new RestHandler(throwOnGet, throwOnGet,
+                createCacheMetadata(), requestHandler, internalExecutor));
     }
 
     private static void assertProblemDetail(RestHandler.HTTPRestResponse response,

--- a/transport/rest/src/test/java/org/a2aproject/sdk/transport/rest/handler/RestHandlerTest.java
+++ b/transport/rest/src/test/java/org/a2aproject/sdk/transport/rest/handler/RestHandlerTest.java
@@ -1,6 +1,5 @@
 package org.a2aproject.sdk.transport.rest.handler;
 
-
 import static org.a2aproject.sdk.common.MediaType.APPLICATION_JSON;
 
 import java.util.Collections;
@@ -18,8 +17,9 @@ import com.google.gson.JsonParser;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import jakarta.enterprise.inject.Instance;
-import org.a2aproject.sdk.common.MediaType;
+
 import org.a2aproject.sdk.server.AgentCardCacheMetadata;
+import org.a2aproject.sdk.server.TestInstances;
 import org.a2aproject.sdk.server.ServerCallContext;
 import org.a2aproject.sdk.server.auth.UnauthenticatedUser;
 import org.a2aproject.sdk.server.config.DefaultValuesConfigProvider;
@@ -1081,10 +1081,8 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
     }
 
     @Test
-    void constructorDoesNotResolveAgentCardInstance() {
-        @SuppressWarnings("unchecked")
-        Instance<AgentCard> throwOnGet = Mockito.mock(Instance.class);
-        Mockito.when(throwOnGet.get()).thenThrow(new AssertionError("Instance.get() must not be called during construction"));
+    void constructorDoesNotResolveAgentCardInstances() {
+        Instance<AgentCard> throwOnGet = TestInstances.throwOnGet();
 
         Assertions.assertDoesNotThrow(() -> new RestHandler(throwOnGet, throwOnGet,
                 createCacheMetadata(), requestHandler, internalExecutor));


### PR DESCRIPTION
All three handler implementations (gRPC, JSON-RPC, REST) now store Instance<AgentCard> and resolve lazily on first access instead of eagerly in the constructor. This prevents startup failures when the AgentCard producer depends on the HTTP server's bound address, which is not yet available during gRPC service construction at RUNTIME_INIT.

Transport validation is also deferred to first use via an AtomicBoolean guard, consistent with the existing pattern in GrpcHandler.

This fixes #1033
