### PR TITLE
feat(http-client): add CDI provider and priority-ordered factory fallback

### DIFF
--- a/boms/extras/pom.xml
+++ b/boms/extras/pom.xml
@@ -46,6 +46,11 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>a2a-java-sdk-http-client-cdi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>a2a-java-sdk-opentelemetry-common</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/boms/extras/src/it/extras-usage-test/pom.xml
+++ b/boms/extras/src/it/extras-usage-test/pom.xml
@@ -54,6 +54,10 @@
         </dependency>
         <dependency>
             <groupId>org.a2aproject.sdk</groupId>
+            <artifactId>a2a-java-sdk-http-client-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.a2aproject.sdk</groupId>
             <artifactId>a2a-java-sdk-opentelemetry-common</artifactId>
         </dependency>
         <dependency>

--- a/docs/content/dev/extra/http-clients.md
+++ b/docs/content/dev/extra/http-clients.md
@@ -6,7 +6,7 @@ layout: page
 
 # HTTP Clients
 
-The A2A SDK uses an `A2AHttpClient` abstraction for all HTTP communication — fetching agent cards, making transport calls, and Server-Sent Events (SSE) streaming. By default, the SDK uses a JDK 11+ HttpClient implementation. These extras provide alternative implementations.
+The A2A SDK uses an `A2AHttpClient` abstraction for all HTTP communication — fetching agent cards, making transport calls, and Server-Sent Events (SSE) streaming. By default, the SDK uses a JDK 11+ HttpClient implementation. These extras provide alternative implementations or a CDI-based extension point for custom clients.
 
 ## Vert.x HTTP Client
 
@@ -53,7 +53,19 @@ For non-Quarkus environments, also add `vertx-web-client`:
 
 ### 2. Automatic Discovery (No Code Changes)
 
-The `VertxA2AHttpClientProvider` has **priority 100** (vs. 0 for the JDK client). The SDK's `A2AHttpClientFactory` uses `ServiceLoader` to discover and select the highest-priority provider available:
+The `VertxA2AHttpClientProvider` has **priority 100**. The SDK's `A2AHttpClientFactory` discovers all registered providers via `ServiceLoader`, sorts them by descending priority, and tries each in order, falling back to the next one on failure.
+
+To force a specific provider by name (useful in tests), use `A2AHttpClientFactory.create(String providerName)`:
+
+```java
+// Force the JDK client regardless of what else is on the classpath
+try (A2AHttpClient client = A2AHttpClientFactory.create("jdk")) {
+    // ...
+}
+```
+
+Available built-in provider names: `jdk`, `vertx`, `android`, `cdi`.
+
 
 ```java
 // No changes needed — A2A SDK automatically uses VertxA2AHttpClient
@@ -65,7 +77,7 @@ Client client = Client.builder(card)
     .build();
 ```
 
-If Vert.x classes are not on the classpath, the provider returns priority `-1` and the SDK falls back to the JDK HttpClient.
+If Vert.x classes are not on the classpath, the provider returns priority `-1` and the SDK falls back to the next available provider.
 
 ### Usage Examples
 
@@ -205,3 +217,52 @@ The `AndroidA2AHttpClientProvider` has **priority 110** and detects the Android 
 - **SSE streaming** via `getAsyncSSE()` and `postAsyncSSE()` — async operations run on a dedicated cached thread pool (`A2A-Android-Net`)
 - **Timeouts**: 15 s connection, 60 s read
 - **Response size limit**: 10 MB
