### PR TITLE
fix: wrong name for docs/ artifact

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>a2a-java-sdk-jsonrpc-common</artifactId>
+    <artifactId>a2a-java-sdk-docs</artifactId>
     <packaging>quarkus</packaging>
 
     <properties>
@@ -18,6 +18,7 @@
         <roq.version>2.1.6</roq.version>
         <roq.version>2.1.4</roq.version>
         <maven.compiler.release>21</maven.compiler.release>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Also add property so it won't be deployed to Maven as a safeguard, although it currently is not part of the aggregator modules
