### PR TITLE
fix: validate A2A version and extensions on all JSON-RPC and REST operations

### DIFF
--- a/reference/rest/src/test/java/org/a2aproject/sdk/server/rest/quarkus/QuarkusA2ARestWithAuthAndroidTest.java
+++ b/reference/rest/src/test/java/org/a2aproject/sdk/server/rest/quarkus/QuarkusA2ARestWithAuthAndroidTest.java
@@ -1,12 +1,14 @@
 package org.a2aproject.sdk.server.rest.quarkus;
 
 import org.a2aproject.sdk.client.ClientBuilder;
+import org.a2aproject.sdk.common.A2AHeaders;
 import org.a2aproject.sdk.client.http.android.AndroidA2AHttpClient;
 import org.a2aproject.sdk.client.transport.rest.RestTransport;
 import org.a2aproject.sdk.client.transport.rest.RestTransportConfigBuilder;
 import org.a2aproject.sdk.client.transport.spi.interceptors.auth.AuthInterceptor;
 import org.a2aproject.sdk.server.apps.common.AbstractA2AServerWithAuthTest;
 import org.a2aproject.sdk.server.apps.common.AuthTestProfile;
+import org.a2aproject.sdk.spec.AgentInterface;
 import org.a2aproject.sdk.spec.TransportProtocol;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -58,6 +60,7 @@ public class QuarkusA2ARestWithAuthAndroidTest extends AbstractA2AServerWithAuth
         saveTaskInTaskStore(MINIMAL_TASK);
 
         givenAuthenticated()
+                .header(A2AHeaders.A2A_VERSION, AgentInterface.CURRENT_PROTOCOL_VERSION)
                 .get("/tasks/" + MINIMAL_TASK.id())
                 .then()
                 .statusCode(200);

--- a/reference/rest/src/test/java/org/a2aproject/sdk/server/rest/quarkus/QuarkusA2ARestWithAuthJdkTest.java
+++ b/reference/rest/src/test/java/org/a2aproject/sdk/server/rest/quarkus/QuarkusA2ARestWithAuthJdkTest.java
@@ -1,12 +1,14 @@
 package org.a2aproject.sdk.server.rest.quarkus;
 
 import org.a2aproject.sdk.client.ClientBuilder;
+import org.a2aproject.sdk.common.A2AHeaders;
 import org.a2aproject.sdk.client.http.JdkA2AHttpClient;
 import org.a2aproject.sdk.client.transport.rest.RestTransport;
 import org.a2aproject.sdk.client.transport.rest.RestTransportConfigBuilder;
 import org.a2aproject.sdk.client.transport.spi.interceptors.auth.AuthInterceptor;
 import org.a2aproject.sdk.server.apps.common.AbstractA2AServerWithAuthTest;
 import org.a2aproject.sdk.server.apps.common.AuthTestProfile;
+import org.a2aproject.sdk.spec.AgentInterface;
 import org.a2aproject.sdk.spec.TransportProtocol;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -69,6 +71,7 @@ public class QuarkusA2ARestWithAuthJdkTest extends AbstractA2AServerWithAuthTest
         saveTaskInTaskStore(MINIMAL_TASK);
 
         givenAuthenticated()
+                .header(A2AHeaders.A2A_VERSION, AgentInterface.CURRENT_PROTOCOL_VERSION)
                 .get("/tasks/" + MINIMAL_TASK.id())
                 .then()
                 .statusCode(200);

--- a/reference/rest/src/test/java/org/a2aproject/sdk/server/rest/quarkus/QuarkusA2ARestWithAuthVertxTest.java
+++ b/reference/rest/src/test/java/org/a2aproject/sdk/server/rest/quarkus/QuarkusA2ARestWithAuthVertxTest.java
@@ -1,12 +1,14 @@
 package org.a2aproject.sdk.server.rest.quarkus;
 
 import org.a2aproject.sdk.client.ClientBuilder;
+import org.a2aproject.sdk.common.A2AHeaders;
 import org.a2aproject.sdk.client.http.vertx.VertxA2AHttpClient;
 import org.a2aproject.sdk.client.transport.rest.RestTransport;
 import org.a2aproject.sdk.client.transport.rest.RestTransportConfigBuilder;
 import org.a2aproject.sdk.client.transport.spi.interceptors.auth.AuthInterceptor;
 import org.a2aproject.sdk.server.apps.common.AbstractA2AServerWithAuthTest;
 import org.a2aproject.sdk.server.apps.common.AuthTestProfile;