+
+## CDI HTTP Client
+
+Allows providing a fully custom `A2AHttpClient` bean through the CDI container. When this module is on the classpath and a user-provided `A2AHttpClient` bean is registered, it is used in place of any other provider.
+
+### When to Use
+
+- Quarkus or Jakarta EE applications that need a custom HTTP client (specific TLS configuration, connection pooling, tracing, etc.)
+- When neither the JDK nor the Vert.x client meets your requirements out of the box
+
+### 1. Add Dependency
+
+```xml
+<dependency>
+    <groupId>org.a2aproject.sdk</groupId>
+    <artifactId>a2a-java-sdk-http-client-cdi</artifactId>
+</dependency>
+```
+
+### 2. Produce an A2AHttpClient Bean
+
+Declare a CDI producer in your application. The SDK will discover and use it automatically:
+
+```java
+@ApplicationScoped
+public class MyHttpClientProducer {
+
+    @Produces
+    @ApplicationScoped
+    public A2AHttpClient produce(MyConfig config) {
+        // return any A2AHttpClient implementation
+    }
+}
+```
+
+> **Scope requirement:** Use a normal scope such as `@ApplicationScoped`. A `@Dependent`-scoped producer will leak a new unmanaged instance on every `create()` call because the `Instance` used to obtain the bean is discarded immediately and CDI cannot destroy the dependent instance.
+
+### How It Works
+
+`CdiA2AHttpClientProvider` has **priority 200** — the highest of all built-in providers (Android: 110, Vert.x: 100, JDK: 0). The `A2AHttpClientFactory` iterates providers in descending priority order and falls back to the next one if a provider is unavailable:
+
+| Priority | Provider | Activates when |
+|----------|----------|----------------|
+| 200 | CDI | A CDI container is active and an `A2AHttpClient` bean is registered |
+| 110 | Android | Android runtime detected |
+| 100 | Vert.x | `vertx-web-client` is on the classpath |
+| 0 | JDK | Always (fallback) |
+
+If the CDI container is active but no `A2AHttpClient` bean is registered, this provider is skipped and the next available provider is used.

--- a/docs/content/dev/extras.md
+++ b/docs/content/dev/extras.md
@@ -30,7 +30,7 @@ Import the extras BOM to manage versions:
 
 ## [HTTP Clients](../extra/http-clients)
 
-Alternative `A2AHttpClient` implementations. The **Vert.x HTTP Client** (`a2a-java-sdk-http-client-vertx`) replaces the default JDK HttpClient with a reactive, non-blocking Vert.x WebClient — recommended for Quarkus, reactive frameworks, and high-throughput scenarios. An **Android HTTP Client** (`a2a-java-sdk-http-client-android`) is also available for mobile applications.
+Alternative `A2AHttpClient` implementations. The **Vert.x HTTP Client** (`a2a-java-sdk-http-client-vertx`) replaces the default JDK HttpClient with a reactive, non-blocking Vert.x WebClient — recommended for Quarkus, reactive frameworks, and high-throughput scenarios. An **Android HTTP Client** (`a2a-java-sdk-http-client-android`) is available for mobile applications. The **CDI HTTP Client** (`a2a-java-sdk-http-client-cdi`) lets you supply any custom `A2AHttpClient` bean via the CDI container, taking highest priority (200) over all built-in providers.
 
 ## [Storage & Persistence](../extra/storage)
 

