### PR TITLE
chore: Don't deploy tests and examples to Maven

### DIFF
--- a/boms/test-utils/pom.xml
+++ b/boms/test-utils/pom.xml
@@ -21,6 +21,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <build>

--- a/compat-0.3/tests/server-common/pom.xml
+++ b/compat-0.3/tests/server-common/pom.xml
@@ -17,6 +17,10 @@
     <name>Java A2A Compat 0.3 Server Tests Common</name>
     <description>Java SDK for the Agent2Agent Protocol (A2A) - Compat 0.3 Server Tests Common</description>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/examples/cloud-deployment/server/pom.xml
+++ b/examples/cloud-deployment/server/pom.xml
@@ -16,6 +16,10 @@
     <name>A2A Java SDK - Cloud Deployment Example Server</name>
     <description>Example demonstrating A2A agent deployment in Kubernetes with database persistence and event replication</description>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <!-- Core A2A SDK with JSON-RPC transport. This pulls in the rest of the needed a2a-java dependencies -->
         <dependency>

--- a/examples/helloworld/pom.xml
+++ b/examples/helloworld/pom.xml
@@ -15,6 +15,10 @@
     <packaging>pom</packaging>
 
     <name>Java SDK A2A Examples: Hello World</name>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
     <description>Examples for the Java SDK for the Agent2Agent Protocol (A2A)</description>
 
     <dependencyManagement>

--- a/examples/stream-lifecycle/pom.xml
+++ b/examples/stream-lifecycle/pom.xml
@@ -15,6 +15,10 @@
     <packaging>pom</packaging>
 
     <name>Java SDK A2A Examples: Stream Lifecycle</name>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
     <description>Example demonstrating TaskStreamLifecycleHook for managing streaming connections</description>
 
     <dependencyManagement>

--- a/extras/opentelemetry/integration-tests/pom.xml
+++ b/extras/opentelemetry/integration-tests/pom.xml
@@ -15,6 +15,10 @@
     <name>A2A Java SDK :: Extras :: OpenTelemetry :: Integration Tests</name>
     <description>Quarkus-based integration tests for OpenTelemetry support in A2A Java SDK</description>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <!-- A2A SDK modules -->
         <dependency>

--- a/extras/queue-manager-replicated/tests-multi-instance/pom.xml
+++ b/extras/queue-manager-replicated/tests-multi-instance/pom.xml
@@ -15,6 +15,10 @@
     <packaging>pom</packaging>
     <name>Java A2A Extras: Replicated Queue Manager Tests - Multi Instance Parent</name>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <modules>
         <module>quarkus-common</module>
         <module>quarkus-app-1</module>

--- a/extras/queue-manager-replicated/tests-single-instance/pom.xml
+++ b/extras/queue-manager-replicated/tests-single-instance/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>a2a-java-queue-manager-replicated-tests-single-instance</artifactId>
     <name>Java A2A Extras: Replicated Queue Manager Tests - Single Instance</name>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <!-- Project Modules -->
         <dependency>

--- a/tests/multiversion/grpc/pom.xml
+++ b/tests/multiversion/grpc/pom.xml
@@ -17,6 +17,10 @@
     <name>Java A2A SDK Tests Multi-Version gRPC</name>
     <description>Tests for multi-version v1.0/v0.3 gRPC deployment</description>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <!-- v1.0 gRPC reference server -->
         <dependency>

--- a/tests/multiversion/jsonrpc/pom.xml
+++ b/tests/multiversion/jsonrpc/pom.xml
@@ -17,6 +17,10 @@
     <name>Java A2A SDK Tests Multi-Version JSON-RPC</name>
     <description>Tests for multi-version v1.0/v0.3 JSON-RPC deployment</description>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <!-- Production multiversion module (provides MultiVersionJSONRPCRoutes) -->
         <dependency>

--- a/tests/multiversion/rest/pom.xml
+++ b/tests/multiversion/rest/pom.xml
@@ -17,6 +17,10 @@
     <name>Java A2A SDK Tests Multi-Version REST</name>
     <description>Tests for multi-version v1.0/v0.3 REST deployment</description>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <!-- Production multiversion module (provides MultiVersionRestRoutes) -->
         <dependency>


### PR DESCRIPTION
This is an effort to save size.

The reusable tests in server-common, and the TCKs are intended for use by external integrations so they need to be deployed