+import org.a2aproject.sdk.spec.AgentInterface;
 import org.a2aproject.sdk.spec.TransportProtocol;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -70,6 +72,7 @@ public class QuarkusA2ARestWithAuthVertxTest extends AbstractA2AServerWithAuthTe
         saveTaskInTaskStore(MINIMAL_TASK);
 
         givenAuthenticated()
+                .header(A2AHeaders.A2A_VERSION, AgentInterface.CURRENT_PROTOCOL_VERSION)
                 .get("/tasks/" + MINIMAL_TASK.id())
                 .then()
                 .statusCode(200);

--- a/tests/multiversion/rest/src/test/java/org/a2aproject/sdk/tests/multiversion/rest/MultiVersionRestWithAuthTest.java
+++ b/tests/multiversion/rest/src/test/java/org/a2aproject/sdk/tests/multiversion/rest/MultiVersionRestWithAuthTest.java
@@ -5,11 +5,13 @@ import io.quarkus.test.junit.TestProfile;
 import io.vertx.core.Vertx;
 import jakarta.inject.Inject;
 import org.a2aproject.sdk.client.ClientBuilder;
+import org.a2aproject.sdk.common.A2AHeaders;
 import org.a2aproject.sdk.client.http.vertx.VertxA2AHttpClient;
 import org.a2aproject.sdk.client.transport.rest.RestTransport;
 import org.a2aproject.sdk.client.transport.rest.RestTransportConfigBuilder;
 import org.a2aproject.sdk.client.transport.spi.interceptors.auth.AuthInterceptor;
 import org.a2aproject.sdk.server.apps.common.AbstractA2AServerWithAuthTest;
+import org.a2aproject.sdk.spec.AgentInterface;
 import org.a2aproject.sdk.spec.TransportProtocol;
 import org.junit.jupiter.api.Test;
 
@@ -59,6 +61,7 @@ public class MultiVersionRestWithAuthTest extends AbstractA2AServerWithAuthTest 
         saveTaskInTaskStore(MINIMAL_TASK);
 
         givenAuthenticated()
+                .header(A2AHeaders.A2A_VERSION, AgentInterface.CURRENT_PROTOCOL_VERSION)
                 .get("/tasks/" + MINIMAL_TASK.id())
                 .then()
                 .statusCode(200);

