### PR TITLE
fix(jsonrpc): fix tenant extraction in getTenantAgentCard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -632,6 +632,9 @@
         <!-- Multitenancy test module (Weld SE unit tests, no Quarkus) -->
         <module>tests/multitenancy</module>
 
+        <!-- Multitenancy JSON-RPC integration tests (no REST transport on classpath) -->
+        <module>tests/multitenancy/jsonrpc</module>
+
         <!-- Multi-version test modules -->
         <module>tests/multiversion/jsonrpc</module>
         <module>tests/multiversion/rest</module>

--- a/reference/jsonrpc/src/main/java/org/a2aproject/sdk/server/apps/quarkus/A2AServerRoutes.java
+++ b/reference/jsonrpc/src/main/java/org/a2aproject/sdk/server/apps/quarkus/A2AServerRoutes.java
@@ -440,7 +440,7 @@ public class A2AServerRoutes {
      * @throws JsonProcessingException if serialization fails
      */
     public String getTenantAgentCard(RoutingContext rc) throws JsonProcessingException {
-        String tenant = extractTenant(rc);
+        String tenant = rc.pathParam("tenant");
         cacheMetadata.getHttpHeadersMap().forEach((k, v) -> rc.response().putHeader(k, v));
         return JsonUtil.toJson(jsonRpcHandler.getAgentCard(tenant));
     }

--- a/tests/multitenancy/jsonrpc/pom.xml
+++ b/tests/multitenancy/jsonrpc/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.a2aproject.sdk</groupId>
+        <artifactId>a2a-java-sdk-parent</artifactId>
+        <version>1.3.1.Final-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>a2a-java-sdk-tests-multitenancy-jsonrpc</artifactId>
+
+    <packaging>jar</packaging>
+
+    <name>Java A2A SDK Tests Multitenancy JSON-RPC</name>
+    <description>Integration tests for multi-tenant public agent card on a JSON-RPC-only server (no REST transport on classpath)</description>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>a2a-java-extras-multitenancy</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Security disabled for tests — no auth module intentionally -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/multitenancy/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multitenancy/jsonrpc/AgentCardProducer.java
+++ b/tests/multitenancy/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multitenancy/jsonrpc/AgentCardProducer.java
@@ -1,0 +1,75 @@
+package org.a2aproject.sdk.tests.multitenancy.jsonrpc;
+
+import java.util.List;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import org.a2aproject.sdk.extras.multitenancy.Tenant;
+import org.a2aproject.sdk.server.ExtendedAgentCard;
+import org.a2aproject.sdk.server.PublicAgentCard;
+import org.a2aproject.sdk.spec.AgentCapabilities;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.AgentInterface;
+import org.a2aproject.sdk.spec.TransportProtocol;
+
+@Singleton
+public class AgentCardProducer {
+
+    private static final String BASE_URL = "http://localhost:8081";
+
+    @Produces
+    @PublicAgentCard
+    public AgentCard publicCard() {
+        return card("Default Agent");
+    }
+
+    @Produces
+    @ExtendedAgentCard
+    public AgentCard defaultExtendedCard() {
+        return card("Default Agent (extended)");
+    }
+
+    @Produces
+    @Singleton
+    @Tenant("acme")
+    public AgentCard acmePublicCard() {
+        return card("Acme Agent");
+    }
+
+    @Produces
+    @Singleton
+    @Tenant("acme")
+    @ExtendedAgentCard
+    public AgentCard acmeExtendedCard() {
+        return card("Acme Agent (extended)");
+    }
+
+    @Produces
+    @Singleton
+    @Tenant("beta")
+    public AgentCard betaPublicCard() {
+        return card("Beta Agent");
+    }
+
+    @Produces
+    @Singleton
+    @Tenant("beta")
+    @ExtendedAgentCard
+    public AgentCard betaExtendedCard() {
+        return card("Beta Agent (extended)");
+    }
+
+    private static AgentCard card(String name) {
+        return AgentCard.builder()
+                .name(name)
+                .description(name)
+                .version("1.0.0")
+                .defaultInputModes(List.of("text"))
+                .defaultOutputModes(List.of("text"))
+                .capabilities(AgentCapabilities.builder().streaming(true).extendedAgentCard(true).build())
+                .skills(List.of())
+                .supportedInterfaces(List.of(new AgentInterface(TransportProtocol.JSONRPC.asString(), BASE_URL)))
+                .build();
+    }
+}

--- a/tests/multitenancy/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multitenancy/jsonrpc/AgentExecutorProducer.java
+++ b/tests/multitenancy/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multitenancy/jsonrpc/AgentExecutorProducer.java
@@ -1,0 +1,22 @@
+package org.a2aproject.sdk.tests.multitenancy.jsonrpc;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import org.a2aproject.sdk.server.agentexecution.AgentExecutor;
+import org.a2aproject.sdk.spec.TextPart;
+
+@ApplicationScoped
+public class AgentExecutorProducer {
+
+    @Produces
+    public AgentExecutor defaultExecutor() {
+        return (context, emitter) -> {
+            emitter.startWork();
+            emitter.addArtifact(List.of(new TextPart("default")));
+            emitter.complete();
+        };
+    }
+}

--- a/tests/multitenancy/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multitenancy/jsonrpc/MultiTenantJSONRPCPublicCardTest.java
+++ b/tests/multitenancy/jsonrpc/src/test/java/org/a2aproject/sdk/tests/multitenancy/jsonrpc/MultiTenantJSONRPCPublicCardTest.java
@@ -1,0 +1,53 @@
+package org.a2aproject.sdk.tests.multitenancy.jsonrpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the JSON-RPC transport serves the public agent card endpoints
+ * (/.well-known/agent-card.json and /.well-known/{tenant}/agent-card.json)
+ * when the REST transport is NOT on the classpath.
+ */
+@QuarkusTest
+public class MultiTenantJSONRPCPublicCardTest {
+
+    @Test
+    public void defaultPublicCardIsServed() {
+        String response = RestAssured.given()
+                .when().get("/.well-known/agent-card.json")
+                .then().statusCode(200)
+                .extract().asString();
+        assertEquals("Default Agent", JsonPath.from(response).getString("name"));
+    }
+
+    @Test
+    public void acmeTenantPublicCardIsServed() {
+        String response = RestAssured.given()
+                .when().get("/.well-known/acme/agent-card.json")
+                .then().statusCode(200)
+                .extract().asString();
+        assertEquals("Acme Agent", JsonPath.from(response).getString("name"));
+    }
+
+    @Test
+    public void betaTenantPublicCardIsServed() {
+        String response = RestAssured.given()
+                .when().get("/.well-known/beta/agent-card.json")
+                .then().statusCode(200)
+                .extract().asString();
+        assertEquals("Beta Agent", JsonPath.from(response).getString("name"));
+    }
+
+    @Test
+    public void unknownTenantPublicCardFallsBackToDefault() {
+        String response = RestAssured.given()
+                .when().get("/.well-known/unknown-corp/agent-card.json")
+                .then().statusCode(200)
+                .extract().asString();
+        assertEquals("Default Agent", JsonPath.from(response).getString("name"));
+    }
+}

--- a/tests/multitenancy/jsonrpc/src/test/resources/META-INF/beans.xml
+++ b/tests/multitenancy/jsonrpc/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,7 @@
+
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/tests/multitenancy/jsonrpc/src/test/resources/application.properties
+++ b/tests/multitenancy/jsonrpc/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+a2a.authorization.required=false


### PR DESCRIPTION
- Was calling extractTenant() (full normalized path) instead of rc.pathParam("tenant")
- Add tests/multitenancy/jsonrpc: proves tenant public cards work without REST on classpath

Fixes #1106 🦕