### PR TITLE
fix(grpc): align unsupported operation status

### DIFF
--- a/client/transport/grpc/src/main/java/org/a2aproject/sdk/client/transport/grpc/GrpcErrorMapper.java
+++ b/client/transport/grpc/src/main/java/org/a2aproject/sdk/client/transport/grpc/GrpcErrorMapper.java
@@ -74,7 +74,8 @@ public class GrpcErrorMapper {
         String desc = message != null ? message : e.getMessage() == null ? "" : e.getMessage();
         return switch (code) {
             case NOT_FOUND -> new A2AClientException(errorPrefix + desc, new TaskNotFoundError());
-            case UNIMPLEMENTED -> new A2AClientException(errorPrefix + desc, new UnsupportedOperationError());
+            case UNIMPLEMENTED, FAILED_PRECONDITION ->
+                    new A2AClientException(errorPrefix + desc, new UnsupportedOperationError());
             case INVALID_ARGUMENT -> new A2AClientException(errorPrefix + desc, new InvalidParamsError());
             case INTERNAL -> new A2AClientException(errorPrefix + desc, new org.a2aproject.sdk.spec.InternalError(null, desc, null));
             case UNAUTHENTICATED -> new A2AClientException(errorPrefix + A2AErrorMessages.AUTHENTICATION_FAILED);

--- a/client/transport/grpc/src/test/java/org/a2aproject/sdk/client/transport/grpc/GrpcErrorMapperTest.java
+++ b/client/transport/grpc/src/test/java/org/a2aproject/sdk/client/transport/grpc/GrpcErrorMapperTest.java
@@ -119,6 +119,20 @@ public class GrpcErrorMapperTest {
     }
 
     @Test
+    public void testUnsupportedOperationErrorFallbackUsesFailedPrecondition() {
+        String errorMessage = "Operation not supported";
+        StatusRuntimeException grpcException = Status.FAILED_PRECONDITION
+                .withDescription(errorMessage)
+                .asRuntimeException();
+
+        A2AClientException result = GrpcErrorMapper.mapGrpcError(grpcException);
+
+        assertNotNull(result);
+        assertNotNull(result.getCause());
+        assertInstanceOf(UnsupportedOperationError.class, result.getCause());
+    }
+
+    @Test
     public void testInvalidParamsErrorUnmarshalling() {
         String errorMessage = "Invalid parameters provided";
         StatusRuntimeException grpcException = createA2AStatusException(

--- a/client/transport/grpc/src/test/java/org/a2aproject/sdk/client/transport/grpc/GrpcErrorMapperTest.java
+++ b/client/transport/grpc/src/test/java/org/a2aproject/sdk/client/transport/grpc/GrpcErrorMapperTest.java
@@ -109,7 +109,7 @@ public class GrpcErrorMapperTest {
     public void testUnsupportedOperationErrorUnmarshalling() {
         String errorMessage = "Operation not supported";
         StatusRuntimeException grpcException = createA2AStatusException(
-                Status.Code.UNIMPLEMENTED.value(), errorMessage, "UNSUPPORTED_OPERATION");
+                Status.Code.FAILED_PRECONDITION.value(), errorMessage, "UNSUPPORTED_OPERATION");
 
         A2AClientException result = GrpcErrorMapper.mapGrpcError(grpcException);
 

--- a/spec/src/main/java/org/a2aproject/sdk/spec/A2AErrorCodes.java
+++ b/spec/src/main/java/org/a2aproject/sdk/spec/A2AErrorCodes.java
@@ -26,7 +26,7 @@ public enum A2AErrorCodes {
     PUSH_NOTIFICATION_NOT_SUPPORTED(-32003, "UNIMPLEMENTED", 400),
 
     /** Error code indicating the requested operation is not supported (-32004). */
-    UNSUPPORTED_OPERATION(-32004, "UNIMPLEMENTED", 400),
+    UNSUPPORTED_OPERATION(-32004, "FAILED_PRECONDITION", 400),
 
     /** Error code indicating the content type is not supported (-32005). */
     CONTENT_TYPE_NOT_SUPPORTED(-32005, "INVALID_ARGUMENT", 415),

--- a/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
+++ b/transport/grpc/src/main/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandler.java
@@ -119,7 +119,7 @@ import org.jspecify.annotations.Nullable;
  *   <li>{@link org.a2aproject.sdk.spec.MethodNotFoundError} → {@link Status#NOT_FOUND}</li>
  *   <li>{@link org.a2aproject.sdk.spec.TaskNotFoundError} → {@link Status#NOT_FOUND}</li>
  *   <li>{@link org.a2aproject.sdk.spec.InternalError} → {@link Status#INTERNAL}</li>
- *   <li>{@link org.a2aproject.sdk.spec.UnsupportedOperationError} → {@link Status#UNIMPLEMENTED}</li>
+ *   <li>{@link org.a2aproject.sdk.spec.UnsupportedOperationError} → {@link Status#FAILED_PRECONDITION}</li>
  *   <li>{@link SecurityException} → {@link Status#UNAUTHENTICATED} or {@link Status#PERMISSION_DENIED}</li>
  * </ul>
  *
@@ -746,7 +746,7 @@ public abstract class GrpcHandler extends A2AServiceGrpc.A2AServiceImplBase {
      *   <li>{@link TaskNotFoundError} → {@code NOT_FOUND}</li>
      *   <li>{@link TaskNotCancelableError} → {@code FAILED_PRECONDITION}</li>
      *   <li>{@link PushNotificationNotSupportedError} → {@code UNIMPLEMENTED}</li>
-     *   <li>{@link UnsupportedOperationError} → {@code UNIMPLEMENTED}</li>
+     *   <li>{@link UnsupportedOperationError} → {@code FAILED_PRECONDITION}</li>
      *   <li>{@link JSONParseError} → {@code INTERNAL}</li>
      *   <li>{@link ContentTypeNotSupportedError} → {@code INVALID_ARGUMENT}</li>
      *   <li>{@link InvalidAgentResponseError} → {@code INTERNAL}</li>

--- a/transport/grpc/src/test/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandlerTest.java
+++ b/transport/grpc/src/test/java/org/a2aproject/sdk/transport/grpc/handler/GrpcHandlerTest.java
@@ -161,7 +161,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
         handler.cancelTask(request, streamRecorder);
         streamRecorder.awaitCompletion(5, TimeUnit.SECONDS);
 
-        assertGrpcError(streamRecorder, Status.Code.UNIMPLEMENTED);
+        assertGrpcError(streamRecorder, Status.Code.FAILED_PRECONDITION);
     }
 
     @Test
@@ -218,7 +218,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
             agentEmitter.fail(new UnsupportedOperationError());
         };
         StreamRecorder<SendMessageResponse> streamRecorder = sendMessageRequest(handler);
-        assertGrpcError(streamRecorder, Status.Code.UNIMPLEMENTED);
+        assertGrpcError(streamRecorder, Status.Code.FAILED_PRECONDITION);
     }
 
     @Test
@@ -286,7 +286,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
         GrpcHandler handler = new TestGrpcHandler(card, requestHandler, internalExecutor);
         StreamRecorder<TaskPushNotificationConfig> streamRecorder = getTaskPushNotificationConfigRequest(handler,
                 AbstractA2ARequestHandlerTest.MINIMAL_TASK.id(), AbstractA2ARequestHandlerTest.MINIMAL_TASK.id());
-        assertGrpcError(streamRecorder, Status.Code.UNIMPLEMENTED);
+        assertGrpcError(streamRecorder, Status.Code.FAILED_PRECONDITION);
     }
 
     @Test
@@ -301,7 +301,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
         GrpcHandler handler = new TestGrpcHandler(card, requestHandler, internalExecutor);
         StreamRecorder<TaskPushNotificationConfig> streamRecorder = createTaskPushNotificationConfigRequest(handler,
                 AbstractA2ARequestHandlerTest.MINIMAL_TASK.id(), AbstractA2ARequestHandlerTest.MINIMAL_TASK.id());
-        assertGrpcError(streamRecorder, Status.Code.UNIMPLEMENTED);
+        assertGrpcError(streamRecorder, Status.Code.FAILED_PRECONDITION);
     }
 
     @Test
@@ -625,7 +625,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
         AgentCard card = AbstractA2ARequestHandlerTest.createAgentCard(false, true);
         GrpcHandler handler = new TestGrpcHandler(card, requestHandler, internalExecutor);
         StreamRecorder<StreamResponse> streamRecorder = sendStreamingMessageRequest(handler);
-        assertGrpcError(streamRecorder, Status.Code.UNIMPLEMENTED);
+        assertGrpcError(streamRecorder, Status.Code.FAILED_PRECONDITION);
     }
 
     @Test
@@ -639,7 +639,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
         StreamRecorder<StreamResponse> streamRecorder = StreamRecorder.create();
         handler.subscribeToTask(request, streamRecorder);
         streamRecorder.awaitCompletion(5, TimeUnit.SECONDS);
-        assertGrpcError(streamRecorder, Status.Code.UNIMPLEMENTED);
+        assertGrpcError(streamRecorder, Status.Code.FAILED_PRECONDITION);
     }
 
     @Test
@@ -735,7 +735,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
                 .build();
         StreamRecorder<ListTaskPushNotificationConfigsResponse> streamRecorder = StreamRecorder.create();
         handler.listTaskPushNotificationConfigs(request, streamRecorder);
-        assertGrpcError(streamRecorder, Status.Code.UNIMPLEMENTED);
+        assertGrpcError(streamRecorder, Status.Code.FAILED_PRECONDITION);
     }
 
     @Test
@@ -806,7 +806,7 @@ public class GrpcHandlerTest extends AbstractA2ARequestHandlerTest {
                 .build();
         StreamRecorder<Empty> streamRecorder = StreamRecorder.create();
         handler.deleteTaskPushNotificationConfig(request, streamRecorder);
-        assertGrpcError(streamRecorder, Status.Code.UNIMPLEMENTED);
+        assertGrpcError(streamRecorder, Status.Code.FAILED_PRECONDITION);
     }
 
     @Disabled


### PR DESCRIPTION
# Description

Align `UnsupportedOperationError` with the A2A gRPC specification by mapping it to `FAILED_PRECONDITION` instead of `UNIMPLEMENTED`. Update the existing server and client mapping assertions, plus the handler mapping documentation.

- [x] Follow the [`CONTRIBUTING` Guide](../blob/main/CONTRIBUTING.md).
- [x] Use a Conventional Commits PR title.
- [x] Ensure the affected tests pass.
- [x] Appropriate documentation was updated.

## Reproduction

On current `main`, changing only the eight existing `GrpcHandlerTest` expectations for paths that emit `UnsupportedOperationError` produced 8 consistent failures out of 42 tests:

```
expected: <FAILED_PRECONDITION> but was: <UNIMPLEMENTED>
```

## Verification

Run with OpenJDK 17:

```bash
mvn -DskipTests install -pl transport/grpc,client/transport/grpc -am
mvn -pl transport/grpc test
mvn -pl client/transport/grpc test
```

Results:

- `transport/grpc`: 42 tests passed
- `client/transport/grpc`: 9 tests passed
- all 12 prerequisite/affected reactor modules compiled and installed successfully

A root `mvn clean install` was also attempted, but the unrelated `client/transport/jsonrpc` tests could not bind/use their hard-coded local endpoint because `127.0.0.1:4001` was already occupied by another local application. The two changed gRPC modules were fully tested separately above.

This fixes #1051