### PR TITLE
fix(jsonrpc): reject Part with multiple populated content keys

### DIFF
--- a/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/json/JsonUtil.java
+++ b/jsonrpc-common/src/main/java/org/a2aproject/sdk/jsonrpc/common/json/JsonUtil.java
@@ -603,7 +603,14 @@ public class JsonUtil {
             // A producer that emits every content key, leaving the unset ones as "", would otherwise
             // have its payload discarded by whichever empty placeholder came first on the wire.
             // The fallback keeps a deliberately empty TextPart decodable.
-            String discriminator = contentKeys(jsonObject).filter(key -> !isEmptyString(jsonObject.get(key))).findFirst()
+            List<String> populatedKeys = contentKeys(jsonObject)
+                    .filter(key -> !isEmptyString(jsonObject.get(key)))
+                    .toList();
+            if (populatedKeys.size() > 1) {
+                throw new JsonSyntaxException(
+                        format("Part is a oneOf: expected exactly one populated content key, but found: %s", populatedKeys));
+            }
+            String discriminator = populatedKeys.stream().findFirst()
                     .or(() -> contentKeys(jsonObject).findFirst())
                     .orElseThrow(() -> new JsonSyntaxException(format("Part must have one of: %s (found: %s)", VALID_KEYS, keys)));
 

--- a/jsonrpc-common/src/test/java/org/a2aproject/sdk/jsonrpc/common/json/PartSerializationTest.java
+++ b/jsonrpc-common/src/test/java/org/a2aproject/sdk/jsonrpc/common/json/PartSerializationTest.java
@@ -152,6 +152,14 @@ public class PartSerializationTest {
     }
 
     @Test
+    void testMultiplePopulatedContentKeysAreRejected() {
+        String json = """
+            {"text": "hello", "data": {"answer": "42"}}
+            """;
+        assertThrows(JsonProcessingException.class, () -> JsonUtil.fromJson(json, Part.class));
+    }
+
+    @Test
     void testNonStringContentKeyIsRejected() {
         String json = """
             {"text": "", "raw": {"nested": 1}}


### PR DESCRIPTION
## Summary

- Reject Part JSON with multiple populated content keys as ambiguous, since Part is a oneOf in the A2A spec
- Follows up on #1061 which handled empty-string placeholders from protobuf serializers
- Adds regression test for the two-populated-keys case

## Root cause

The deserializer silently accepted a Part with e.g. both `"text": "hello"` and `"data": {"answer": "42"}` populated, picking whichever key appeared first in document order. This hid malformed input that violates the spec's oneOf constraint.

## Validation

- All 17 `PartSerializationTest` tests pass, including the new `testMultiplePopulatedContentKeysAreRejected`
- Empty-string placeholder tolerance from #1061 is preserved

This fixes #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)