--- a/transport/jsonrpc/src/main/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandler.java
+++ b/transport/jsonrpc/src/main/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandler.java
@@ -233,8 +233,7 @@ public class JSONRPCHandler {
      */
     public SendMessageResponse onMessageSend(SendMessageRequest request, ServerCallContext context) {
         try {
-            A2AVersionValidator.validateProtocolVersion(resolveAgentCard(), context);
-            A2AExtensions.validateRequiredExtensions(resolveAgentCard(), context);
+            validateVersionAndExtensions(context);
             EventKind taskOrMessage = requestHandler.onMessageSend(request.getParams(), context);
             return new SendMessageResponse(request.getId(), taskOrMessage);
         } catch (A2AError e) {
@@ -290,8 +289,7 @@ public class JSONRPCHandler {
         }
 
         try {
-            A2AVersionValidator.validateProtocolVersion(resolveAgentCard(), context);
-            A2AExtensions.validateRequiredExtensions(resolveAgentCard(), context);
+            validateVersionAndExtensions(context);
             Flow.Publisher<StreamingEventKind> publisher =
                     requestHandler.onMessageSendStream(request.getParams(), context);
             // We can't use the convertingProcessor convenience method since that propagates any errors as an error handled
@@ -331,6 +329,7 @@ public class JSONRPCHandler {
      */
     public CancelTaskResponse onCancelTask(CancelTaskRequest request, ServerCallContext context) {
         try {
+            validateVersionAndExtensions(context);
             Task task = requestHandler.onCancelTask(request.getParams(), context);
             if (task != null) {
                 return new CancelTaskResponse(request.getId(), task);
@@ -387,6 +386,7 @@ public class JSONRPCHandler {
         }
         requestHandler.authorizeTaskAccess(request.getParams().id(), context, TaskOperation.SUBSCRIBE_TO_TASK);
         try {
+            validateVersionAndExtensions(context);
             Flow.Publisher<StreamingEventKind> publisher =
                     requestHandler.onSubscribeToTask(request.getParams(), context);
             // We can't use the convertingProcessor convenience method since that propagates any errors as an error handled
@@ -431,6 +431,7 @@ public class JSONRPCHandler {
                     new PushNotificationNotSupportedError());
         }
         try {
+            validateVersionAndExtensions(context);
             TaskPushNotificationConfig config =
                     requestHandler.onGetTaskPushNotificationConfig(request.getParams(), context);
             return new GetTaskPushNotificationConfigResponse(request.getId(), config);
@@ -473,6 +474,7 @@ public class JSONRPCHandler {
                     new PushNotificationNotSupportedError());
         }
         try {
+            validateVersionAndExtensions(context);
             TaskPushNotificationConfig config =
                     requestHandler.onCreateTaskPushNotificationConfig(request.getParams(), context);
             return new CreateTaskPushNotificationConfigResponse(request.getId(), config);
@@ -509,6 +511,7 @@ public class JSONRPCHandler {
      */
     public GetTaskResponse onGetTask(GetTaskRequest request, ServerCallContext context) {
         try {
+            validateVersionAndExtensions(context);
             Task task = requestHandler.onGetTask(request.getParams(), context);
             return new GetTaskResponse(request.getId(), task);
         } catch (A2AError e) {
@@ -556,6 +559,7 @@ public class JSONRPCHandler {
      */
     public ListTasksResponse onListTasks(ListTasksRequest request, ServerCallContext context) {
         try {
+            validateVersionAndExtensions(context);
             ListTasksResult result = requestHandler.onListTasks(request.getParams(), context);
             return new ListTasksResponse(request.getId(), result);
         } catch (A2AError e) {
@@ -596,6 +600,7 @@ public class JSONRPCHandler {
                     new PushNotificationNotSupportedError());
         }
         try {
+            validateVersionAndExtensions(context);
             ListTaskPushNotificationConfigsResult result =
                     requestHandler.onListTaskPushNotificationConfigs(request.getParams(), context);
             return new ListTaskPushNotificationConfigsResponse(request.getId(), result);
@@ -638,6 +643,7 @@ public class JSONRPCHandler {
                     new PushNotificationNotSupportedError());
         }
         try {
+            validateVersionAndExtensions(context);
             requestHandler.onDeleteTaskPushNotificationConfig(request.getParams(), context);
             return new DeleteTaskPushNotificationConfigResponse(request.getId());
         } catch (A2AError e) {
@@ -681,12 +687,28 @@ public class JSONRPCHandler {
                     new ExtendedAgentCardNotConfiguredError(null, "Extended Card not configured", null));
         }
         try {
+            validateVersionAndExtensions(context);
             return new GetExtendedAgentCardResponse(request.getId(), extendedAgentCard.get());
         } catch (A2AError e) {
             return new GetExtendedAgentCardResponse(request.getId(), e);
         } catch (Throwable t) {
             return new GetExtendedAgentCardResponse(request.getId(), internalError(t));
         }
+    }
+
+    /**
+     * Validates the requested protocol version and extensions against the agent card.
+     *
+     * <p>Section 3.6.2 of the specification requires this on every request, so every operation
+     * calls it before reaching the request handler.
+     *
+     * @param context the server call context carrying the requested version and extensions
+     * @throws A2AError if the requested version or a required extension is not supported
+     */
+    private void validateVersionAndExtensions(ServerCallContext context) throws A2AError {
+        AgentCard agentCard = resolveAgentCard();
+        A2AVersionValidator.validateProtocolVersion(agentCard, context);
+        A2AExtensions.validateRequiredExtensions(agentCard, context);
     }
 
     /**

--- a/transport/jsonrpc/src/test/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandlerTest.java
+++ b/transport/jsonrpc/src/test/java/org/a2aproject/sdk/transport/jsonrpc/handler/JSONRPCHandlerTest.java
@@ -23,6 +23,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import jakarta.enterprise.inject.Instance;
+
 import org.a2aproject.sdk.jsonrpc.common.wrappers.CancelTaskRequest;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.CancelTaskResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.CreateTaskPushNotificationConfigRequest;
@@ -45,12 +47,15 @@ import org.a2aproject.sdk.jsonrpc.common.wrappers.SendMessageResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.SendStreamingMessageRequest;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.SendStreamingMessageResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.SubscribeToTaskRequest;
+
+import org.a2aproject.sdk.server.FixedInstance;
 import org.a2aproject.sdk.server.ServerCallContext;
 import org.a2aproject.sdk.server.auth.UnauthenticatedUser;
 import org.a2aproject.sdk.server.events.EventConsumer;
 import org.a2aproject.sdk.server.requesthandlers.AbstractA2ARequestHandlerTest;
 import org.a2aproject.sdk.server.requesthandlers.DefaultRequestHandler;
 import org.a2aproject.sdk.server.tasks.ResultAggregator;
+import org.a2aproject.sdk.spec.A2AError;
 import org.a2aproject.sdk.spec.AgentCapabilities;
 import org.a2aproject.sdk.spec.AgentCard;
 import org.a2aproject.sdk.spec.AgentExtension;
@@ -2035,5 +2040,224 @@ public class JSONRPCHandlerTest extends AbstractA2ARequestHandlerTest {
         Instance<AgentCard> throwOnGet = TestInstances.throwOnGet();
 
         assertDoesNotThrow(() -> new JSONRPCHandler(throwOnGet, null, requestHandler, internalExecutor));
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnGetTask() throws Exception {
+        JSONRPCHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        GetTaskRequest request = new GetTaskRequest("1", new TaskQueryParams(MINIMAL_TASK.id()));
+        GetTaskResponse response = handler.onGetTask(request, incompatibleVersionContext());
+
+        assertVersionRejected(response.getError());
+        assertNull(response.getResult());
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnListTasks() throws Exception {
+        JSONRPCHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        ListTasksParams params = ListTasksParams.builder().contextId(MINIMAL_TASK.contextId()).tenant("").build();
+        ListTasksResponse response = handler.onListTasks(new ListTasksRequest("1", params), incompatibleVersionContext());
+
+        assertVersionRejected(response.getError());
+        assertNull(response.getResult());
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnCancelTask() throws Exception {
+        JSONRPCHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        // Without this the executor emits nothing, and a cancel that reaches the request handler
+        // waits forever for a final event rather than failing the assertion.
+        agentExecutorCancel = (context, agentEmitter) -> agentEmitter.cancel();
+
+        CancelTaskRequest request = new CancelTaskRequest("1", new CancelTaskParams(MINIMAL_TASK.id()));
+        CancelTaskResponse response = handler.onCancelTask(request, incompatibleVersionContext());
+
+        assertVersionRejected(response.getError());
+        assertNull(response.getResult());
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnSetPushNotificationConfig() throws Exception {
+        JSONRPCHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        TaskPushNotificationConfig config = TaskPushNotificationConfig.builder()
+                .id(MINIMAL_TASK.id())
+                .taskId(MINIMAL_TASK.id())
+                .url("http://example.com")
+                .build();
+        CreateTaskPushNotificationConfigResponse response =
+                handler.setPushNotificationConfig(
+                        new CreateTaskPushNotificationConfigRequest("1", config), incompatibleVersionContext());
+
+        assertVersionRejected(response.getError());
+        assertNull(response.getResult());
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnGetPushNotificationConfig() throws Exception {
+        JSONRPCHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        GetTaskPushNotificationConfigParams params =
+                new GetTaskPushNotificationConfigParams(MINIMAL_TASK.id(), MINIMAL_TASK.id());
+        GetTaskPushNotificationConfigResponse response =
+                handler.getPushNotificationConfig(
+                        new GetTaskPushNotificationConfigRequest("1", params), incompatibleVersionContext());
+
+        assertVersionRejected(response.getError());
+        assertNull(response.getResult());
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnListPushNotificationConfigs() throws Exception {
+        JSONRPCHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        ListTaskPushNotificationConfigsParams params =
+                new ListTaskPushNotificationConfigsParams(MINIMAL_TASK.id());
+        ListTaskPushNotificationConfigsResponse response =
+                handler.listPushNotificationConfigs(
+                        new ListTaskPushNotificationConfigsRequest("1", params), incompatibleVersionContext());
+
+        assertVersionRejected(response.getError());
+        assertNull(response.getResult());
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnDeletePushNotificationConfig() throws Exception {
+        JSONRPCHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        DeleteTaskPushNotificationConfigParams params =
+                new DeleteTaskPushNotificationConfigParams(MINIMAL_TASK.id(), MINIMAL_TASK.id());
+        DeleteTaskPushNotificationConfigResponse response =
+                handler.deletePushNotificationConfig(
+                        new DeleteTaskPushNotificationConfigRequest("1", params), incompatibleVersionContext());
+
+        assertVersionRejected(response.getError());
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnGetExtendedCard() throws Exception {
+        AgentCard extended = AgentCard.builder(versionTestCard()).description("extended").build();
+        Instance<AgentCard> extendedInstance = new FixedInstance<>(extended);
+
+        JSONRPCHandler handler = new JSONRPCHandler(
+                new FixedInstance<>(versionTestCard()), extendedInstance, requestHandler, internalExecutor);
+
+        GetExtendedAgentCardResponse response =
+                handler.onGetExtendedCardRequest(new GetExtendedAgentCardRequest("1"), incompatibleVersionContext());
+
+        assertVersionRejected(response.getError());
+        assertNull(response.getResult());
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnSubscribeToTask() throws Exception {
+        JSONRPCHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        SubscribeToTaskRequest request = new SubscribeToTaskRequest("1", new TaskIdParams(MINIMAL_TASK.id()));
+        Flow.Publisher<SendStreamingMessageResponse> publisher =
+                handler.onSubscribeToTask(request, incompatibleVersionContext());
+
+        List<SendStreamingMessageResponse> results = drainStream(publisher);
+
+        assertEquals(1, results.size());
+        assertVersionRejected(results.get(0).getError());
+        assertNull(results.get(0).getResult());
+    }
+
+    /**
+     * A card whose sole interface speaks protocol version 1.0, with every capability enabled so
+     * that each operation reaches the version check instead of stopping at a capability guard.
+     */
+    private static AgentCard versionTestCard() {
+        return AgentCard.builder()
+                .name("test-card")
+                .description("Test card with version 1.0")
+                .supportedInterfaces(Collections.singletonList(new AgentInterface("JSONRPC", "http://localhost:9999")))
+                .version("1.0.0")
+                .capabilities(AgentCapabilities.builder()
+                        .streaming(true)
+                        .pushNotifications(true)
+                        .extendedAgentCard(true)
+                        .build())
+                .defaultInputModes(List.of("text"))
+                .defaultOutputModes(List.of("text"))
+                .skills(List.of())
+                .build();
+    }
+
+    private JSONRPCHandler versionTestHandler() {
+        return new JSONRPCHandler(versionTestCard(), requestHandler, internalExecutor);
+    }
+
+    /**
+     * A context requesting version 2.0, whose major differs from the card built by
+     * {@link #versionTestCard()} and is therefore incompatible under section 3.6.2.
+     */
+    private static ServerCallContext incompatibleVersionContext() {
+        return new ServerCallContext(UnauthenticatedUser.INSTANCE, Map.of("foo", "bar"), new HashSet<>(), "2.0");
+    }
+
+    /**
+     * Asserts that an operation refused the call over its version rather than for some other
+     * reason, by checking that the rejected version is named in the message.
+     *
+     * @param error the error an operation placed on its response
+     */
+    private static void assertVersionRejected(A2AError error) {
+        assertInstanceOf(VersionNotSupportedError.class, error);
+        assertTrue(error.getMessage().contains("2.0"));
+    }
+
+    /**
+     * Subscribes to a streaming response and returns the items it emitted before terminating,
+     * so that a rejection delivered as a stream item can be asserted like a unary one.
+     *
+     * @param publisher the streaming response under test
+     * @return the emitted items, in order
+     * @throws InterruptedException if the wait for termination is interrupted
+     */
+    private static List<SendStreamingMessageResponse> drainStream(
+            Flow.Publisher<SendStreamingMessageResponse> publisher) throws InterruptedException {
+        List<SendStreamingMessageResponse> results = new ArrayList<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        publisher.subscribe(new Flow.Subscriber<>() {
+            private Flow.Subscription subscription;
+
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                this.subscription = subscription;
+                subscription.request(1);
+            }
+
+            @Override
+            public void onNext(SendStreamingMessageResponse item) {
+                results.add(item);
+                subscription.request(1);
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onComplete() {
+                latch.countDown();
+            }
+        });
+        assertTrue(latch.await(2, TimeUnit.SECONDS), "Expected an event within timeout");
+        return results;
     }
 }

--- a/transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java
+++ b/transport/rest/src/main/java/org/a2aproject/sdk/transport/rest/handler/RestHandler.java
@@ -228,8 +228,7 @@ public class RestHandler {
      */
     public HTTPRestResponse sendMessage(ServerCallContext context, String tenant, String body) {
         try {
-            A2AVersionValidator.validateProtocolVersion(resolveAgentCard(), context);
-            A2AExtensions.validateRequiredExtensions(resolveAgentCard(), context);
+            validateVersionAndExtensions(context);
             org.a2aproject.sdk.grpc.SendMessageRequest.Builder request = org.a2aproject.sdk.grpc.SendMessageRequest.newBuilder();
             parseRequestBody(body, request);
             request.setTenant(tenant);
@@ -296,8 +295,7 @@ public class RestHandler {
             if (!resolveAgentCard().capabilities().streaming()) {
                 return createErrorResponse(new UnsupportedOperationError(null, "Streaming is not supported by the agent", null));
             }
-            A2AVersionValidator.validateProtocolVersion(resolveAgentCard(), context);
-            A2AExtensions.validateRequiredExtensions(resolveAgentCard(), context);
+            validateVersionAndExtensions(context);
             org.a2aproject.sdk.grpc.SendMessageRequest.Builder request = org.a2aproject.sdk.grpc.SendMessageRequest.newBuilder();
             parseRequestBody(body, request);
             request.setTenant(tenant);
@@ -342,6 +340,7 @@ public class RestHandler {
     @SuppressWarnings("unchecked")
     public HTTPRestResponse cancelTask(ServerCallContext context, String tenant, String body, String taskId) {
         try {
+            validateVersionAndExtensions(context);
             if (taskId == null || taskId.isEmpty()) {
                 throw new InvalidParamsError();
             }
@@ -373,6 +372,7 @@ public class RestHandler {
             if (!resolveAgentCard().capabilities().pushNotifications()) {
                 throw new PushNotificationNotSupportedError();
             }
+            validateVersionAndExtensions(context);
             org.a2aproject.sdk.grpc.TaskPushNotificationConfig.Builder builder = org.a2aproject.sdk.grpc.TaskPushNotificationConfig.newBuilder();
             parseRequestBody(body, builder);
 
@@ -428,6 +428,7 @@ public class RestHandler {
             if (!resolveAgentCard().capabilities().streaming()) {
                 return createErrorResponse(new UnsupportedOperationError(null, "Streaming is not supported by the agent", null));
             }
+            validateVersionAndExtensions(context);
             TaskIdParams params = TaskIdParams.builder().id(taskId).tenant(tenant).build();
             try {
                 requestHandler.authorizeTaskAccess(params.id(), context, TaskOperation.SUBSCRIBE_TO_TASK);
@@ -454,6 +455,7 @@ public class RestHandler {
      */
     public HTTPRestResponse getTask(ServerCallContext context, String tenant, String taskId, @Nullable Integer historyLength) {
         try {
+            validateVersionAndExtensions(context);
             TaskQueryParams params = new TaskQueryParams(taskId, historyLength, tenant);
             Task task = requestHandler.onGetTask(params, context);
             if (task != null) {
@@ -515,6 +517,7 @@ public class RestHandler {
             @Nullable Integer historyLength, @Nullable String statusTimestampAfter,
             @Nullable Boolean includeArtifacts) {
         try {
+            validateVersionAndExtensions(context);
             // Build params
             ListTasksParams.Builder paramsBuilder = ListTasksParams.builder();
             if (contextId != null) {
@@ -585,6 +588,7 @@ public class RestHandler {
             if (!resolveAgentCard().capabilities().pushNotifications()) {
                 throw new PushNotificationNotSupportedError();
             }
+            validateVersionAndExtensions(context);
             GetTaskPushNotificationConfigParams params = new GetTaskPushNotificationConfigParams(taskId, configId, tenant);
             TaskPushNotificationConfig config = requestHandler.onGetTaskPushNotificationConfig(params, context);
             return createSuccessResponse(200, org.a2aproject.sdk.grpc.TaskPushNotificationConfig.newBuilder(ProtoUtils.ToProto.taskPushNotificationConfig(config)));
@@ -610,6 +614,7 @@ public class RestHandler {
             if (!resolveAgentCard().capabilities().pushNotifications()) {
                 throw new PushNotificationNotSupportedError();
             }
+            validateVersionAndExtensions(context);
             ListTaskPushNotificationConfigsParams params = new ListTaskPushNotificationConfigsParams(taskId, pageSize, pageToken, tenant);
             ListTaskPushNotificationConfigsResult result = requestHandler.onListTaskPushNotificationConfigs(params, context);
             return createSuccessResponse(200, org.a2aproject.sdk.grpc.ListTaskPushNotificationConfigsResponse.newBuilder(ProtoUtils.ToProto.listTaskPushNotificationConfigsResponse(result)));
@@ -634,6 +639,7 @@ public class RestHandler {
             if (!resolveAgentCard().capabilities().pushNotifications()) {
                 throw new PushNotificationNotSupportedError();
             }
+            validateVersionAndExtensions(context);
             DeleteTaskPushNotificationConfigParams params = new DeleteTaskPushNotificationConfigParams(taskId, configId, tenant);
             requestHandler.onDeleteTaskPushNotificationConfig(params, context);
             return new HTTPRestResponse(204, APPLICATION_JSON, "");
@@ -642,6 +648,21 @@ public class RestHandler {
         } catch (Throwable throwable) {
             return createErrorResponse(internalError(throwable));
         }
+    }
+
+    /**
+     * Validates the requested protocol version and extensions against the agent card.
+     *
+     * <p>Section 3.6.2 of the specification requires this on every request, so every operation
+     * calls it before reaching the request handler.
+     *
+     * @param context the server call context carrying the requested version and extensions
+     * @throws A2AError if the requested version or a required extension is not supported
+     */
+    private void validateVersionAndExtensions(ServerCallContext context) throws A2AError {
+        AgentCard agentCard = resolveAgentCard();
+        A2AVersionValidator.validateProtocolVersion(agentCard, context);
+        A2AExtensions.validateRequiredExtensions(agentCard, context);
     }
 
     private void parseRequestBody(String body, com.google.protobuf.Message.Builder builder) throws A2AError {
@@ -821,6 +842,7 @@ public class RestHandler {
             if (extendedAgentCard == null || !extendedAgentCard.isResolvable()) {
                 throw new ExtendedAgentCardNotConfiguredError(null, "Extended Card not configured", null);
             }
+            validateVersionAndExtensions(context);
             return new HTTPRestResponse(200, APPLICATION_JSON, JsonUtil.toJson(extendedAgentCard.get()));
         } catch (A2AError e) {
             return createErrorResponse(e);

--- a/transport/rest/src/test/java/org/a2aproject/sdk/transport/rest/handler/RestHandlerTest.java
+++ b/transport/rest/src/test/java/org/a2aproject/sdk/transport/rest/handler/RestHandlerTest.java
@@ -12,14 +12,15 @@ import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import jakarta.enterprise.inject.Instance;
+
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.protobuf.InvalidProtocolBufferException;
 
-import jakarta.enterprise.inject.Instance;
-
 import org.a2aproject.sdk.server.AgentCardCacheMetadata;
 import org.a2aproject.sdk.server.TestInstances;
+import org.a2aproject.sdk.server.FixedInstance;
 import org.a2aproject.sdk.server.ServerCallContext;
 import org.a2aproject.sdk.server.auth.UnauthenticatedUser;
 import org.a2aproject.sdk.server.config.DefaultValuesConfigProvider;
@@ -1134,5 +1135,195 @@ public class RestHandlerTest extends AbstractA2ARequestHandlerTest {
         Assertions.assertEquals("Internal error", error.get("message").getAsString());
         Assertions.assertFalse(error.get("message").getAsString().contains("sensitive"),
                 "Internal exception message must not be leaked to the client");
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnGetTask() {
+        RestHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        assertVersionRejected(handler.getTask(incompatibleVersionContext(), "", MINIMAL_TASK.id(), null));
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnListTasks() {
+        RestHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        assertVersionRejected(handler.listTasks(incompatibleVersionContext(), "",
+                MINIMAL_TASK.contextId(), null, null, null, null, null, null));
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnCancelTask() {
+        RestHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        // Without this the executor emits nothing, and a cancel that reaches the request handler
+        // waits forever for a final event rather than failing the assertion.
+        agentExecutorCancel = (context, agentEmitter) -> agentEmitter.cancel();
+
+        assertVersionRejected(handler.cancelTask(incompatibleVersionContext(), "", "{}", MINIMAL_TASK.id()));
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnCreateTaskPushNotificationConfiguration() {
+        RestHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        String requestBody = """
+            {
+              "id": "config-1",
+              "taskId": "%s",
+              "url": "http://example.com"
+            }""".formatted(MINIMAL_TASK.id());
+
+        assertVersionRejected(handler.createTaskPushNotificationConfiguration(
+                incompatibleVersionContext(), "", requestBody, MINIMAL_TASK.id()));
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnGetTaskPushNotificationConfiguration() {
+        RestHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        assertVersionRejected(handler.getTaskPushNotificationConfiguration(
+                incompatibleVersionContext(), "", MINIMAL_TASK.id(), "config-1"));
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnListTaskPushNotificationConfigurations() {
+        RestHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        assertVersionRejected(handler.listTaskPushNotificationConfigurations(
+                incompatibleVersionContext(), "", MINIMAL_TASK.id(), 10, ""));
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnDeleteTaskPushNotificationConfiguration() {
+        RestHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        assertVersionRejected(handler.deleteTaskPushNotificationConfiguration(
+                incompatibleVersionContext(), "", MINIMAL_TASK.id(), "config-1"));
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnGetExtendedAgentCard() {
+        AgentCard card = versionTestCard();
+        AgentCard extended = AgentCard.builder(card).description("extended").build();
+        Instance<AgentCard> extendedInstance = new FixedInstance<>(extended);
+
+        RestHandler handler = new RestHandler(new FixedInstance<>(card), extendedInstance,
+                createCacheMetadata(card), requestHandler, internalExecutor);
+
+        assertVersionRejected(handler.getExtendedAgentCard(incompatibleVersionContext(), ""));
+    }
+
+    @Test
+    public void testVersionNotSupportedErrorOnSubscribeToTask() throws Exception {
+        RestHandler handler = versionTestHandler();
+        taskStore.save(MINIMAL_TASK, false);
+
+        RestHandler.HTTPRestResponse response =
+                handler.subscribeToTask(incompatibleVersionContext(), "", MINIMAL_TASK.id());
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertInstanceOf(RestHandler.HTTPRestStreamingResponse.class, response);
+        assertVersionRejectedInStream((RestHandler.HTTPRestStreamingResponse) response);
+    }
+
+    /**
+     * A card whose sole interface speaks protocol version 1.0, with every capability enabled so
+     * that each operation reaches the version check instead of stopping at a capability guard.
+     */
+    private static AgentCard versionTestCard() {
+        return AgentCard.builder()
+                .name("test-card")
+                .description("Test card with version 1.0")
+                .supportedInterfaces(Collections.singletonList(new AgentInterface("HTTP+JSON", "http://localhost:9999")))
+                .version("1.0.0")
+                .capabilities(AgentCapabilities.builder()
+                        .streaming(true)
+                        .pushNotifications(true)
+                        .extendedAgentCard(true)
+                        .build())
+                .defaultInputModes(List.of("text"))
+                .defaultOutputModes(List.of("text"))
+                .skills(List.of())
+                .build();
+    }
+
+    private RestHandler versionTestHandler() {
+        AgentCard card = versionTestCard();
+        return new RestHandler(card, createCacheMetadata(card), requestHandler, internalExecutor);
+    }
+
+    /**
+     * A context requesting version 2.0, whose major differs from the card built by
+     * {@link #versionTestCard()} and is therefore incompatible under section 3.6.2.
+     */
+    private static ServerCallContext incompatibleVersionContext() {
+        return new ServerCallContext(UnauthenticatedUser.INSTANCE, Map.of("foo", "bar"), new HashSet<>(), "2.0");
+    }
+
+    /**
+     * Asserts that an operation answered with the problem detail carried by a version refusal,
+     * rather than with a success status or an unrelated error.
+     *
+     * @param response the response an operation returned
+     */
+    private static void assertVersionRejected(RestHandler.HTTPRestResponse response) {
+        assertProblemDetail(response, 400, "VERSION_NOT_SUPPORTED",
+                "Protocol version '2.0' is not supported. Supported versions: [1.0]");
+    }
+
+    /**
+     * Asserts the same refusal for a streaming operation, which answers 200 and embeds the error
+     * as an event rather than surfacing it in the status line.
+     *
+     * @param response the streaming response under test
+     * @throws InterruptedException if the wait for termination is interrupted
+     */
+    private static void assertVersionRejectedInStream(RestHandler.HTTPRestStreamingResponse response)
+            throws InterruptedException {
+        AtomicBoolean errorFound = new AtomicBoolean(false);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        response.getPublisher().subscribe(new Flow.Subscriber<>() {
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(String item) {
+                JsonObject body = JsonParser.parseString(item).getAsJsonObject();
+                if (!body.has("error")) {
+                    return;
+                }
+                JsonObject error = body.getAsJsonObject("error");
+                var details = error.has("details") ? error.getAsJsonArray("details") : null;
+                if (details != null && !details.isEmpty()
+                        && "VERSION_NOT_SUPPORTED".equals(details.get(0).getAsJsonObject().get("reason").getAsString())
+                        && error.get("message").getAsString().contains("2.0")) {
+                    errorFound.set(true);
+                }
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onComplete() {
+                latch.countDown();
+            }
+        });
+
+        Assertions.assertTrue(latch.await(2, TimeUnit.SECONDS), "Expected the stream to terminate within timeout");
+        Assertions.assertTrue(errorFound.get(), "Expected a VERSION_NOT_SUPPORTED event in the stream");
     }
 }


### PR DESCRIPTION
# Description

`A2AVersionValidator` was called from two places in each transport, both of them message sends. A client on an unsupported version was refused on `sendMessage` and served normally on the other nine operations. #1042 fixed this for gRPC; this does the same for JSON-RPC and REST.

Both handlers receive the `ServerCallContext` as a parameter rather than building it, so there is no `createCallContext` to centralize in. A private `validateRequest` carries the pair of checks and every operation calls it before reaching the request handler.

## Behaviour change

A client that sends no `A2A-Version` is now refused on every operation rather than only on message sends, since section 3.6.2 makes the empty value mean 0.3 and a 1.0-only card rejects it.

Four REST tests called `GET /tasks/{id}` without the header; they now send it, as section 3.6.1 requires of clients on every request. The SDK's own REST and JSON-RPC clients already send it, as does the TCK.

## Tests

Nine new tests per transport, one for each operation that now validates.

- [ ] Follow the [`CONTRIBUTING` Guide](../CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests pass
- [ ] Appropriate READMEs were updated (if necessary)

Fixes #1035 🦕
