### PR TITLE
fix(server-common): keep task streams open after messages

### DIFF
--- a/server-common/src/main/java/org/a2aproject/sdk/server/events/EventConsumer.java
+++ b/server-common/src/main/java/org/a2aproject/sdk/server/events/EventConsumer.java
@@ -228,9 +228,9 @@ public class EventConsumer {
                             boolean isFinalEvent = false;
                             if (event instanceof TaskStatusUpdateEvent tue && tue.isFinal()) {
                                 isFinalEvent = true;
-                            } else if (event instanceof Message) {
-                                // Per A2A spec §3.1.2 (Send Streaming Message): a Message is the
-                                // complete response — the stream must close after delivering it.
+                            } else if (event instanceof Message && lastSeenTaskState == null) {
+                                // A stateless Message is the complete response. Messages emitted
+                                // after a task has started are intermediate task stream events.
                                 isFinalEvent = true;
                             } else if (event instanceof Task task) {
                                 isFinalEvent = isStreamTerminatingTask(task);

--- a/server-common/src/test/java/org/a2aproject/sdk/server/events/EventConsumerTest.java
+++ b/server-common/src/test/java/org/a2aproject/sdk/server/events/EventConsumerTest.java
@@ -237,6 +237,41 @@ public class EventConsumerTest {
     }
 
     @Test
+    public void testConsumeTaskMessageBeforeInputRequired() throws Exception {
+        Task workingTask = Task.builder()
+                .id(TASK_ID)
+                .contextId("session-xyz")
+                .status(new TaskStatus(TaskState.TASK_STATE_WORKING))
+                .build();
+        Message message = fromJson(MESSAGE_PAYLOAD, Message.class);
+        TaskStatusUpdateEvent inputRequiredEvent = TaskStatusUpdateEvent.builder()
+                .taskId(TASK_ID)
+                .contextId("session-xyz")
+                .status(new TaskStatus(TaskState.TASK_STATE_INPUT_REQUIRED))
+                .build();
+        TaskStatusUpdateEvent completedEvent = TaskStatusUpdateEvent.builder()
+                .taskId(TASK_ID)
+                .contextId("session-xyz")
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
+                .build();
+        List<Event> events = List.of(workingTask, message, inputRequiredEvent, completedEvent);
+
+        for (Event event : events) {
+            eventQueue.enqueueEvent(event);
+        }
+
+        List<Event> receivedEvents = new ArrayList<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        eventConsumer.consumeAll().subscribe(getSubscriber(receivedEvents, error));
+
+        assertNull(error.get());
+        assertEquals(events.size(), receivedEvents.size());
+        for (int i = 0; i < events.size(); i++) {
+            assertSame(events.get(i), receivedEvents.get(i));
+        }
+    }
+
+    @Test
     public void testBufferFlushDelayMsDefaultsTo150() {
         String original = System.getProperty("a2a.eventconsumer.bufferFlushDelayMs");
         try {


### PR DESCRIPTION
# Description

Keep a task stream open when an agent emits a `Message` after the task lifecycle has started. A stateless `Message` remains a complete response and still closes its stream.

The new regression test covers `WORKING Task -> Message -> INPUT_REQUIRED -> COMPLETED`, including a custom message without task/context IDs as accepted by `AgentEmitter.sendMessage(Message)`.

- [x] Follow the [`CONTRIBUTING` Guide](../blob/main/CONTRIBUTING.md).
- [x] Use a Conventional Commits PR title.
- [x] Ensure the affected tests pass.
- [x] Appropriate documentation was updated.

## Reproduction

On current `main`, the focused Java 17 regression was run three times. Every run failed after delivering only the working task and message:

```
expected: <4> but was: <2>
```

The following `INPUT_REQUIRED` and `COMPLETED` updates were lost because every `Message` was treated as stream-terminal.

## Verification

Run with OpenJDK 17:

```bash
mvn -pl server-common -Dtest=EventConsumerTest test
mvn -pl server-common test
```

Results:

- `EventConsumerTest`: 19 tests passed
- `server-common`: 475 tests passed
- existing stateless-message stream termination coverage remains green

This fixes #1037