### PR TITLE
fix: keep current status messages out of task history

### DIFF
--- a/client/base/src/main/java/org/a2aproject/sdk/client/ClientTaskManager.java
+++ b/client/base/src/main/java/org/a2aproject/sdk/client/ClientTaskManager.java
@@ -67,12 +67,12 @@ class ClientTaskManager {
         }
 
         Task.Builder taskBuilder = Task.builder(task);
-        if (taskStatusUpdateEvent.status().message() != null) {
+        if (task.status().message() != null) {
             if (task.history() == null) {
-                taskBuilder.history(taskStatusUpdateEvent.status().message());
+                taskBuilder.history(task.status().message());
             } else {
                 List<Message> history = new ArrayList<>(task.history());
-                history.add(taskStatusUpdateEvent.status().message());
+                history.add(task.status().message());
                 taskBuilder.history(history);
             }
         }

--- a/client/base/src/test/java/org/a2aproject/sdk/client/ClientTaskManagerTest.java
+++ b/client/base/src/test/java/org/a2aproject/sdk/client/ClientTaskManagerTest.java
@@ -89,8 +89,8 @@ public class ClientTaskManagerTest {
         
         assertEquals(TaskState.TASK_STATE_COMPLETED, updatedTask.status().state());
         assertNotNull(updatedTask.history());
-        assertEquals(1, updatedTask.history().size());
-        assertEquals(sampleMessage, updatedTask.history().get(0));
+        assertEquals(0, updatedTask.history().size());
+        assertEquals(sampleMessage, updatedTask.status().message());
     }
 
     @Test
@@ -251,7 +251,8 @@ public class ClientTaskManagerTest {
         
         Task updatedTask1 = taskManager.saveTaskEvent(statusUpdate1);
         assertEquals(TaskState.TASK_STATE_WORKING, updatedTask1.status().state());
-        assertEquals(1, updatedTask1.history().size());
+        assertEquals(0, updatedTask1.history().size());
+        assertEquals(sampleMessage, updatedTask1.status().message());
         
         // Second status update
         Message secondMessage = Message.builder()
@@ -268,7 +269,9 @@ public class ClientTaskManagerTest {
         
         Task updatedTask2 = taskManager.saveTaskEvent(statusUpdate2);
         assertEquals(TaskState.TASK_STATE_COMPLETED, updatedTask2.status().state());
-        assertEquals(2, updatedTask2.history().size());
+        assertEquals(1, updatedTask2.history().size());
+        assertEquals(sampleMessage, updatedTask2.history().get(0));
+        assertEquals(secondMessage, updatedTask2.status().message());
     }
 
     @Test

--- a/compat-0.3/client/base/src/main/java/org/a2aproject/sdk/compat03/client/ClientTaskManager_v0_3.java
+++ b/compat-0.3/client/base/src/main/java/org/a2aproject/sdk/compat03/client/ClientTaskManager_v0_3.java
@@ -67,9 +67,9 @@ class ClientTaskManager_v0_3 {
         }
 
         Task_v0_3.Builder taskBuilder = new Task_v0_3.Builder(task);
-        if (taskStatusUpdateEvent.status().message() != null) {
+        if (task.status().message() != null) {
             List<Message_v0_3> history = new ArrayList<>(task.history());
-            history.add(taskStatusUpdateEvent.status().message());
+            history.add(task.status().message());
             taskBuilder.history(history);
         }
         if (taskStatusUpdateEvent.metadata() != null) {

--- a/compat-0.3/client/base/src/test/java/org/a2aproject/sdk/compat03/client/ClientTaskManager_v0_3_Test.java
+++ b/compat-0.3/client/base/src/test/java/org/a2aproject/sdk/compat03/client/ClientTaskManager_v0_3_Test.java
@@ -1,0 +1,51 @@
+package org.a2aproject.sdk.compat03.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.a2aproject.sdk.compat03.spec.Message_v0_3;
+import org.a2aproject.sdk.compat03.spec.TaskState_v0_3;
+import org.a2aproject.sdk.compat03.spec.TaskStatusUpdateEvent_v0_3;
+import org.a2aproject.sdk.compat03.spec.TaskStatus_v0_3;
+import org.a2aproject.sdk.compat03.spec.Task_v0_3;
+import org.a2aproject.sdk.compat03.spec.TextPart_v0_3;
+import org.junit.jupiter.api.Test;
+
+public class ClientTaskManager_v0_3_Test {
+
+    @Test
+    public void testStatusMessagesMoveToHistoryWhenSuperseded() throws Exception {
+        ClientTaskManager_v0_3 taskManager = new ClientTaskManager_v0_3();
+        Message_v0_3 workingMessage = new Message_v0_3.Builder()
+                .messageId("working-message")
+                .role(Message_v0_3.Role.AGENT)
+                .parts(new TextPart_v0_3("working"))
+                .build();
+        Message_v0_3 completedMessage = new Message_v0_3.Builder()
+                .messageId("completed-message")
+                .role(Message_v0_3.Role.AGENT)
+                .parts(new TextPart_v0_3("completed"))
+                .build();
+
+        Task_v0_3 workingTask = taskManager.saveTaskEvent(new TaskStatusUpdateEvent_v0_3.Builder()
+                .taskId("task-123")
+                .contextId("context-123")
+                .status(new TaskStatus_v0_3(TaskState_v0_3.WORKING, workingMessage, null))
+                .build());
+
+        assertTrue(workingTask.history().isEmpty());
+        assertEquals(workingMessage, workingTask.status().message());
+
+        Task_v0_3 completedTask = taskManager.saveTaskEvent(new TaskStatusUpdateEvent_v0_3.Builder()
+                .taskId("task-123")
+                .contextId("context-123")
+                .status(new TaskStatus_v0_3(TaskState_v0_3.COMPLETED, completedMessage, null))
+                .isFinal(true)
+                .build());
+
+        assertEquals(List.of(workingMessage), completedTask.history());
+        assertEquals(completedMessage, completedTask.status().message());
+    }
+}


### PR DESCRIPTION
# Description

A streaming client currently puts the active status message in both `Task.status.message` and `Task.history`. A client that receives the update reconstructs different state from a later subscriber reading the server snapshot.

The client now moves only the previous status message into history. This matches the Java server and the Python and Go SDKs. The v0.3 compatibility client uses the same rule.

## End-to-end repro

I used the existing stream lifecycle example with this temporary instrumentation:

```diff
-emitter.startWork();
+emitter.startWork(emitter.newAgentMessage(java.util.List.of(new TextPart("working")), null));

-System.out.printf("[%s] StatusUpdate — %s%n", subscriber, tue.getTask().status().state());
+System.out.printf("[%s] StatusUpdate — %s statusMessage=%s history=%s%n", subscriber, tue.getTask().status().state(), tue.getTask().status().message().messageId(), tue.getTask().history().stream().map(Message::messageId).toList());

-System.out.printf("[%s] TaskEvent — state: %s, id: %s%n", subscriber, te.getTask().status().state(), te.getTask().id());
+System.out.printf("[%s] TaskEvent — state: %s, id: %s statusMessage=%s history=%s%n", subscriber, te.getTask().status().state(), te.getTask().id(), te.getTask().status().message().messageId(), te.getTask().history().stream().map(Message::messageId).toList());
```

```shell
cd examples/stream-lifecycle/server && mvn -q quarkus:dev
cd examples/stream-lifecycle/client && mvn -q compile exec:java
```

Before:

```text
StatusUpdate ... statusMessage=2b86bb5b-921a-4775-b413-6e90b667b8db history=[2b86bb5b-921a-4775-b413-6e90b667b8db]
TaskEvent ... statusMessage=2b86bb5b-921a-4775-b413-6e90b667b8db history=[]
```

After:

```text
StatusUpdate ... statusMessage=30b9d47f-5358-4c0c-9805-f790becec694 history=[]
TaskEvent ... statusMessage=30b9d47f-5358-4c0c-9805-f790becec694 history=[]
```

- [x] Followed the [`CONTRIBUTING` Guide](../CONTRIBUTING.md).
- [x] Used a Conventional Commits title.
- [x] `mvn -pl client/base,compat-0.3/client/base -am test`

```text
[ERROR] Tests run: 14, Failures: 2, Errors: 0, Skipped: 0
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

- [x] No README update is needed because the public API is unchanged.