--- a/extras/http-client-cdi/pom.xml
+++ b/extras/http-client-cdi/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.a2aproject.sdk</groupId>
+        <artifactId>a2a-java-sdk-parent</artifactId>
+        <version>1.2.1.Final-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>a2a-java-sdk-http-client-cdi</artifactId>
+
+    <packaging>jar</packaging>
+
+    <name>Java SDK A2A HTTP Client - CDI Implementation</name>
+    <description>CDI-based A2AHttpClientProvider that resolves a user-provided A2AHttpClient bean from the CDI container</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>a2a-java-sdk-http-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/extras/http-client-cdi/src/main/java/org/a2aproject/sdk/client/http/cdi/CdiA2AHttpClientProvider.java
+++ b/extras/http-client-cdi/src/main/java/org/a2aproject/sdk/client/http/cdi/CdiA2AHttpClientProvider.java
@@ -1,0 +1,56 @@
+package org.a2aproject.sdk.client.http.cdi;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+
+import org.a2aproject.sdk.client.http.A2AHttpClient;
+import org.a2aproject.sdk.client.http.A2AHttpClientProvider;
+
+/**
+ * CDI-based {@link A2AHttpClientProvider} that resolves an {@link A2AHttpClient} bean
+ * from the CDI container.
+ *
+ * <p>When a user declares a CDI producer for {@link A2AHttpClient}, this provider
+ * picks it up at priority 200 (above Vert.x at 100 and JDK at 0), allowing
+ * application-level customization without replacing the ServiceLoader mechanism.
+ *
+ * <p>If no CDI container is active, or if no unambiguous {@link A2AHttpClient} bean
+ * is registered, this provider throws and the factory falls back to the next
+ * lower-priority provider.
+ *
+ * <p><strong>Scope requirement:</strong> The producer must use a normal scope (e.g.
+ * {@code @ApplicationScoped}). A {@code @Dependent}-scoped producer will leak a new
+ * unmanaged instance on every {@code create()} call, because the {@link Instance}
+ * used to obtain the bean is discarded after this method returns and CDI cannot
+ * destroy the dependent instance.
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * @Produces
+ * @ApplicationScoped
+ * public A2AHttpClient myHttpClient(MyConfig config) {
+ *     return ...; // custom client
+ * }
+ * }</pre>
+ */
+public final class CdiA2AHttpClientProvider implements A2AHttpClientProvider {
+
+    @Override
+    public A2AHttpClient create() {
+        Instance<A2AHttpClient> instance = CDI.current().select(A2AHttpClient.class);
+        if (!instance.isResolvable()) {
+            throw new IllegalStateException("No unambiguous A2AHttpClient CDI bean found");
+        }
+        return instance.get();
+    }
+
+    @Override
+    public int priority() {
+        return 200;
+    }
+
+    @Override
+    public String name() {
+        return "cdi";
+    }
+}

--- a/extras/http-client-cdi/src/main/java/org/a2aproject/sdk/client/http/cdi/package-info.java
+++ b/extras/http-client-cdi/src/main/java/org/a2aproject/sdk/client/http/cdi/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.a2aproject.sdk.client.http.cdi;
+
+import org.jspecify.annotations.NullMarked;

--- a/extras/http-client-cdi/src/main/resources/META-INF/services/org.a2aproject.sdk.client.http.A2AHttpClientProvider
+++ b/extras/http-client-cdi/src/main/resources/META-INF/services/org.a2aproject.sdk.client.http.A2AHttpClientProvider
@@ -1,0 +1,1 @@
+org.a2aproject.sdk.client.http.cdi.CdiA2AHttpClientProvider

--- a/extras/http-client-cdi/src/test/java/org/a2aproject/sdk/client/http/cdi/AnotherDummyA2AHttpClient.java
+++ b/extras/http-client-cdi/src/test/java/org/a2aproject/sdk/client/http/cdi/AnotherDummyA2AHttpClient.java
@@ -1,0 +1,25 @@
+package org.a2aproject.sdk.client.http.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.a2aproject.sdk.client.http.A2AHttpClient;
+
+// Second distinct A2AHttpClient type registered alongside DummyA2AHttpClient to produce an
+// ambiguous CDI resolution — two beans of the same type with no qualifier to disambiguate.
+@ApplicationScoped
+class AnotherDummyA2AHttpClient implements A2AHttpClient {
+
+    @Override
+    public GetBuilder createGet() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PostBuilder createPost() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DeleteBuilder createDelete() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extras/http-client-cdi/src/test/java/org/a2aproject/sdk/client/http/cdi/CdiA2AHttpClientFactoryTest.java
+++ b/extras/http-client-cdi/src/test/java/org/a2aproject/sdk/client/http/cdi/CdiA2AHttpClientFactoryTest.java
@@ -1,0 +1,167 @@
+package org.a2aproject.sdk.client.http.cdi;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.a2aproject.sdk.client.http.A2AHttpClient;
+import org.a2aproject.sdk.client.http.A2AHttpClientFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class CdiA2AHttpClientFactoryTest {
+
+    private static void assertCdiProviderSkippedLogged(List<LogRecord> records, String context) {
+        assertTrue(records.stream()
+                .anyMatch(r -> r.getLevel() == Level.WARNING
+                        && r.getMessage().equals("Provider cdi skipped")),
+                "Expected WARNING 'Provider cdi skipped' " + context);
+    }
+
+    private static List<LogRecord> captureFactoryWarnings(Runnable action) {
+        Logger logger = Logger.getLogger(A2AHttpClientFactory.class.getName());
+        List<LogRecord> records = new ArrayList<>();
+        Handler captureHandler = new Handler() {
+            @Override public void publish(LogRecord r) { records.add(r); }
+            @Override public void flush() {}
+            @Override public void close() {}
+        };
+        Level saved = logger.getLevel();
+        logger.setLevel(Level.WARNING);
+        logger.addHandler(captureHandler);
+        try {
+            action.run();
+        } finally {
+            logger.removeHandler(captureHandler);
+            logger.setLevel(saved);
+        }
+        return records;
+    }
+
+    @Nested
+    class WithCdiContainer {
+
+        private SeContainer container;
+
+        @BeforeEach
+        void startContainer() {
+            container = SeContainerInitializer.newInstance()
+                    .disableDiscovery()
+                    .addBeanClasses(DummyA2AHttpClient.class)
+                    .initialize();
+        }
+
+        @AfterEach
+        void closeContainer() {
+            container.close();
+        }
+
+        @Test
+        public void testCreateUsesCdiBeanAtPriority200() {
+            A2AHttpClient result = A2AHttpClientFactory.create();
+            assertNotNull(result);
+            assertInstanceOf(DummyA2AHttpClient.class, result,
+                    "Factory should return CDI-provided client (priority 200) over JDK/Vert.x");
+        }
+
+        @Test
+        public void testCreateDoesNotLogWarningWhenCdiSucceeds() {
+            List<LogRecord> records = captureFactoryWarnings(A2AHttpClientFactory::create);
+            assertFalse(records.stream().anyMatch(r -> r.getLevel() == Level.WARNING),
+                    "No warning should be logged when CDI provider succeeds");
+        }
+    }
+
+    @Nested
+    class WithCdiContainerButNoBeanRegistered {
+
+        private SeContainer container;
+
+        @BeforeEach
+        void startContainer() {
+            container = SeContainerInitializer.newInstance()
+                    .disableDiscovery()
+                    .addBeanClasses(FillerBean.class)
+                    .initialize();
+        }
+
+        @AfterEach
+        void closeContainer() {
+            container.close();
+        }
+
+        @Test
+        public void testCreateFallsBackWhenNoBeanRegistered() {
+            A2AHttpClient client = A2AHttpClientFactory.create();
+            assertNotNull(client, "Factory should fall back when CDI has no A2AHttpClient bean");
+            assertFalse(client instanceof DummyA2AHttpClient,
+                    "Fallback client must not be the CDI bean");
+        }
+
+        @Test
+        public void testCreateLogsWarningWhenNoBeanRegistered() {
+            List<LogRecord> records = captureFactoryWarnings(A2AHttpClientFactory::create);
+            assertCdiProviderSkippedLogged(records, "when CDI has no A2AHttpClient bean");
+        }
+    }
+
+    @Nested
+    class WithAmbiguousBeansInContainer {
+
+        private SeContainer container;
+
+        @BeforeEach
+        void startContainer() {
+            container = SeContainerInitializer.newInstance()
+                    .disableDiscovery()
+                    .addBeanClasses(DummyA2AHttpClient.class, AnotherDummyA2AHttpClient.class)
+                    .initialize();
+        }
+
+        @AfterEach
+        void closeContainer() {
+            container.close();
+        }
+
+        @Test
+        public void testCreateFallsBackWhenBeansAreAmbiguous() {
+            A2AHttpClient client = A2AHttpClientFactory.create();
+            assertNotNull(client, "Factory should fall back when CDI resolution is ambiguous");
+            assertFalse(client instanceof DummyA2AHttpClient || client instanceof AnotherDummyA2AHttpClient,
+                    "Fallback client must not be any of the ambiguous CDI beans");
+        }
+
+        @Test
+        public void testCreateLogsWarningWhenBeansAreAmbiguous() {
+            List<LogRecord> records = captureFactoryWarnings(A2AHttpClientFactory::create);
+            assertCdiProviderSkippedLogged(records, "when CDI resolution is ambiguous");
+        }
+    }
+
+    @Nested
+    class WithoutCdiContainer {
+
+        @Test
+        public void testCreateFallsBackWhenNoCdiContainer() {
+            A2AHttpClient client = A2AHttpClientFactory.create();
+            assertNotNull(client, "Factory should fall back to next provider when CDI is unavailable");
+        }
+
+        @Test
+        public void testCreateLogsWarningWhenNoCdiContainer() {
+            List<LogRecord> records = captureFactoryWarnings(A2AHttpClientFactory::create);
+            assertCdiProviderSkippedLogged(records, "when no CDI container is active");
+        }
+    }
+}

--- a/extras/http-client-cdi/src/test/java/org/a2aproject/sdk/client/http/cdi/CdiA2AHttpClientProviderTest.java
+++ b/extras/http-client-cdi/src/test/java/org/a2aproject/sdk/client/http/cdi/CdiA2AHttpClientProviderTest.java
@@ -1,0 +1,99 @@
+package org.a2aproject.sdk.client.http.cdi;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import org.a2aproject.sdk.client.http.A2AHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class CdiA2AHttpClientProviderTest {
+
+    @Nested
+    class WithBeanInContainer {
+
+        private SeContainer container;
+
+        @BeforeEach
+        void startContainer() {
+            container = SeContainerInitializer.newInstance()
+                    .disableDiscovery()
+                    .addBeanClasses(DummyA2AHttpClient.class)
+                    .initialize();
+        }
+
+        @AfterEach
+        void closeContainer() {
+            container.close();
+        }
+
+        @Test
+        public void testCreateReturnsBeanWhenResolvable() {
+            A2AHttpClient result = new CdiA2AHttpClientProvider().create();
+            assertNotNull(result);
+            assertInstanceOf(DummyA2AHttpClient.class, result);
+        }
+    }
+
+    @Nested
+    class WithoutBeanInContainer {
+
+        private SeContainer container;
+
+        @BeforeEach
+        void startContainer() {
+            container = SeContainerInitializer.newInstance()
+                    .disableDiscovery()
+                    .addBeanClasses(FillerBean.class)
+                    .initialize();
+        }
+
+        @AfterEach
+        void closeContainer() {
+            container.close();
+        }
+
+        @Test
+        public void testCreateThrowsWhenNoBeanRegistered() {
+            assertThrows(IllegalStateException.class, new CdiA2AHttpClientProvider()::create);
+        }
+    }
+
+    @Nested
+    class WithAmbiguousBeansInContainer {
+
+        private SeContainer container;
+
+        @BeforeEach
+        void startContainer() {
+            container = SeContainerInitializer.newInstance()
+                    .disableDiscovery()
+                    .addBeanClasses(DummyA2AHttpClient.class, AnotherDummyA2AHttpClient.class)
+                    .initialize();
+        }
+
+        @AfterEach
+        void closeContainer() {
+            container.close();
+        }
+
+        @Test
+        public void testCreateThrowsWhenMultipleBeansRegistered() {
+            assertThrows(IllegalStateException.class, new CdiA2AHttpClientProvider()::create);
+        }
+    }
+
+    @Nested
+    class WithoutCdiContainer {
+
+        @Test
+        public void testCreateThrowsWhenNoCdiContainer() {
+            assertThrows(IllegalStateException.class, new CdiA2AHttpClientProvider()::create);
+        }
+    }
+}

--- a/extras/http-client-cdi/src/test/java/org/a2aproject/sdk/client/http/cdi/DummyA2AHttpClient.java
+++ b/extras/http-client-cdi/src/test/java/org/a2aproject/sdk/client/http/cdi/DummyA2AHttpClient.java
@@ -1,0 +1,23 @@
+package org.a2aproject.sdk.client.http.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.a2aproject.sdk.client.http.A2AHttpClient;
+
+@ApplicationScoped
+class DummyA2AHttpClient implements A2AHttpClient {
+
+    @Override
+    public GetBuilder createGet() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PostBuilder createPost() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DeleteBuilder createDelete() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extras/http-client-cdi/src/test/java/org/a2aproject/sdk/client/http/cdi/FillerBean.java
+++ b/extras/http-client-cdi/src/test/java/org/a2aproject/sdk/client/http/cdi/FillerBean.java
@@ -1,0 +1,8 @@
+package org.a2aproject.sdk.client.http.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+// Weld SE requires at least one bean class when disableDiscovery() is active.
+// Used in test scenarios that start a CDI container without registering an A2AHttpClient bean.
+@ApplicationScoped
+class FillerBean {}

--- a/extras/http-client-vertx/src/main/java/org/a2aproject/sdk/client/http/vertx/VertxA2AHttpClientProvider.java
+++ b/extras/http-client-vertx/src/main/java/org/a2aproject/sdk/client/http/vertx/VertxA2AHttpClientProvider.java
@@ -10,8 +10,9 @@ import org.a2aproject.sdk.client.http.A2AHttpClientProvider;
  * Service provider for {@link VertxA2AHttpClient}.
  *
  * <p>
- * This provider has a higher priority (100) than the JDK implementation and will be
- * preferred when the Vert.x dependencies are available on the classpath.
+ * This provider has priority 100, placing it above the JDK implementation (0) but below
+ * the Android (110) and CDI (200) providers. It is preferred over JDK when the Vert.x
+ * dependencies are available on the classpath.
  *
  * <p>
  * If Vert.x classes are not available at runtime, this provider will check for their
@@ -20,8 +21,8 @@ import org.a2aproject.sdk.client.http.A2AHttpClientProvider;
  */
 public final class VertxA2AHttpClientProvider implements A2AHttpClientProvider {
 
+    private static final Logger LOGGER = Logger.getLogger(VertxA2AHttpClientProvider.class.getName());
     private static final boolean VERTX_AVAILABLE = isVertxAvailable();
-    private static final Logger log = Logger.getLogger(VertxA2AHttpClientProvider.class.getName());
 
     private static boolean isVertxAvailable() {
         try {
@@ -29,7 +30,7 @@ public final class VertxA2AHttpClientProvider implements A2AHttpClientProvider {
             Class.forName("io.vertx.ext.web.client.WebClient");
             return true;
         } catch (ClassNotFoundException ex) {
-            Logger.getLogger(VertxA2AHttpClientProvider.class.getName()).log(Level.FINE, "Vert.x classes are not available on the classpath. Falling back to other providers.", ex);
+            LOGGER.log(Level.FINE, "Vert.x classes are not available on the classpath. Falling back to other providers.", ex);
             return false;
         }
     }

--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/A2AHttpClientFactory.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/A2AHttpClientFactory.java
@@ -3,20 +3,22 @@ package org.a2aproject.sdk.client.http;
 import java.util.Comparator;
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.stream.Collectors;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
  * Factory for creating {@link A2AHttpClient} instances using the ServiceLoader mechanism.
  *
  * <p>
- * This factory discovers available {@link A2AHttpClientProvider} implementations at runtime
- * and selects the one with the highest priority. If no providers are found, it throws
- * an {@link IllegalStateException}.
+ * This factory discovers available {@link A2AHttpClientProvider} implementations at runtime,
+ * tries them in descending priority order, and returns the first one that succeeds.
+ * If no provider can be instantiated, it throws an {@link IllegalStateException}.
  *
  * <h2>Usage</h2>
  * <pre>{@code
- * // Get the default client (highest priority provider)
+ * // Get the default client (highest available priority provider)
  * A2AHttpClient client = A2AHttpClientFactory.create();
  *
  * // Use with try-with-resources if the client implements AutoCloseable
@@ -29,10 +31,13 @@ import java.util.stream.StreamSupport;
  *
  * <h2>Priority System</h2>
  * <p>
- * Providers are selected based on their priority value (higher is better):
+ * Providers are tried in descending priority order. If a provider's {@code create()} throws,
+ * the factory logs the failure at {@code WARNING} level and falls back to the next provider:
  * <ul>
- * <li>JdkA2AHttpClient: priority 0 (fallback)</li>
- * <li>VertxA2AHttpClient: priority 100 (preferred when available)</li>
+ * <li>CdiA2AHttpClient: priority 200 (CDI-provided bean, when a container and bean are active)</li>
+ * <li>AndroidA2AHttpClient: priority 110 (Android runtime only)</li>
+ * <li>VertxA2AHttpClient: priority 100 (when {@code vertx-web-client} is on the classpath)</li>
+ * <li>JdkA2AHttpClient: priority 0 (always available, last resort)</li>
  * </ul>
  *
  * <h2>Custom Providers</h2>
@@ -42,11 +47,13 @@ import java.util.stream.StreamSupport;
  */
 public final class A2AHttpClientFactory {
 
+    private static final Logger LOGGER = Logger.getLogger(A2AHttpClientFactory.class.getName());
     private static final List<A2AHttpClientProvider> PROVIDERS;
 
     static {
         PROVIDERS = StreamSupport.stream(ServiceLoader.load(A2AHttpClientProvider.class, A2AHttpClientProvider.class.getClassLoader()).spliterator(), false)
-                .collect(Collectors.toList());
+                .sorted(Comparator.comparingInt(A2AHttpClientProvider::priority).reversed())
+                .toList();
     }
 
     private A2AHttpClientFactory() {
@@ -54,20 +61,28 @@ public final class A2AHttpClientFactory {
     }
 
     /**
-     * Creates a new A2AHttpClient instance using the highest priority provider available.
+     * Creates a new A2AHttpClient instance using the highest available priority provider.
      *
      * <p>
-     * This method uses the ServiceLoader mechanism to discover providers at runtime.
-     * If no providers are found, it throws an {@link IllegalStateException}.
+     * Providers are tried in descending priority order. If a provider's {@code create()}
+     * throws, it is skipped and the next provider is tried. Failures are logged at
+     * {@code WARNING} level.
      *
      * @return a new A2AHttpClient instance
-     * @throws IllegalStateException if no providers are found
+     * @throws IllegalStateException if no provider found or all providers failed to instantiate
      */
     public static A2AHttpClient create() {
         return PROVIDERS.stream()
-                .max(Comparator.comparingInt(A2AHttpClientProvider::priority))
-                .map(A2AHttpClientProvider::create)
-                .orElseThrow(() -> new IllegalStateException("No A2AHttpClientProvider found"));
+                .flatMap(p -> {
+                    try {
+                        return Stream.of(p.create());
+                    } catch (Exception e) {
+                        LOGGER.log(Level.WARNING, e, () -> "Provider " + p.name() + " skipped");
+                        return Stream.empty();
+                    }
+                })
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No A2AHttpClientProvider could be instantiated"));
     }
 
     /**
@@ -85,11 +100,8 @@ public final class A2AHttpClientFactory {
             throw new IllegalArgumentException("Provider name must not be null or empty");
         }
 
-        ServiceLoader<A2AHttpClientProvider> loader =
-                ServiceLoader.load(A2AHttpClientProvider.class, A2AHttpClientProvider.class.getClassLoader());
-
-        return StreamSupport.stream(loader.spliterator(), false)
-                .filter(provider -> providerName.equals(provider.name()))
+        return PROVIDERS.stream()
+                .filter(p -> providerName.equals(p.name()))
                 .findFirst()
                 .map(A2AHttpClientProvider::create)
                 .orElseThrow(() -> new IllegalArgumentException(

--- a/http-client/src/main/java/org/a2aproject/sdk/client/http/A2AHttpClientProvider.java
+++ b/http-client/src/main/java/org/a2aproject/sdk/client/http/A2AHttpClientProvider.java
@@ -5,8 +5,9 @@ package org.a2aproject.sdk.client.http;
  *
  * <p>
  * Implementations of this interface can be registered via the Java ServiceLoader
- * mechanism. The {@link A2AHttpClientFactory} will discover and use the highest
- * priority provider available.
+ * mechanism. The {@link A2AHttpClientFactory} discovers all registered providers,
+ * sorts them by descending {@link #priority()}, and tries each in order, returning
+ * the first one whose {@link #create()} succeeds.
  *
  * <p>
  * To register a provider, create a file named
@@ -24,13 +25,15 @@ public interface A2AHttpClientProvider {
 
     /**
      * Returns the priority of this provider. Higher priority providers are
-     * preferred over lower priority ones.
+     * tried first; the first one whose {@link #create()} succeeds is used.
      *
      * <p>
-     * Default priorities:
+     * Built-in priorities (for reference when choosing a custom value):
      * <ul>
-     * <li>JdkA2AHttpClient: 0 (fallback)</li>
-     * <li>VertxA2AHttpClient: 100 (preferred when available)</li>
+     * <li>CdiA2AHttpClient: 200 (CDI-provided bean, when a container and bean are active)</li>
+     * <li>AndroidA2AHttpClient: 110 (Android runtime only)</li>
+     * <li>VertxA2AHttpClient: 100 (when {@code vertx-web-client} is on the classpath)</li>
+     * <li>JdkA2AHttpClient: 0 (always available, last resort)</li>
      * </ul>
      *
      * @return the priority value (higher is better)

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <mapstruct.version>1.6.3</mapstruct.version>
         <mapstruct-spi-protobuf.version>1.62.0</mapstruct-spi-protobuf.version>
         <mockito-core.version>5.23.0</mockito-core.version>
+        <weld-se-core.version>5.1.7.Final</weld-se-core.version>
         <mockserver.version>6.1.0</mockserver.version>
         <mutiny-zero.version>1.1.1</mutiny-zero.version>
         <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
@@ -347,6 +348,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.jboss.weld.se</groupId>
+                <artifactId>weld-se-core</artifactId>
+                <version>${weld-se-core.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.mock-server</groupId>
                 <artifactId>mockserver-netty</artifactId>
                 <version>${mockserver.version}</version>
@@ -584,6 +591,7 @@
         <module>extras/queue-manager-replicated</module>
         <module>extras/http-client-vertx</module>
         <module>extras/http-client-android</module>
+        <module>extras/http-client-cdi</module>
         <module>http-client</module>
         <module>jsonrpc-common</module>
         <module>integrations/microprofile-config</module>


### PR DESCRIPTION
- new extras/http-client-cdi module: CdiA2AHttpClientProvider (priority 200) resolves a user-provided A2AHttpClient CDI bean via CDI.current()
- factory iterates providers sorted by descending priority, catching exceptions and falling back to the next provider instead of failing


Fixes #135 🦕